### PR TITLE
Include each ItemDAO in the health check

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAO.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAO.groovy
@@ -21,7 +21,7 @@ package com.netflix.spinnaker.front50.model.application
 import com.netflix.spinnaker.front50.exception.NotFoundException
 import com.netflix.spinnaker.front50.model.ItemDAO
 
-public interface ApplicationDAO extends ItemDAO<Application> {
+public interface ApplicationDAO extends com.netflix.spinnaker.front50.model.ItemDAO<Application> {
   Application findByName(String name) throws NotFoundException
 
   Collection<Application> search(Map<String, String> attributes)

--- a/front50-pipelines/src/main/groovy/com/netflix/spinnaker/front50/pipeline/StrategyRepository.groovy
+++ b/front50-pipelines/src/main/groovy/com/netflix/spinnaker/front50/pipeline/StrategyRepository.groovy
@@ -144,7 +144,7 @@ class StrategyRepository implements PipelineStrategyDAO {
 
     @Override
     boolean isHealthy() {
-        return false
+        return true
     }
 
     List<Pipeline> getPipelinesByApplication(String application) {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -17,8 +17,13 @@
 package com.netflix.spinnaker.front50.config
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
+import com.netflix.spinnaker.front50.model.project.ProjectDAO
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
@@ -37,5 +42,25 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
             this.registry, "controller.invocations", ["account", "application"], ["BasicErrorController"]
         )
     )
+  }
+
+  @Bean
+  ItemDAOHealthIndicator applicationDAOHealthIndicator(ApplicationDAO applicationDAO) {
+    return new ItemDAOHealthIndicator(itemDAO: applicationDAO)
+  }
+
+  @Bean
+  ItemDAOHealthIndicator projectDAOHealthIndicator(ProjectDAO projectDAO) {
+    return new ItemDAOHealthIndicator(itemDAO: projectDAO)
+  }
+
+  @Bean
+  ItemDAOHealthIndicator pipelineDAOHealthIndicator(PipelineDAO pipelineDAO) {
+    return new ItemDAOHealthIndicator(itemDAO: pipelineDAO)
+  }
+
+  @Bean
+  ItemDAOHealthIndicator pipelineStrategyDAOHealthIndicator(PipelineStrategyDAO pipelineStrategyDAO) {
+    return new ItemDAOHealthIndicator(itemDAO: pipelineStrategyDAO)
   }
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/ItemDAOHealthIndicator.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/ItemDAOHealthIndicator.groovy
@@ -17,20 +17,16 @@
 
 package com.netflix.spinnaker.front50.config
 
-import com.netflix.spinnaker.front50.model.application.ApplicationDAO
-import org.springframework.beans.factory.annotation.Autowired
+import com.netflix.spinnaker.front50.model.ItemDAO
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Component
 
 import java.util.concurrent.atomic.AtomicReference
 
-@Component
-public class ApplicationDAOProviderHealthIndicator implements HealthIndicator {
+public class ItemDAOHealthIndicator implements HealthIndicator {
 
-  @Autowired
-  ApplicationDAO applicationDAO
+  ItemDAO itemDAO
 
   private final AtomicReference<Health> lastHealth = new AtomicReference<>(null)
 
@@ -47,13 +43,13 @@ public class ApplicationDAOProviderHealthIndicator implements HealthIndicator {
     def healthBuilder = new Health.Builder().up()
 
     try {
-      if (applicationDAO.healthy) {
-        healthBuilder.withDetail(applicationDAO.class.simpleName, "Healthy")
+      if (itemDAO.healthy) {
+        healthBuilder.withDetail(itemDAO.class.simpleName, "Healthy")
       } else {
-        healthBuilder.down().withDetail(applicationDAO.class.simpleName, "Unhealthy")
+        healthBuilder.down().withDetail(itemDAO.class.simpleName, "Unhealthy")
       }
     } catch (RuntimeException e) {
-      healthBuilder.down().withDetail(applicationDAO.class.simpleName, "Unhealthy: `${e.message}`" as String)
+      healthBuilder.down().withDetail(itemDAO.class.simpleName, "Unhealthy: `${e.message}`" as String)
     }
 
     lastHealth.set(healthBuilder.build())

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/config/ItemDAOHealthIndicatorSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/config/ItemDAOHealthIndicatorSpec.groovy
@@ -22,16 +22,16 @@ import org.springframework.boot.actuate.health.Status
 import spock.lang.Shared
 import spock.lang.Specification
 
-class ApplicationDAOProviderHealthIndicatorSpec extends Specification {
+class ItemDAOHealthIndicatorSpec extends Specification {
   @Shared
-  ApplicationDAOProviderHealthIndicator healthCheck
+  ItemDAOHealthIndicator healthCheck
 
   @Shared
   ApplicationDAO dao
 
   void setup() {
     dao = Mock(ApplicationDAO)
-    healthCheck = new ApplicationDAOProviderHealthIndicator(applicationDAO: dao)
+    healthCheck = new ItemDAOHealthIndicator(itemDAO: dao)
   }
 
   void 'health check should return 5xx error if dao is not working'() {


### PR DESCRIPTION
- S3 just ensures it's refreshed itself in the past 45s
- Cassandra* executes a query

 * Only CassandraApplicationDAO executes a query, the other DAOs just return true (just tests Cassandra connectivity which should be the same regardless of DAO)