### PR TITLE
Fix errors in front50 caused by jamm not being a part of -javaagent

### DIFF
--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -119,5 +119,5 @@ buildDeb {
 bootRun {
   // jamm is required when using prepared statements with in-memory C*
   def jamm = project.configurations.compile.find { it.name.startsWith('jamm') }
-  jvmArgs applicationDefaultJvmArgs.join(" ") + " -javaagent:${jamm}"
+  jvmArgs applicationDefaultJvmArgs + "-javaagent:${jamm}"
 }


### PR DESCRIPTION
Commit 7ca8419 broke front50 in our testing, triggering the following exception every time we try to create an application:

java.lang.IllegalStateException: Instrumentation is not set; Jamm must be set as -javaagent

Looks like jvmArgs accepts an array instead of a string, so changing it to pass in a list of arguments rather than a single string fixed it for us.