### PR TITLE
core: NPE thrown while reporting save error

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -275,7 +275,7 @@ class Application implements Timestamped {
         log.error("Rollback failed (onRollback)", rollbackException)
       }
 
-      log.error("Failed to perform action (name: ${originalApplication.name ?: updatedApplication.name})")
+      log.error("Failed to perform action (name: ${originalApplication?.name ?: updatedApplication?.name})")
       throw e
     }
   }


### PR DESCRIPTION
On application save: https://github.com/spinnaker/front50/blob/master/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy#L171 `originalApplication` is passed as `null`, causing the error reporting to fail.

@spinnaker/netflix-reviewers PTAL