### PR TITLE
S3 DAOs should refresh only when a modification is detected

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -70,12 +70,12 @@ public class S3Config {
   @Bean
   @ConditionalOnExpression("${spinnaker.s3.enabled:false}")
   public S3PipelineStrategyDAO s3PipelineStrategyDAO(ObjectMapper objectMapper, AmazonS3 amazonS3) {
-    return new S3PipelineStrategyDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(5)), 5000, bucket, rootFolder);
+    return new S3PipelineStrategyDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(5)), 20000, bucket, rootFolder);
   }
 
   @Bean
   @ConditionalOnExpression("${spinnaker.s3.enabled:false}")
   public S3PipelineDAO s3PipelineDAO(ObjectMapper objectMapper, AmazonS3 amazonS3) {
-    return new S3PipelineDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(25)), 5000, bucket, rootFolder);
+    return new S3PipelineDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(25)), 10000, bucket, rootFolder);
   }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineDAO.java
@@ -52,7 +52,6 @@ public class S3PipelineDAO extends S3Support<Pipeline> implements PipelineDAO {
 
   @Override
   public Collection<Pipeline> getPipelinesByApplication(String application) {
-    refresh();
     return all()
         .stream()
         .filter(pipelineStrategy -> pipelineStrategy.getApplication().equalsIgnoreCase(application))

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineStrategyDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineStrategyDAO.java
@@ -61,7 +61,6 @@ public class S3PipelineStrategyDAO extends S3Support<Pipeline> implements Pipeli
 
   @Override
   public Collection<Pipeline> getPipelinesByApplication(String application) {
-    refresh();
     return all()
         .stream()
         .filter(pipelineStrategy -> pipelineStrategy.getApplication().equalsIgnoreCase(application))

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/NotificationController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/NotificationController.groovy
@@ -67,12 +67,13 @@ class NotificationController {
         def notification = notificationDAO.get(level, name)
 
         if (level == HierarchicalLevel.APPLICATION) {
+            def global = getGlobal()
             NotificationDAO.NOTIFICATION_FORMATS.each {
-                if (getGlobal()."$it") {
+                if (global."$it") {
                     if (!notification."${it}") {
                         notification."${it}" = []
                     }
-                    notification."$it".addAll(getGlobal()."$it")
+                    notification."$it".addAll(global."$it")
                 }
             }
         }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsControllerTck.groovy
@@ -292,15 +292,7 @@ class S3ApplicationsControllerTck extends ApplicationsControllerTck {
     amazonS3.setEndpoint("http://127.0.0.1:9999")
     S3TestHelper.setupBucket(amazonS3, "front50")
 
-    s3ApplicationDAO = new S3ApplicationDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test")  {
-      @Override
-      Collection<Application> all() {
-        // normally a refresh happens periodically, this forces it before every call to all()
-        refresh()
-        return super.all()
-      }
-    }
-
+    s3ApplicationDAO = new S3ApplicationDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test")
     return s3ApplicationDAO
   }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
@@ -196,15 +196,7 @@ class S3NotificationControllerTck extends NotificationControllerTck {
     amazonS3.setEndpoint("http://127.0.0.1:9999")
     S3TestHelper.setupBucket(amazonS3, "front50")
 
-    s3NotificationDAO = new S3NotificationDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test") {
-      @Override
-      Collection<Notification> all() {
-        // normally a refresh happens periodically, this forces it before every call to all()
-        refresh()
-        return super.all()
-      }
-    }
-
+    s3NotificationDAO = new S3NotificationDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test")
     return s3NotificationDAO
   }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -171,15 +171,7 @@ class S3PipelineControllerTck extends PipelineControllerTck {
     amazonS3.setEndpoint("http://127.0.0.1:9999")
     S3TestHelper.setupBucket(amazonS3, "front50")
 
-    s3PipelineDAO = new S3PipelineDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test") {
-      @Override
-      Collection<Pipeline> all() {
-        // normally a refresh happens periodically, this forces it before every call to all()
-        refresh()
-        return super.all()
-      }
-    }
-
+    s3PipelineDAO = new S3PipelineDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test")
     return s3PipelineDAO
   }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
@@ -174,15 +174,7 @@ class S3StrategyControllerTck extends StrategyControllerTck {
     amazonS3.setEndpoint("http://127.0.0.1:9999")
     S3TestHelper.setupBucket(amazonS3, "front50")
 
-    s3PipelineStrategyDAO = new S3PipelineStrategyDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test") {
-      @Override
-      Collection<Pipeline> all() {
-        // normally a refresh happens periodically, this forces it before every call to all()
-        refresh()
-        return super.all()
-      }
-    }
-
+    s3PipelineStrategyDAO = new S3PipelineStrategyDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test")
     return s3PipelineStrategyDAO
   }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
@@ -238,15 +238,7 @@ class S3ProjectsControllerTck extends ProjectsControllerTck {
     amazonS3.setEndpoint("http://127.0.0.1:9999")
     S3TestHelper.setupBucket(amazonS3, "front50")
 
-    s3ProjectDAO = new S3ProjectDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test") {
-      @Override
-      Collection<Project> all() {
-        // normally a refresh happens periodically, this forces it before every call to all()
-        refresh()
-        return super.all()
-      }
-    }
-
+    s3ProjectDAO = new S3ProjectDAO(new ObjectMapper(), amazonS3, scheduler, 0, "front50", "test")
     return s3ProjectDAO
   }
 }


### PR DESCRIPTION
- update/delete now writes "last-modified.json" containing a modification timestamp
- all() will now check and only refresh() if a recent modification is detected, avoids fetching all object metadata which can be an expensive operation on larger folders (pipelines/applications)
- NotificationController no longer repeatedly loads the global notification config