### PR TITLE
allow optional list of applications in project cluster config

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/Project.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/Project.groovy
@@ -37,6 +37,7 @@ class Project {
     String account
     String stack
     String detail
+    Collection<String> applications
   }
 
   static class PipelineConfig {


### PR DESCRIPTION
It turns out that not every project cluster has every application in the project.

This will be used by the UI to let users specify which applications should be surfaced in the project's cluster pod. If none are specified, the project will assume all project applications are part of the cluster pod.
