### PR TITLE
'lastRefreshedTime' should be calculated pre-fetchAll not post-fetchAll

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineDAO.java
@@ -54,7 +54,7 @@ public class S3PipelineDAO extends S3Support<Pipeline> implements PipelineDAO {
   public Collection<Pipeline> getPipelinesByApplication(String application) {
     return all()
         .stream()
-        .filter(pipelineStrategy -> pipelineStrategy.getApplication().equalsIgnoreCase(application))
+        .filter(pipeline -> pipeline.getApplication().equalsIgnoreCase(application))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
- Tested via a loop of create pipeline -> delete pipeline -> query for pipelines by application
- Fixed the serialization warnings by setting MD5 and Content-Length on ObjectMetadata