### PR TITLE
Initial pass at using Google Cloud Storage instead of cassandra.

### DIFF
--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-rootProject.name = "front50"
+dependencies {
+  compile project(":front50-core")
+  compile 'io.reactivex:rxjava:1.0.10'
 
-include 'front50-web', 'front50-core', 'front50-cassandra', 'front50-gcs', 'front50-pipelines', 'front50-redis', 'front50-s3', 'front50-test'
+  spinnaker.group('google')
+  /* spinnaker.group('googleStorage') */
+  compile 'com.google.apis:google-api-services-storage:v1-rev72-1.22.0'
 
-def setBuildFile(project) {
-  project.buildFileName = "${project.name}.gradle"
-  project.children.each {
-    setBuildFile(it)
-  }
-}
 
-rootProject.children.each {
-  setBuildFile(it)
+  testCompile project(":front50-test")
 }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+import com.netflix.spinnaker.front50.model.*;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.schedulers.Schedulers;
+
+import java.io.FileInputStream;
+import java.util.concurrent.Executors;
+import java.util.Collections;
+
+@Configuration
+public class GcsConfig {
+  @Value("${spinnaker.gcs.bucket}")
+  private String bucket;
+
+  @Value("${spinnaker.gcs.rootFolder}")
+  private String rootFolder;
+
+  @Value("${providers.google.primaryCredentials.jsonPath}")
+  private String jsonPath;
+
+  @Value("${Implementation-Version:Unknown}")
+  private String applicationVersion;
+
+  @Bean
+  public Storage googleCloudStorageClient() {
+      try {
+        HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+        JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+
+        GoogleCredential credential;
+        Logger log = LoggerFactory.getLogger(getClass());
+
+        if (!jsonPath.isEmpty()) {
+            FileInputStream credentialStream = new FileInputStream(jsonPath);
+            credential = GoogleCredential.fromStream(credentialStream, httpTransport, jsonFactory)
+                                         .createScoped(Collections.singleton(StorageScopes.DEVSTORAGE_FULL_CONTROL));
+          log.info("Loaded credentials from from " + jsonPath);
+        } else {
+            log.info("spinnaker.gcs.enabled without providers.google.primaryCredentials.jsonPath. Using default application credentials. Using default credentials.");
+            credential = GoogleCredential.getApplicationDefault();
+        }
+
+        String applicationName = "Spinnaker-front50/" + applicationVersion;
+        return new Storage.Builder(httpTransport, jsonFactory, credential)
+                .setApplicationName(applicationName)
+                .build();
+      } catch (java.io.IOException|java.security.GeneralSecurityException e) {
+          throw new IllegalStateException(e);
+      }
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(RestTemplate.class)
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+  @Bean
+  public ObjectMapper gcsObjectMapper() {
+    return new ObjectMapper();
+  }
+
+  @Bean
+  @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
+  public GcsApplicationDAO gcsApplicationDAO(ObjectMapper objectMapper, Storage storage) {
+    return new GcsApplicationDAO(objectMapper, storage, Schedulers.from(Executors.newFixedThreadPool(20)), 15000, bucket, rootFolder);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
+  public GcsProjectDAO gcsProjectDAO(ObjectMapper objectMapper, Storage storage) {
+    return new GcsProjectDAO(objectMapper, storage, Schedulers.from(Executors.newFixedThreadPool(10)), 30000, bucket, rootFolder);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
+  public GcsNotificationDAO gcsNotificationDAO(ObjectMapper objectMapper, Storage storage) {
+    return new GcsNotificationDAO(objectMapper, storage, Schedulers.from(Executors.newFixedThreadPool(5)), 30000, bucket, rootFolder);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
+  public GcsPipelineStrategyDAO gcsPipelineStrategyDAO(ObjectMapper objectMapper, Storage storage) {
+    return new GcsPipelineStrategyDAO(objectMapper, storage, Schedulers.from(Executors.newFixedThreadPool(5)), 20000, bucket, rootFolder);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
+  public GcsPipelineDAO gcsPipelineDAO(ObjectMapper objectMapper, Storage storage) {
+    return new GcsPipelineDAO(objectMapper, storage, Schedulers.from(Executors.newFixedThreadPool(25)), 10000, bucket, rootFolder);
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsApplicationDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsApplicationDAO.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
+import rx.Scheduler;
+
+import java.util.*;
+
+public class GcsApplicationDAO extends GcsSupport<Application> implements ApplicationDAO {
+  public GcsApplicationDAO(ObjectMapper objectMapper,
+                           Storage storage,
+                           Scheduler scheduler,
+                           int refreshIntervalMs,
+                           String bucket,
+                           String rootFolder) {
+      super(objectMapper, storage, scheduler, refreshIntervalMs, bucket, (rootFolder + "/applications/").replaceAll("//", "/"));
+  }
+
+  @Override
+  public Application findByName(String name) throws NotFoundException {
+      return findById(name);
+  }
+
+  @Override
+  public Application create(String id, Application application) {
+      if (application.getCreateTs() == null) {
+          application.setCreateTs(String.valueOf(System.currentTimeMillis()));
+      }
+
+        update(id, application);
+        return findById(id);
+    }
+
+  @Override
+  public void update(String id, Application application) {
+      application.setName(id);
+      super.update(id, application);
+  }
+
+  @Override
+  public Collection<Application> search(Map<String, String> attributes) {
+      return Searcher.search(all(), attributes);
+  }
+
+  @Override
+  public Collection<Application> getApplicationHistory(String name, int maxResults) {
+    return allVersionsOf(name, maxResults);
+  }
+
+  @Override
+  Class<Application> getSerializedClass() {
+      return Application.class;
+  }
+
+  @Override
+  String getMetadataFilename() {
+      return "application-metadata.json";
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsNotificationDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsNotificationDAO.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.notification.HierarchicalLevel;
+import com.netflix.spinnaker.front50.model.notification.Notification;
+import com.netflix.spinnaker.front50.model.notification.NotificationDAO;
+import rx.Scheduler;
+
+public class GcsNotificationDAO extends GcsSupport<Notification> implements NotificationDAO {
+  public GcsNotificationDAO(ObjectMapper objectMapper,
+                            Storage storage,
+                            Scheduler scheduler,
+                            int refreshIntervalMs,
+                            String bucket,
+                            String rootFolder) {
+    super(objectMapper, storage, scheduler, refreshIntervalMs, bucket, (rootFolder + "/notifications/").replaceAll("//", "/"));
+  }
+
+  @Override
+  public Notification getGlobal() {
+    return get(HierarchicalLevel.GLOBAL, Notification.GLOBAL_ID);
+  }
+
+  @Override
+  public Notification get(HierarchicalLevel level, String name) {
+    try {
+      return findById(name);
+    } catch (NotFoundException e) {
+      // an empty Notification is expected for applications that do not exist
+      return new Notification();
+    }
+  }
+
+  @Override
+  public void saveGlobal(Notification notification) {
+    update(Notification.GLOBAL_ID, notification);
+  }
+
+  @Override
+  public void save(HierarchicalLevel level, String name, Notification notification) {
+    update(name, notification);
+  }
+
+  @Override
+  public void delete(HierarchicalLevel level, String name) {
+    delete(name);
+  }
+
+  @Override
+  Class<Notification> getSerializedClass() {
+    return Notification.class;
+  }
+
+  @Override
+  public String getMetadataFilename() {
+    return "notification-metadata.json";
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsPipelineDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsPipelineDAO.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
+import rx.Scheduler;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class GcsPipelineDAO extends GcsSupport<Pipeline> implements PipelineDAO {
+  public GcsPipelineDAO(ObjectMapper objectMapper,
+                        Storage storage,
+                        Scheduler scheduler,
+                        int refreshIntervalMs,
+                        String bucket,
+                        String rootFolder) {
+    super(objectMapper, storage, scheduler, refreshIntervalMs, bucket, (rootFolder + "/pipelines/").replaceAll("//", "/"));
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelineHistory(String name, int maxResults) {
+    return allVersionsOf(name, maxResults);
+  }
+
+  @Override
+  public String getPipelineId(String application, String pipelineName) {
+    Pipeline matched = getPipelinesByApplication(application)
+        .stream()
+        .filter(pipeline -> pipeline.getName().equalsIgnoreCase(pipelineName))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException(
+            String.format("No pipeline found with name '%s' in application '%s'", pipelineName, application)
+        ));
+
+    return matched.getId();
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelinesByApplication(String application) {
+    return all()
+        .stream()
+        .filter(pipeline -> pipeline.getApplication().equalsIgnoreCase(application))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Pipeline create(String id, Pipeline item) {
+    if (id == null) {
+      id = UUID.randomUUID().toString();
+    }
+    item.setId(id);
+
+    update(id, item);
+    return findById(id);
+  }
+
+  @Override
+  public String getMetadataFilename() {
+    return "pipeline-metadata.json";
+  }
+
+  @Override
+  Class<Pipeline> getSerializedClass() {
+    return Pipeline.class;
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsPipelineStrategyDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsPipelineStrategyDAO.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO;
+import rx.Scheduler;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class GcsPipelineStrategyDAO extends GcsSupport<Pipeline> implements PipelineStrategyDAO {
+  public GcsPipelineStrategyDAO(ObjectMapper objectMapper,
+                                Storage storage,
+                                Scheduler scheduler,
+                                int refreshIntervalMs,
+                                String bucket,
+                                String rootFolder) {
+    super(objectMapper, storage, scheduler, refreshIntervalMs, bucket, (rootFolder + "/pipeline-strategies/").replaceAll("//", "/"));
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelineHistory(String name, int maxResults) {
+    return allVersionsOf(name, maxResults);
+  }
+
+  @Override
+  public String getPipelineId(String application, String pipelineName) {
+    Pipeline matched = getPipelinesByApplication(application)
+        .stream()
+        .filter(pipeline -> pipeline.getName().equalsIgnoreCase(pipelineName))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException(
+            String.format("No pipeline strategy found with name '%s' in application '%s'", pipelineName, application)
+        ));
+
+    return matched.getId();
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelinesByApplication(String application) {
+    return all()
+        .stream()
+        .filter(pipelineStrategy -> pipelineStrategy.getApplication().equalsIgnoreCase(application))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Pipeline create(String id, Pipeline item) {
+    if (id == null) {
+      id = UUID.randomUUID().toString();
+    }
+    item.setId(id);
+
+    update(id, item);
+    return findById(id);
+  }
+
+  @Override
+  public String getMetadataFilename() {
+    return "pipeline-strategy-metadata.json";
+  }
+
+  @Override
+  Class<Pipeline> getSerializedClass() {
+    return Pipeline.class;
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsProjectDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsProjectDAO.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.project.Project;
+import com.netflix.spinnaker.front50.model.project.ProjectDAO;
+import rx.Scheduler;
+
+import java.util.*;
+
+public class GcsProjectDAO extends GcsSupport<Project> implements ProjectDAO {
+    public GcsProjectDAO(ObjectMapper objectMapper,
+                         Storage storage,
+                         Scheduler scheduler,
+                         int refreshIntervalMs,
+                         String bucket,
+                         String rootFolder) {
+        super(objectMapper, storage, scheduler, refreshIntervalMs, bucket, (rootFolder + "/projects/").replaceAll("//", "/"));
+    }
+
+    @Override
+    public Project findByName(String name) throws NotFoundException {
+        return fetchAllItems(allItemsCache.get())
+                .stream()
+                .filter(project -> project.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(String.format("No project found with name of %s", name)));
+    }
+
+    @Override
+    public Project create(String id, Project item) {
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+        item.setId(id);
+
+        update(id, item);
+        return findById(id);
+    }
+
+    @Override
+    public void truncate() {
+    }
+
+    @Override
+    String getMetadataFilename() {
+        return "project-metadata.json";
+    }
+
+    @Override
+    Class<Project> getSerializedClass() {
+        return Project.class;
+    }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsSupport.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsSupport.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.*;
+import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.util.DateTime;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Scheduler;
+
+import javax.annotation.PostConstruct;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public abstract class GcsSupport<T extends Timestamped> {
+    private static final String LAST_MODIFIED_FILENAME = "last-modified";
+    private static final long HEALTH_MILLIS = 45000;
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final ObjectMapper objectMapper;
+    private final Storage storage;
+    private final Scheduler scheduler;
+    private final int refreshIntervalMs;
+    private final String bucket;
+
+    private long lastRefreshedTime;
+
+    protected final String rootFolder;
+
+    protected final AtomicReference<Set<T>> allItemsCache = new AtomicReference<>();
+
+    public GcsSupport(ObjectMapper objectMapper,
+                      Storage storage,
+                      Scheduler scheduler,
+                      int refreshIntervalMs,
+                      String bucket,
+                      String rootFolder) {
+        this.objectMapper = objectMapper;
+        this.storage = storage;
+        this.scheduler = scheduler;
+        this.refreshIntervalMs = refreshIntervalMs;
+        this.bucket = bucket;
+        this.rootFolder = rootFolder;
+    }
+
+    @PostConstruct
+    void startRefresh() {
+        Observable
+                .timer(refreshIntervalMs, TimeUnit.MILLISECONDS, scheduler)
+                .repeat()
+                .subscribe(interval -> {
+                    try {
+                        log.debug("Refreshing");
+                        refresh();
+                    } catch (Exception e) {
+                        log.error("Unable to refresh", e);
+                    }
+                });
+    }
+
+    public Collection<T> all() {
+        if (readLastModified() > lastRefreshedTime || allItemsCache.get() == null) {
+            // only refresh if there was a modification since our last refresh cycle
+            refresh();
+        }
+
+        return allItemsCache.get().stream().collect(Collectors.toList());
+    }
+
+    /**
+     * @return Healthy if refreshed in the past HEALTH_MILLIS
+     */
+    public boolean isHealthy() {
+        return (System.currentTimeMillis() - lastRefreshedTime) < HEALTH_MILLIS
+                && allItemsCache.get() != null;
+    }
+
+    public T findById(String id) throws NotFoundException {
+        try {
+            String key = buildStorageKey(id);
+            StorageObject object = storage.objects().get(bucket, key).execute();
+            return deserialize(object, null);
+        } catch (HttpResponseException e) {
+            if (e.getStatusCode() == 404) {
+                throw new NotFoundException(String.format("No item found with id of %s",
+                        id.toLowerCase()));
+            }
+
+            throw new IllegalStateException(e);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+
+        }
+    }
+
+  public Collection<T> allVersionsOf(String id, int maxResults) throws NotFoundException {
+      // TODO(ewiseblatt): Add enable bucket versioning and implement this.
+      log.warn("GCS bucket versioning not yet implemented.");
+      Collection<T> result = new java.util.ArrayList<T>();
+      result.add(findById(id));
+      return result;
+  }
+
+    public void update(String id, T item) {
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(item);
+            StorageObject object = new StorageObject().setBucket(bucket).setName(buildStorageKey(id));
+            storage.objects().insert(bucket, object,
+                                     new ByteArrayContent("application/json", bytes)).execute();
+            writeLastModified();
+        } catch (IOException e) {
+            log.error("update failed on id=" + id + ": " + e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public void delete(String id) {
+        try {
+            storage.objects().delete(bucket, buildStorageKey(id)).execute();
+            writeLastModified();
+        } catch (IOException e) {
+            log.error("delete failed on id=" + id);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public void bulkImport(Collection<T> items) {
+        Observable
+                .from(items)
+                .buffer(10)
+                .flatMap(itemSet -> Observable
+                        .from(itemSet)
+                        .flatMap(item -> {
+                            update(item.getId(), item);
+                            return Observable.just(item);
+                        })
+                        .subscribeOn(scheduler)
+                ).subscribeOn(scheduler)
+                .toList()
+                .toBlocking()
+                .single();
+    }
+
+    /**
+     * Update local cache with any recently modified items.
+     */
+    protected void refresh() {
+        allItemsCache.set(fetchAllItems(allItemsCache.get()));
+    }
+
+    /**
+     * Fetch any previously cached applications that have been updated since last retrieved.
+     *
+     * @param existingItems Previously cached applications
+     * @return Refreshed applications
+     */
+    protected Set<T> fetchAllItems(Set<T> existingItems) {
+        Set<T> result = new HashSet<T>();
+        Map<String, T> cache = new HashMap<String, T>();
+
+        if (existingItems != null) {
+            for (T item : existingItems) {
+                cache.put(buildStorageKey(item), item);
+            }
+        }
+
+        String ends_with = getMetadataFilename();
+        long refreshTime = System.currentTimeMillis();
+        try {
+            Storage.Objects.List listObjects = storage.objects().list(bucket);
+            com.google.api.services.storage.model.Objects objects;
+            do {
+                objects = listObjects.execute();
+                List<StorageObject> items = objects.getItems();
+                if (items != null) {
+                    for (StorageObject object : items) {
+                        if (!object.getName().endsWith(ends_with)) {
+                            continue;
+                        }
+                        T item = deserialize(object, cache);
+                        result.add(item);
+                    }
+                }
+                listObjects.setPageToken(objects.getNextPageToken());
+            } while (objects.getNextPageToken() != null);
+
+            this.lastRefreshedTime = refreshTime;
+            return result;
+        } catch (IOException e) {
+            log.error("Could not fetch items from Google Cloud Storage: " + e);
+            return new HashSet<>();
+        }
+    }
+
+    protected String buildStorageKey(T item) {
+        return buildStorageKey(item.getId());
+    }
+
+    protected String buildStorageKey(String id) {
+        return rootFolder + id.toLowerCase() + "/" + getMetadataFilename();
+    }
+
+    private void writeLastModified() {
+        // We'll just touch the file since the StorageObject manages a timestamp.
+        byte[] bytes = "{}".getBytes();
+        ByteArrayContent content = new ByteArrayContent("application/json", bytes);
+        StorageObject object = new StorageObject()
+            .setBucket(bucket)
+            .setName(rootFolder + LAST_MODIFIED_FILENAME)
+            .setUpdated(new DateTime(System.currentTimeMillis()));
+        try {
+            storage.objects().insert(bucket, object, content).execute();
+        } catch (HttpResponseException e) {
+            log.error("writeLastModified failed: " + e);
+            try {
+                storage.objects().update(bucket, object.getName(), object);
+            } catch (IOException ioex) {
+                log.error("writeLastModified update failed too. " + ioex);
+                throw new IllegalStateException(ioex);
+            }
+        } catch (IOException e) {
+            log.error("writeLastModified failed: " + e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Long readLastModified() {
+        try {
+            return storage.objects().get(bucket, rootFolder + LAST_MODIFIED_FILENAME).execute()
+                .getUpdated().getValue();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+
+    private T deserialize(StorageObject object, Map<String, T> cache) throws IOException, java.io.UnsupportedEncodingException {
+        long lastModified = object.getUpdated().getValue();
+        if (cache != null) {
+            T have = cache.get(object.getName());
+            if (have != null && have.getLastModified() == lastModified) {
+                return have;
+            }
+        }
+        ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        storage.objects().get(object.getBucket(), object.getName())
+            .executeMediaAndDownloadTo(output);
+        String json = output.toString("UTF8");
+
+        T item = objectMapper.readValue(json, getSerializedClass());
+        item.setLastModified(lastModified);
+        return item;
+    }
+
+    private boolean filterStorageObject(StorageObject object) {
+        return object.getName().endsWith(getMetadataFilename());
+    }
+
+    private String extractItemName(StorageObject object) {
+        return object.getName().replaceAll(rootFolder, "").replaceAll("/" + getMetadataFilename(), "");
+    }
+
+    abstract Class<T> getSerializedClass();
+
+    abstract String getMetadataFilename();
+}

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -47,6 +47,7 @@ jar {
 dependencies {
   compile project(":front50-core")
   compile project(":front50-cassandra")
+  compile project(":front50-gcs")
   compile project(":front50-redis")
   compile project(":front50-s3")
   compile project(":front50-pipelines")


### PR DESCRIPTION
@duftler, @ajordens 

This doesnt have tests yet, but seems to work when I run it.
I'm not sure how to port the test because it is a live test (not a mock) so needs credentials to run.

Adam,
I'd like to refactor this to remove a lot of the copy/paste stuff.
I'm thinking about changinging the Support class to a templated base class, removing the actual storage mechanism from it, and injecting that back in with an interface. If that's possible, then it will concentrate the mechanism in one place and clarify what it needs to do and will make the behavior stuff more consistent and less brittle across different implementations. I'd move the feature implementation classes into front50-core (?) but and just keep the mechanism class and config class in the front50-<mechanism> components.

Does that make sense? I could do that after this PR.