### PR TITLE
The id is upper-cased on both create and update. So it has to be upper-c...

### DIFF
--- a/front50-gce/src/main/groovy/com/netflix/spinnaker/front50/model/application/GoogleApplicationDAO.groovy
+++ b/front50-gce/src/main/groovy/com/netflix/spinnaker/front50/model/application/GoogleApplicationDAO.groovy
@@ -106,7 +106,7 @@ class GoogleApplicationDAO implements ApplicationDAO {
 
       // Create the key.
       Key.Builder key = Key.newBuilder().addPathElement(Key.PathElement.newBuilder().setKind(KIND)
-                                                                                    .setName(id));
+                                                                                    .setName(id.toUpperCase()));
       key.getPartitionIdBuilder().setNamespace(NAMESPACE);
 
       // Create the commit request and associate it with the transaction.


### PR DESCRIPTION
...ased on delete as well.

With this fix, Delete Application works from the ui for Datastore-backed Front50.
