### PR TITLE
Load properties straight into Spring Boot

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/Main.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/Main.groovy
@@ -18,7 +18,6 @@
 
 package com.netflix.spinnaker.front50
 
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -43,22 +42,12 @@ public class Main extends SpringBootServletInitializer {
     'spring.profiles.active': "${System.getProperty('netflix.environment', 'test')},local"
   ]
 
-  static {
-    applyDefaults()
-  }
-
-  static void applyDefaults() {
-    DEFAULT_PROPS.each { k, v ->
-      System.setProperty(k, System.getProperty(k, v))
-    }
-  }
-
   static void main(String... args) {
-    SpringApplication.run Main, args
+    new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)
   }
 
   @Override
   SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-    application.sources Main
+    application.properties(DEFAULT_PROPS).sources(Main)
   }
 }


### PR DESCRIPTION
The current mechanism of writing default propeties straight into the environment breaks the Spring property lifecycle, making it impossible to override certain settings. This path does what's intended, load the default properties into the Spring Boot application builder while still allowing overrides.
