### PR TITLE
add cloudProviders field to application

### DIFF
--- a/front50-cassandra/src/test/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAOSpec.groovy
+++ b/front50-cassandra/src/test/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAOSpec.groovy
@@ -178,21 +178,21 @@ class CassandraApplicationDAOSpec extends Specification {
     foundApplication."${attribute}" == value
 
     where:
-    attribute     | value
-    "email"       | "updated@netflix.com"
-    "description" | null
-    "pdApiKey"    | "another pdApiKey"
-    "repoProjectKey" | "project-key"
-    "repoSlug" | "repo"
-    "repoType" | "github"
+    attribute         | value
+    "email"           | "updated@netflix.com"
+    "description"     | null
+    "pdApiKey"        | "another pdApiKey"
+    "repoProjectKey"  | "project-key"
+    "repoSlug"        | "repo"
+    "repoType"        | "github"
   }
 
   void "application updates should merge with existing details"() {
     given:
-    cassandraApplicationDAO.create(name, [name: name, email: email, owner: owner])
+    cassandraApplicationDAO.create(name, [name: name, email: email, owner: owner, repoType: repoType, repoSlug: repoSlug, cloudProviders: ["aws", "titan"]])
 
     when:
-    cassandraApplicationDAO.update(name, [pdApiKey: pdApiKey, repoProjectKey: "project-key", repoSlug: "repo", repoType: "stash"])
+    cassandraApplicationDAO.update(name, [pdApiKey: pdApiKey, repoProjectKey: "project-key", repoSlug: "repo", repoType: "stash", cloudProviders: ["titan"]])
 
     then:
     def foundApplication = cassandraApplicationDAO.findByName(name)
@@ -202,6 +202,7 @@ class CassandraApplicationDAOSpec extends Specification {
     foundApplication.repoProjectKey  == "project-key"
     foundApplication.repoSlug == "repo"
     foundApplication.repoType == "stash"
+    foundApplication.cloudProviders == cloudProviders
 
     where:
     name = "another-app"
@@ -211,6 +212,7 @@ class CassandraApplicationDAOSpec extends Specification {
     repoProjectKey = "project-key"
     repoSlug = "repo"
     repoType = "github"
+    cloudProviders = "titan"
   }
 }
 

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -54,6 +54,7 @@ class Application {
   String repoProjectKey
   String repoSlug
   String repoType
+  String cloudProviders
 
   @JsonIgnore
   ApplicationDAO dao
@@ -82,7 +83,8 @@ class Application {
               @JsonProperty("updateTs") String updatedAt,
               @JsonProperty("repoProjectKey") String repoProjectKey,
               @JsonProperty("repoSlug") String repoSlug,
-              @JsonProperty("repoType") String repoType
+              @JsonProperty("repoType") String repoType,
+              @JsonProperty("cloudProviders") String cloudProviders
 
   ) {
     this.group = group
@@ -101,6 +103,7 @@ class Application {
     this.repoProjectKey = repoProjectKey
     this.repoSlug = repoSlug
     this.repoType = repoType
+    this.cloudProviders = cloudProviders
   }
 
   void update(Application updatedApplication) {

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsControllerSpec.groovy
@@ -59,7 +59,7 @@ class ApplicationsControllerSpec extends Specification {
   void 'a put should update an application'() {
     setup:
     def sampleApp = new Application("SAMPLEAPP", null, "web@netflix.com", "Andy McEntee",
-      null, null, null, null, null, null, null, null, null, null, null, null)
+      null, null, null, null, null, null, null, null, null, null, null, null, null)
 
     when:
     def response = mockMvc.perform(put("/default/applications").
@@ -75,7 +75,7 @@ class ApplicationsControllerSpec extends Specification {
   void 'a put should not update an application if no name is provided'() {
     setup:
     def sampleApp = new Application(null, null, "web@netflix.com", "Andy McEntee",
-      null, null, null, null, null, null, null, null, null, null, null, null)
+      null, null, null, null, null, null, null, null, null, null, null, null, null)
 
     when:
     def response = mockMvc.perform(put("/default/applications").
@@ -88,7 +88,7 @@ class ApplicationsControllerSpec extends Specification {
   void 'a post w/o a name will throw an error'() {
     setup:
     def sampleApp = new Application(null, "Standalone App", "web@netflix.com", "Kevin McEntee",
-      "netflix.com application", "Standalone Application", null, null, null, null, null, null, null, null, null, null)
+      "netflix.com application", "Standalone Application", null, null, null, null, null, null, null, null, null, null, null)
 
     when:
     def response = mockMvc.perform(post("/default/applications/name/app").
@@ -101,7 +101,7 @@ class ApplicationsControllerSpec extends Specification {
   void 'a post w/an existing application will throw an error'() {
     setup:
     def sampleApp = new Application("SAMPLEAPP", "Standalone App", "web@netflix.com", "Kevin McEntee",
-        "netflix.com application", "Standalone Application", null, null, null, null, null, null, null, null, null, null)
+        "netflix.com application", "Standalone Application", null, null, null, null, null, null, null, null, null, null, null)
 
     when:
     def response = mockMvc.perform(post("/default/applications/name/SAMPLEAPP").
@@ -115,7 +115,7 @@ class ApplicationsControllerSpec extends Specification {
   void 'a post w/a new application should yield a success'() {
     setup:
     def sampleApp = new Application("SAMPLEAPP", "Standalone App", "web@netflix.com", "Kevin McEntee",
-      "netflix.com application", "Standalone Application", null, null, null, null, null, null, null, null, null, null)
+      "netflix.com application", "Standalone Application", null, null, null, null, null, null, null, null, null, null, null)
     dao.create(_, _) >> sampleApp
 
     when:
@@ -131,7 +131,7 @@ class ApplicationsControllerSpec extends Specification {
   void 'a get w/a name should return a JSON document for the found app'() {
     setup:
     def sampleApp = new Application("SAMPLEAPP", "Standalone App", "web@netflix.com", "Kevin McEntee",
-      "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null)
+      "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null, null)
 
     when:
     def response = mockMvc.perform(get("/default/applications/name/SAMPLEAPP"))
@@ -165,9 +165,9 @@ class ApplicationsControllerSpec extends Specification {
   void 'index should return a list of applications'() {
     setup:
     def sampleApps = [new Application("SAMPLEAPP", "Standalone App", "web@netflix.com", "Kevin McEntee",
-      "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null),
+      "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null, null),
                       new Application("SAMPLEAPP-2", "Standalone App", "web@netflix.com", "Kevin McEntee",
-                        "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null)]
+                        "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null, null)]
 
     when:
     def response = mockMvc.perform(get("/${account}/applications"))
@@ -184,9 +184,9 @@ class ApplicationsControllerSpec extends Specification {
   void "search hits the dao"() {
     setup:
     def sampleApps = [new Application("SAMPLEAPP", "Standalone App", "web@netflix.com", "Kevin McEntee",
-      "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null),
+      "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null, null),
                       new Application("SAMPLEAPP-2", "Standalone App", "web@netflix.com", "Kevin McEntee",
-                        "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null)]
+                        "netflix.com application", "Standalone Application", null, null, null, null, null, "1265752693581l", "1265752693581l", null, null, null, null)]
 
     when:
     def response = mockMvc.perform(get("/${account}/applications/search?q=p"))


### PR DESCRIPTION
@ajordens for your holiday review

We need the ability to associate applications with specific cloud providers - mostly to roll out Titan with minimal disruption.

The thinking is that applications will opt in to cloud providers; if none are selected, we'll assume only AWS is enabled for that particular application (but we'll make this configurable in Deck via settings).

Without this in place, users are going to get hit with an extra decision every time they create anything (server group, load balancer, pipeline stage, etc).

I'm a little shaky on whether this should be its own column in Cassandra - it could go into the `details` field, but seems like it is something we'd like to search on without loading everything. Then again, maybe we don't.
