### PR TITLE
declare minimal app properties, allow all others

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/ApplicationDAOProviderHealthIndicator.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/ApplicationDAOProviderHealthIndicator.groovy
@@ -47,7 +47,7 @@ public class ApplicationDAOProviderHealthIndicator implements HealthIndicator {
     def healthBuilder = new Health.Builder().up()
 
     try {
-      if (applicationDAO.healthly) {
+      if (applicationDAO.healthy) {
         healthBuilder.withDetail(applicationDAO.class.simpleName, "Healthy")
       } else {
         healthBuilder.down().withDetail(applicationDAO.class.simpleName, "Unhealthy")

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAO.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAO.groovy
@@ -25,13 +25,13 @@ public interface ApplicationDAO {
 
   Set<Application> all() throws NotFoundException
 
-  Application create(String id, Map<String, String> attributes)
+  Application create(String id, Application application)
 
-  void update(String id, Map<String, String> attributes)
+  void update(String id, Application application)
 
   void delete(String id)
 
-  boolean isHealthly()
+  boolean isHealthy()
 
   Set<Application> search(Map<String, String> attributes)
 

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/config/ApplicationDAOProviderHealthIndicatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/config/ApplicationDAOProviderHealthIndicatorSpec.groovy
@@ -40,7 +40,7 @@ class ApplicationDAOProviderHealthIndicatorSpec extends Specification {
     def result = healthCheck.health()
 
     then:
-    1 * dao.isHealthly() >> false
+    1 * dao.isHealthy() >> false
     result.status == Status.DOWN
   }
 
@@ -50,7 +50,7 @@ class ApplicationDAOProviderHealthIndicatorSpec extends Specification {
     def result = healthCheck.health()
 
     then:
-    1 * dao.isHealthly() >> true
+    1 * dao.isHealthy() >> true
     result.status == Status.UP
   }
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
@@ -56,24 +56,21 @@ class ApplicationModelSpec extends Specification {
     application.name == null
   }
 
-  void 'should support obtaining list of properties who have values'() {
+  void 'should support adding dynamic properties'() {
     def application = new Application()
-    application.setName("TEST_APP")
-    application.email = 'aglover@netflix.com'
     application.pdApiKey = ''
     application.owner = null
     application.repoProjectKey = "project-key"
     application.repoSlug = "repo"
     application.repoType = "github"
 
-    def props = application.allSetColumnProperties()
+    def props = application.details()
 
     expect:
     props != null
-    props.size() == 6
-    props['name'] == 'TEST_APP'
-    props['email'] == "aglover@netflix.com"
+    props.size() == 5
     props['pdApiKey'] == ''
+    props['owner'] == null
     props['repoProjectKey'] == "project-key"
     props['repoSlug'] == "repo"
     props['repoType'] == 'github'

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsController.groovy
@@ -77,7 +77,7 @@ public class ApplicationsController {
     def application = getApplication()
     Application existingApplication = application.findByName(app.getName())
     application.initialize(existingApplication).withName(app.getName()).update(app)
-    return application
+    return app
   }
 
   @ApiOperation(value = "", notes = "Create an application within a specific `account`")


### PR DESCRIPTION
Attempting to define the actual, reliably present fields on an application as:
* name
* description
* email
* accounts
* createTs
* updateTs

All other fields are optional, which will allow users to customize the fields they want to include - we can get rid of things like "pdApiKey" in the OSS world, and add it by exposing the field in the UI via the netflix module.

~~We are still stuck with Strings everywhere, so complex objects would need to be passed in as String from the UI, then parsed when they come back to the UI, which is fine.~~

Complex objects can also be stored, since we're using an ObjectMapper to convert the details to a string for storage. You can also store numbers, booleans, nested objects, etc. without needing to convert them back and forth to/from strings.

It's possible we want to refactor this more, so that the Application object does not have any of the Rails-like (if that's where it came from) methods, and CRUD operations are delegated to a service, which would perform the merges and whatnot. But that could be a separate refactor if we're happy with the proposed functionality here. Also, someone who writes Java regularly might want to do that instead of me.

These changes should require no migration, nor changes to other systems.

@ajordens please review

cc @duftler and anyone else who's interested or considering providing a separate, non-Cassandra DAO.