### PR TITLE
migrate platformHealth* flags to booleans

### DIFF
--- a/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAO.groovy
+++ b/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAO.groovy
@@ -92,6 +92,8 @@ class CassandraApplicationDAO implements ApplicationDAO, ApplicationListener<Con
       runQuery("ALTER TABLE application ADD details_json varchar")
       runQuery("ALTER TABLE application ADD version int")
       all().each { Application application ->
+        application.platformHealthOnly = new Boolean(application.details().platformHealthOnly)
+        application.platformHealthOnlyShowOverride = new Boolean(application.details().platformHealthOnlyShowOverride)
         update(application.name, application)
       }
     }


### PR DESCRIPTION
We've been storing these fields as Strings, so we should update any existing applications to use Booleans, as that is what the UI sends in.

We'll need to migrate Netflix applications with a different script, since we (okay, I) already pushed the previous changes without this migration to production.

@duftler Please review.