### PR TITLE
Added Google Cloud Storage alternative to Cassandra.

### DIFF
--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-rootProject.name = "front50"
+dependencies {
+  compile project(":front50-core")
+  compile 'io.reactivex:rxjava:1.0.10'
 
-include 'front50-web', 'front50-core', 'front50-cassandra', 'front50-gcs', 'front50-pipelines', 'front50-redis', 'front50-s3', 'front50-test'
+  spinnaker.group('google')
+  /* spinnaker.group('googleStorage') */
+  compile 'com.google.apis:google-api-services-storage:v1-rev72-1.22.0'
 
-def setBuildFile(project) {
-  project.buildFileName = "${project.name}.gradle"
-  project.children.each {
-    setBuildFile(it)
-  }
-}
 
-rootProject.children.each {
-  setBuildFile(it)
+  testCompile project(":front50-test")
 }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+import com.netflix.spinnaker.front50.model.*;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.schedulers.Schedulers;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
+public class GcsConfig {
+  // Refresh every 10 minutes. In practice this either doesnt matter because refreshes are fast enough,
+  // or should be finer tuned. But it seems silly to refresh at a fast rate when changes are generally infrequent.
+  // Actual queries always check to see if the cache is out of date anyway. So this is mostly for the benefit of
+  // keeping other replicas up to date so that last-minute updates have fewer changes in them.
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private static int APPLICATION_REFRESH_MS = (int)TimeUnit.MINUTES.toMillis(1);
+  private static int PROJECT_REFRESH_MS = (int)TimeUnit.MINUTES.toMillis(1);
+  private static int NOTIFICATION_REFRESH_MS = (int)TimeUnit.MINUTES.toMillis(1);
+  private static int PIPELINE_REFRESH_MS = (int)TimeUnit.MINUTES.toMillis(1);
+  private static int PIPELINE_STRATEGY_REFRESH_MS = (int)TimeUnit.MINUTES.toMillis(1);
+
+  @Value("${spinnaker.gcs.bucket}")
+  private String bucket;
+
+  @Value("${spinnaker.gcs.rootFolder}")
+  private String rootFolder;
+
+  @Value("${spinnaker.gcs.jsonPath:}")
+  private String jsonPath;
+
+  @Value("${spinnaker.gcs.project:}")
+  private String project;
+
+  @Value("${Implementation-Version:Unknown}")
+  private String applicationVersion;
+
+  @Bean
+  public GcsStorageService googleCloudStorageService() {
+    GcsStorageService service;
+    service = new GcsStorageService(bucket, rootFolder, project, jsonPath, applicationVersion);
+    service.ensureBucketExists();
+    log.info("Using Google Cloud Storage bucket={} in project={}",
+             bucket, project);
+    log.info("Bucket versioning is {}.",
+             service.supportsVersioning() ? "enabled" : "DISABLED");
+    return service;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(RestTemplate.class)
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+  @Bean
+  public ApplicationBucketDAO applicationDAO(GcsStorageService service) {
+    return new ApplicationBucketDAO(
+                           rootFolder, service,
+                           Schedulers.from(Executors.newFixedThreadPool(5)),
+                           APPLICATION_REFRESH_MS);
+  }
+
+  @Bean
+  public ProjectBucketDAO projectDAO(GcsStorageService service) {
+    return new ProjectBucketDAO(
+                           rootFolder, service,
+                           Schedulers.from(Executors.newFixedThreadPool(5)),
+                           PROJECT_REFRESH_MS);
+  }
+
+  @Bean
+  public NotificationBucketDAO notificationDAO(GcsStorageService service) {
+    return new NotificationBucketDAO(
+                             rootFolder, service,
+                             Schedulers.from(Executors.newFixedThreadPool(5)),
+                             NOTIFICATION_REFRESH_MS);
+  }
+
+  @Bean
+  public PipelineStrategyBucketDAO pipelineStrategyDAO(GcsStorageService service) {
+      return new PipelineStrategyBucketDAO(
+                             rootFolder, service,
+                             Schedulers.from(Executors.newFixedThreadPool(5)),
+                             PIPELINE_STRATEGY_REFRESH_MS);
+  }
+
+  @Bean
+  public PipelineBucketDAO pipelineDAO(GcsStorageService service) {
+    return new PipelineBucketDAO(rootFolder, service,
+                                 Schedulers.from(Executors.newFixedThreadPool(5)),
+                                 PIPELINE_REFRESH_MS);
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ApplicationBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ApplicationBucketDAO.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
+import rx.Scheduler;
+
+import java.util.*;
+
+public class ApplicationBucketDAO extends BucketDAO<Application> implements ApplicationDAO {
+   public ApplicationBucketDAO(String basePath,
+                               StorageService service,
+                               Scheduler scheduler,
+                               int refreshIntervalMs) {
+       super(Application.class, "applications",
+             basePath, service, scheduler, refreshIntervalMs);
+  }
+
+  @Override
+  public Application findByName(String name) throws NotFoundException {
+      return findById(name);
+  }
+
+  @Override
+  public Application create(String id, Application application) {
+      if (application.getCreateTs() == null) {
+          application.setCreateTs(String.valueOf(System.currentTimeMillis()));
+      }
+
+      update(id, application);
+      return findById(id);
+    }
+
+  @Override
+  public void update(String id, Application application) {
+      application.setName(id);
+      super.update(id, application);
+  }
+
+  @Override
+  public Collection<Application> search(Map<String, String> attributes) {
+      return Searcher.search(all(), attributes);
+  }
+
+  @Override
+  public Collection<Application> getApplicationHistory(String name, int maxResults) {
+    return allVersionsOf(name, maxResults);
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/BucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/BucketDAO.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Scheduler;
+
+import javax.annotation.PostConstruct;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.Long;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public abstract class BucketDAO<T extends Timestamped> {
+  public static long HEALTH_MILLIS = 45000;
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  protected final AtomicReference<Set<T>> allItemsCache = new AtomicReference<>();
+
+  private final StorageService service;
+  private final String daoTypeName;
+  private final String rootFolder;
+  private final Class<T> serializedClass;
+  private final Scheduler scheduler;
+  private final int refreshIntervalMs;
+
+  private long lastRefreshedTime;
+
+  public BucketDAO(Class<T> serializedClass, String daoTypeName, String basePath,
+                   StorageService service,
+                   Scheduler scheduler, int refreshIntervalMs) {
+    this.serializedClass = serializedClass;
+    this.daoTypeName = daoTypeName;
+    this.service = service;
+    this.rootFolder = basePath + '/' + daoTypeName + '/';
+    this.scheduler = scheduler;
+    this.refreshIntervalMs = refreshIntervalMs;
+  }
+
+  @PostConstruct
+  void startRefresh() {
+    // TODO(ewiseblatt): 20160526
+    // Make this start executing now but in another thread.
+    // I dont know how to say that using this API so am
+    // using a timer instead.
+    Observable
+        .timer(0, TimeUnit.MILLISECONDS, scheduler)
+        .subscribe(interval -> {
+          try {
+            log.debug("Warming Cache");
+            refresh();
+          } catch (Exception e) {
+            log.error("Unable to refresh: {}", e);
+          }
+        });
+    Observable
+        .timer(refreshIntervalMs, TimeUnit.MILLISECONDS, scheduler)
+        .repeat()
+        .subscribe(interval -> {
+          try {
+            log.debug("Refreshing");
+            refresh();
+          } catch (Exception e) {
+            log.error("Unable to refresh: {}", e);
+          }
+        });
+  }
+
+  public Collection<T> all() {
+    if (readLastModified() > lastRefreshedTime || allItemsCache.get() == null) {
+      // only refresh if there was a modification since our last refresh cycle
+      refresh();
+    }
+
+    return allItemsCache.get().stream().collect(Collectors.toList());
+  }
+
+  /**
+   * @return Healthy if refreshed in the past HEALTH_MILLIS
+   */
+  public boolean isHealthy() {
+    return (System.currentTimeMillis() - lastRefreshedTime) < HEALTH_MILLIS
+            && allItemsCache.get() != null;
+  }
+
+
+  public T findById(String id) throws NotFoundException {
+      return service.loadCurrentObject(buildObjectKey(id), daoTypeName,
+                                       serializedClass);
+  }
+
+  public Collection<T> allVersionsOf(String id, int limit)
+      throws NotFoundException {
+    return service.listObjectVersions(buildObjectKey(id), daoTypeName, 
+                                      serializedClass, limit);
+  }
+
+  public void update(String id, T item) {
+    service.storeObject(buildObjectKey(id), daoTypeName, item);
+  }
+
+  public void delete(String id) {
+    service.deleteObject(buildObjectKey(id), daoTypeName);
+  }
+
+  public void bulkImport(Collection<T> items) {
+    Observable
+        .from(items)
+        .buffer(10)
+        .flatMap(itemSet -> Observable
+            .from(itemSet)
+            .flatMap(item -> {
+                    service.loadCurrentObject(buildObjectKey(item.getId()),
+                                              daoTypeName, serializedClass);
+              return Observable.just(item);
+            })
+            .subscribeOn(scheduler)
+        ).subscribeOn(scheduler)
+        .toList()
+        .toBlocking()
+        .single();
+  }
+
+  /**
+   * Update local cache with any recently modified items.
+   */
+  protected void refresh() {
+    allItemsCache.set(fetchAllItems(allItemsCache.get()));
+  }
+
+  /**
+   * Fetch any previously cached applications that have been updated since last retrieved.
+   *
+   * @param existingItems Previously cached applications
+   * @return Refreshed applications
+   */
+  protected Set<T> fetchAllItems(Set<T> existingItems) {
+    if (existingItems == null) {
+      existingItems = new HashSet<>();
+    }
+
+    Map<String, String> keyToId = new HashMap<String, String>();
+    for (T item : existingItems) {
+      String id = item.getId();
+      keyToId.put(buildObjectKey(id), id);
+    }
+
+    Long refreshTime = System.currentTimeMillis();
+    Map<String, Long> keyUpdateTime = service.listObjectKeys(daoTypeName);
+  
+    Map<String, T> resultMap = existingItems
+        .stream()
+        .filter(a -> keyUpdateTime.containsKey(buildObjectKey(a)))
+        .collect(Collectors.toMap(Timestamped::getId, Function.identity()));
+
+    List<Map.Entry<String, Long>> modifiedKeys = keyUpdateTime
+        .entrySet()
+        .stream()
+        .filter(entry -> {
+          T existingItem = resultMap.get(entry.getKey());
+          if (existingItem == null) {
+            return true;
+          }
+          Long modTime = existingItem.getLastModified();
+          return modTime == null || entry.getValue() > modTime;
+         })
+        .collect(Collectors.toList());
+
+    Observable
+        .from(modifiedKeys)
+        .buffer(10)
+        .flatMap(ids -> Observable
+            .from(ids)
+            .flatMap(entry -> {
+                  try {
+                      return Observable.just(service.loadCurrentObject(
+                                                      entry.getKey(), daoTypeName,
+                                                      serializedClass));
+                  } catch (NotFoundException e) {
+                    resultMap.remove(keyToId.get(entry.getKey()));
+                    return Observable.empty();
+                  }
+                }
+            )
+            .subscribeOn(scheduler)
+        )
+        .subscribeOn(scheduler)
+        .toList()
+        .toBlocking()
+        .single()
+        .forEach(item -> {
+          resultMap.put(item.getId().toLowerCase(), item);
+        });
+
+    Set<T>  result = resultMap.values().stream().collect(Collectors.toSet());
+    this.lastRefreshedTime = refreshTime;
+    return result;
+  }
+
+  protected String buildObjectKey(T item) {
+    return buildObjectKey(item.getId());
+  }
+
+  protected String buildObjectKey(String id) {
+    return id.toLowerCase();
+  }
+
+  private Long readLastModified() {
+    return service.getLastModified(this.daoTypeName);
+  }
+}
+

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.api.services.storage.model.*;
+
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.util.DateTime;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class GcsStorageService implements StorageService {
+  private static final String DATA_FILENAME = "specification.json";
+  private static final String LAST_MODIFIED_FILENAME = "last-modified";
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+  private String projectName;
+  private String bucketName;
+  private String basePath;
+  private Storage storage;
+  private Storage.Objects obj_api;
+
+  public Storage getStorage() { return this.storage; }
+  public ObjectMapper getObjectMapper() { return this.objectMapper; }
+
+  private GoogleCredential loadCredential(
+      HttpTransport transport, JsonFactory factory, String jsonPath)
+      throws IOException {
+    GoogleCredential credential;
+    if (!jsonPath.isEmpty()) {
+      FileInputStream stream = new FileInputStream(jsonPath);
+      credential = GoogleCredential.fromStream(stream, transport, factory)
+                      .createScoped(Collections.singleton(StorageScopes.DEVSTORAGE_FULL_CONTROL));
+      log.info("Loaded credentials from from " + jsonPath);
+    } else {
+      log.info("spinnaker.gcs.enabled without spinnaker.gcs.jsonPath. Using default application credentials. Using default credentials.");
+      credential = GoogleCredential.getApplicationDefault();
+    }
+    return credential;
+  }
+
+  public GcsStorageService(String bucketName, String basePath,
+                           String projectName, Storage storage) {
+    this.bucketName = bucketName;
+    this.basePath = basePath;
+    this.projectName = projectName;
+    this.storage = storage;
+    this.obj_api = storage.objects();
+  }
+
+  public GcsStorageService(String bucketName, String basePath,
+                           String projectName, String credentialsPath,
+                           String applicationVersion) {
+    Storage storage;
+
+    try {
+      HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+      JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+      GoogleCredential credential = loadCredential(httpTransport, jsonFactory,
+                                                   credentialsPath);
+
+      String applicationName = "Spinnaker-front50/" + applicationVersion;
+      storage = new Storage.Builder(httpTransport, jsonFactory, credential)
+                           .setApplicationName(applicationName)
+                           .build();
+    } catch (IOException|java.security.GeneralSecurityException e) {
+        throw new IllegalStateException(e);
+    }
+
+    this.bucketName = bucketName;
+    this.basePath = basePath;
+    this.projectName = projectName;
+    this.storage = storage;
+    this.obj_api = this.storage.objects();
+  }
+
+  /**
+   * Check to see if the bucket exists, creating it if it is not there.
+   */
+  public void ensureBucketExists() {
+    try {
+      Bucket bucket = storage.buckets().get(bucketName).execute();
+    } catch (HttpResponseException e) {
+      if (e.getStatusCode() == 404) {
+        log.warn("Bucket {} does not exist. Creating it in project={}",
+                 bucketName, projectName);
+        Bucket.Versioning versioning = new Bucket.Versioning().setEnabled(true);
+        Bucket bucket = new Bucket().setName(bucketName).setVersioning(versioning);
+        try {
+            storage.buckets().insert(projectName, bucket).execute();
+        } catch (IOException e2) {
+            log.error("Could not create bucket={} in project={}: {}",
+                      bucketName, projectName, e2);
+            throw new IllegalStateException(e2);
+        }
+      } else {
+          log.error("Could not get bucket={}: {}", bucketName, e);
+          throw new IllegalStateException(e);
+      }
+    } catch (IOException e) {
+        log.error("Could not get bucket={}: {}", bucketName, e);
+        throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * Returns true if the storage service supports versioning.
+   */
+  public boolean supportsVersioning() {
+    try {
+      Bucket bucket = storage.buckets().get(bucketName).execute();
+      return bucket.getVersioning().getEnabled();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public <T extends Timestamped> T
+         loadCurrentObject(String objectKey, String daoTypeName, Class<T> clas)
+         throws NotFoundException {
+    String path = keyToPath(objectKey, daoTypeName);
+    try {
+      StorageObject storageObject = obj_api.get(bucketName, path).execute();
+      T item = deserialize(storageObject, clas, true);
+      item.setLastModified(storageObject.getUpdated().getValue());
+      return item;
+    } catch (HttpResponseException e) {
+      log.error("Failed to load {} {}:\n{}", daoTypeName, objectKey, e);
+      if (e.getStatusCode() == 404) {
+          throw new NotFoundException(String.format("No file at path=%s", path));
+      }
+      throw new IllegalStateException(e);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+
+    }
+  }
+
+  public <T extends Timestamped> T
+         loadObjectVersion(String objectKey, String daoTypeName, Class<T> clas,
+                           String versionId) throws NotFoundException {
+      return null;
+  }
+
+  public void deleteObject(String objectKey, String daoTypeName) {
+    String path = keyToPath(objectKey, daoTypeName);
+    try {
+      obj_api.delete(bucketName, path).execute();
+      writeLastModified(daoTypeName);
+    } catch (IOException e) {
+      log.error("Delete failed on path={}", path);
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public <T extends Timestamped>
+         void storeObject(String objectKey, String daoTypeName, T obj) {
+    String path = keyToPath(objectKey, daoTypeName);
+    try {
+      byte[] bytes = objectMapper.writeValueAsBytes(obj);
+      StorageObject object = new StorageObject().setBucket(bucketName).setName(path);
+      ByteArrayContent content = new ByteArrayContent("application/json", bytes);
+      obj_api.insert(bucketName, object, content).execute();
+      writeLastModified(daoTypeName);
+    } catch (IOException e) {
+      log.error("Update failed on path={}: {}", path, e);
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public Map<String, Long> listObjectKeys(String daoTypeName) {
+    String rootFolder = daoRoot(daoTypeName);
+    int skipToOffset = rootFolder.length() + 1;  // + Trailing slash
+    int skipFromEnd = DATA_FILENAME.length() + 1;  // + Leading slash
+
+    Map<String, Long> result = new HashMap<String, Long>();
+    try {
+      Storage.Objects.List listObjects = obj_api.list(bucketName);
+      listObjects.setPrefix(rootFolder);
+      com.google.api.services.storage.model.Objects objects;
+      do {
+          objects = listObjects.execute();
+          List<StorageObject> items = objects.getItems();
+          if (items != null) {
+              for (StorageObject item: items) {
+                  String name = item.getName();
+                  if (name.endsWith(DATA_FILENAME)) {
+                      result.put(name.substring(skipToOffset,
+                                                name.length() - skipFromEnd),
+                                 item.getUpdated().getValue());
+                  }
+              }
+          }
+          listObjects.setPageToken(objects.getNextPageToken());
+      } while (objects.getNextPageToken() != null);
+    } catch (IOException e) {
+      log.error("Could not fetch items from Google Cloud Storage: {}", e);
+      return new HashMap<String, Long>();
+    }
+
+    return result;
+  }
+
+  public <T extends Timestamped> Collection<T>
+         listObjectVersions(String objectKey, String daoTypeName, Class<T> clas,
+                            int maxResults) throws NotFoundException {
+    String path = keyToPath(objectKey, daoTypeName);
+    ArrayList<T> result = new ArrayList<T>();
+    try {
+      Storage.Objects.List listObjects = obj_api.list(bucketName)
+          .setPrefix(path)
+          .setVersions(true)
+          .setMaxResults(new Long(maxResults));
+      com.google.api.services.storage.model.Objects objects;
+      do {
+          objects = listObjects.execute();
+          List<StorageObject> items = objects.getItems();
+          if (items != null) {
+            for (StorageObject item : items) {
+                T have = deserialize(item, clas, false);
+                if (have != null) {
+                  result.add(have);
+                }
+            }
+          }
+          listObjects.setPageToken(objects.getNextPageToken());
+      } while (objects.getNextPageToken() != null);
+    } catch (IOException e) {
+      log.error("Could not fetch versions from Google Cloud Storage: {}", e);
+      return new ArrayList<>();
+    }
+    return result;
+  }
+
+  private <T extends Timestamped> T
+          deserialize(StorageObject object, Class<T> clas, boolean current_version)
+      throws java.io.UnsupportedEncodingException {
+    try {
+        ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        Storage.Objects.Get getter = obj_api.get(object.getBucket(), object.getName());
+        if (!current_version) {
+            getter.setGeneration(object.getGeneration());
+        }
+        getter.executeMediaAndDownloadTo(output);
+        String json = output.toString("UTF8");
+        return objectMapper.readValue(json, clas);
+      } catch (IOException ex) {
+        if (current_version) {
+          log.error("Error reading {}: {}", object.getName(), ex);
+        } else {
+          log.error("Error reading {} generation={}: {}",
+                    object.getName(), object.getGeneration(), ex);
+        }
+        return null;
+    }
+  }
+
+  private void writeLastModified(String daoTypeName) {
+      // We'll just touch the file since the StorageObject manages a timestamp.
+      byte[] bytes = "{}".getBytes();
+      ByteArrayContent content = new ByteArrayContent("application/json", bytes);
+      StorageObject object = new StorageObject()
+          .setBucket(bucketName)
+          .setName(daoRoot(daoTypeName) + '/' + LAST_MODIFIED_FILENAME)
+          .setUpdated(new DateTime(System.currentTimeMillis()));
+      try {
+          obj_api.insert(bucketName, object, content).execute();
+      } catch (HttpResponseException e) {
+          log.error("writeLastModified failed: {}", e);
+          try {
+              obj_api.update(bucketName, object.getName(), object);
+          } catch (IOException ioex) {
+              log.error("writeLastModified update failed too: {}", ioex);
+              throw new IllegalStateException(ioex);
+          }
+      } catch (IOException e) {
+          log.error("writeLastModified failed: {}", e);
+          throw new IllegalStateException(e);
+      }
+  }
+
+  public long getLastModified(String daoTypeName) {
+      try {
+        return obj_api.get(
+                  bucketName,
+                  daoRoot(daoTypeName) + '/' + LAST_MODIFIED_FILENAME).execute()
+              .getUpdated().getValue();
+      } catch (Exception e) {
+          return 0L;
+      }
+  }
+
+  private String daoRoot(String daoTypeName) {
+      return basePath + '/' + daoTypeName;
+  }
+
+  private String keyToPath(String key, String daoTypeName) {
+      return daoRoot(daoTypeName) + '/' + key + '/' + DATA_FILENAME;
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/NotificationBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/NotificationBucketDAO.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.notification.HierarchicalLevel;
+import com.netflix.spinnaker.front50.model.notification.Notification;
+import com.netflix.spinnaker.front50.model.notification.NotificationDAO;
+import rx.Scheduler;
+
+public class NotificationBucketDAO extends BucketDAO<Notification> implements NotificationDAO {
+  public NotificationBucketDAO(String basePath,
+                               StorageService service,
+                               Scheduler scheduler,
+                               int refreshIntervalMs) {
+      super(Notification.class, "notifications",
+            basePath, service, scheduler, refreshIntervalMs);
+  }
+
+  @Override
+  public Notification getGlobal() {
+    return get(HierarchicalLevel.GLOBAL, Notification.GLOBAL_ID);
+  }
+
+  @Override
+  public Notification get(HierarchicalLevel level, String name) {
+    try {
+      return findById(name);
+    } catch (NotFoundException e) {
+      // an empty Notification is expected for applications that do not exist
+      return new Notification();
+    }
+  }
+
+  @Override
+  public void saveGlobal(Notification notification) {
+    update(Notification.GLOBAL_ID, notification);
+  }
+
+  @Override
+  public void save(HierarchicalLevel level, String name, Notification notification) {
+    update(name, notification);
+  }
+
+  @Override
+  public void delete(HierarchicalLevel level, String name) {
+    delete(name);
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/PipelineBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/PipelineBucketDAO.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
+import rx.Scheduler;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class PipelineBucketDAO extends BucketDAO<Pipeline> implements PipelineDAO {
+  public PipelineBucketDAO(String basePath,
+                           StorageService service,
+                           Scheduler scheduler,
+                           int refreshIntervalMs) {
+      super(Pipeline.class, "pipelines",
+            basePath, service, scheduler, refreshIntervalMs);
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelineHistory(String name, int maxResults) {
+    return allVersionsOf(name, maxResults);
+  }
+
+  @Override
+  public String getPipelineId(String application, String pipelineName) {
+    Pipeline matched = getPipelinesByApplication(application)
+        .stream()
+        .filter(pipeline -> pipeline.getName().equalsIgnoreCase(pipelineName))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException(
+            String.format("No pipeline found with name '%s' in application '%s'", pipelineName, application)
+        ));
+
+    return matched.getId();
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelinesByApplication(String application) {
+    return all()
+        .stream()
+        .filter(pipeline -> pipeline.getApplication().equalsIgnoreCase(application))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Pipeline create(String id, Pipeline item) {
+    if (id == null) {
+      id = UUID.randomUUID().toString();
+    }
+    item.setId(id);
+
+    update(id, item);
+    return findById(id);
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/PipelineStrategyBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/PipelineStrategyBucketDAO.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO;
+import rx.Scheduler;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class PipelineStrategyBucketDAO extends BucketDAO<Pipeline> implements PipelineStrategyDAO {
+  public PipelineStrategyBucketDAO(String basePath,
+                                   StorageService service,
+                                   Scheduler scheduler,
+                                   int refreshIntervalMs) {
+      super(Pipeline.class, "pipeline-strategies",
+            basePath, service, scheduler, refreshIntervalMs);
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelineHistory(String name, int maxResults) {
+    return allVersionsOf(name, maxResults);
+  }
+
+  @Override
+  public String getPipelineId(String application, String pipelineName) {
+    Pipeline matched = getPipelinesByApplication(application)
+        .stream()
+        .filter(pipeline -> pipeline.getName().equalsIgnoreCase(pipelineName))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException(
+            String.format("No pipeline strategy found with name '%s' in application '%s'", pipelineName, application)
+        ));
+
+    return matched.getId();
+  }
+
+  @Override
+  public Collection<Pipeline> getPipelinesByApplication(String application) {
+    return all()
+        .stream()
+        .filter(pipelineStrategy -> pipelineStrategy.getApplication().equalsIgnoreCase(application))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Pipeline create(String id, Pipeline item) {
+    if (id == null) {
+      id = UUID.randomUUID().toString();
+    }
+    item.setId(id);
+
+    update(id, item);
+    return findById(id);
+  }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ProjectBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ProjectBucketDAO.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.google.api.services.storage.Storage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.project.Project;
+import com.netflix.spinnaker.front50.model.project.ProjectDAO;
+import rx.Scheduler;
+
+import java.util.*;
+
+public class ProjectBucketDAO extends BucketDAO<Project> implements ProjectDAO {
+    public ProjectBucketDAO(String basePath,
+                            StorageService service,
+                            Scheduler scheduler,
+                            int refreshIntervalMs) {
+        super(Project.class, "projects",
+              basePath, service, scheduler,refreshIntervalMs);
+    }
+
+    @Override
+    public Project findByName(String name) throws NotFoundException {
+        return fetchAllItems(allItemsCache.get())
+                .stream()
+                .filter(project -> project.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(String.format("No project found with name of %s", name)));
+    }
+
+    @Override
+    public Project create(String id, Project item) {
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+        item.setId(id);
+
+        update(id, item);
+        return findById(id);
+    }
+
+    @Override
+    public void truncate() {
+    }
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+public interface StorageService {
+    /**
+     * Check to see if the bucket exists, creating it if it is not there.
+     */
+    public void ensureBucketExists();
+
+    /**
+     * Returns true if the storage service supports versioning.
+     */
+    public boolean supportsVersioning();
+
+    public <T extends Timestamped> T
+           loadCurrentObject(String objectKey, String daoTypeName, Class<T> clas)
+           throws NotFoundException;
+
+    // There base mechanism and Timestamped need to work together better in order
+    // to have the concept of a version. The store method should return the version
+    // and the Timestamped object should know what its version is
+    // (or VersionTimestamped). Otherwise it isnt practical to specify or implement
+    // an interface for versioning.
+    public <T extends Timestamped> T
+           loadObjectVersion(String objectKey, String daoTypeName, Class<T> clas,
+                             String versionId) throws NotFoundException;
+
+    public void deleteObject(String objectKey, String daoTypeName);
+    public <T extends Timestamped> void
+           storeObject(String objectKey, String daoTypeName, T item);
+
+    public Map<String, Long> listObjectKeys(String daoTypeName);
+
+    public <T extends Timestamped> Collection<T>
+           listObjectVersions(String objectKey, String daoTypeName, Class<T> clas,
+                              int maxResults) throws NotFoundException;
+
+    public long getLastModified(String daoTypeName);
+}

--- a/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/ApplicationBucketDAOSpec.groovy
+++ b/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/ApplicationBucketDAOSpec.groovy
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model
+
+import com.netflix.spinnaker.front50.model.application.Application;
+
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+import spock.lang.Shared
+import spock.lang.Specification
+import java.util.concurrent.Executors;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+
+class ApplicationBucketDAOSpec extends Specification {
+  class TestDAO extends ApplicationBucketDAO {
+    TestDAO(String rootFolder, StorageService service, Scheduler scheduler, int refreshMs) {
+      super(rootFolder, service, scheduler, refreshMs);
+    }
+
+    public Collection<Application> cache() { return allItemsCache.get().stream().collect(Collectors.toSet()) }
+    public void setCache(Set<Application> items) { allItemsCache.set(items) }
+  }
+
+  @Shared
+  int REFRESH_MS = 10000  // dont refresh during our tests
+
+  @Shared
+  String rootFolder = "A/B/C"
+
+  Application mockApp = Mock(Application)
+  StorageService mockService = Mock(StorageService)
+  Scheduler realScheduler = Schedulers.from(Executors.newFixedThreadPool(5))
+
+  TestDAO dao
+
+  void setup() {
+    dao = new TestDAO(rootFolder, mockService, realScheduler, REFRESH_MS)
+  }
+
+  void "findById"() {
+    when:
+      Application app = dao.findById('TestId')
+
+    then:
+      1 * mockService.loadCurrentObject(
+              "testid", "applications", Application.class) >> mockApp
+      app == mockApp
+  }
+
+  void "findById ignores cache"() {
+    Application no = Mock(Application)
+    Application yes = Mock(Application)
+    dao.setCache([yes, no] as Set)
+
+    when:
+      Application app = dao.findById('TestId')
+
+    then:
+      1 * mockService.loadCurrentObject(
+              "testid", "applications", Application.class) >> mockApp
+      app == mockApp
+  }
+
+  void "startRefresh warms cache"() {
+    dao = new TestDAO(rootFolder, mockService, realScheduler, 2000)
+
+    when:
+      dao.startRefresh();
+      System.sleep(50);
+    then:
+      1 * mockService.listObjectKeys("applications") >> new HashMap()
+  }
+
+  void "startRefresh will poll"() {
+    dao = new TestDAO(rootFolder, mockService, realScheduler, 200)
+    long start = System.currentTimeMillis()
+
+    when:
+      dao.startRefresh();
+      System.sleep(500);
+    then:
+      3 * mockService.listObjectKeys("applications") >> new HashMap()
+  }
+
+  void "update does not affect cache"() {
+    Application old = Mock(Application)
+    Application update = Mock(Application)
+    dao.setCache([old] as Set)
+
+    when:
+     dao.update("New", update)
+
+    then:
+     1 * mockService.storeObject("new", "applications", update)
+     dao.cache() == [old] as Set
+  }
+
+  void "delete does not affect cache"() {
+    Application keep = Mock(Application)
+    Application remove = Mock(Application)
+    dao.setCache([keep, remove] as Set)
+
+    when:
+    dao.delete("Remove")
+
+    then:
+    1 * mockService.deleteObject("remove", "applications")
+    dao.cache() == [keep, remove] as Set
+  }
+
+  void "all empty"() {
+    Map emptyMap = [:]
+
+    when:
+      dao.all();
+    then:
+      1 * mockService.getLastModified("applications") >> 0
+      1 * mockService.listObjectKeys("applications") >> emptyMap
+  }
+
+  void "all with two"() {
+    Map twoMap = ["abc":123, "xyz":987]
+    Application abc = Mock(Application)
+    Application xyz = Mock(Application)
+
+    when:
+      Collection<Application> result = dao.all();
+    then:
+      1 * mockService.getLastModified("applications") >> 1
+      1 * mockService.listObjectKeys("applications") >> twoMap
+      1 * mockService.loadCurrentObject("abc", "applications", Application.class) >> abc
+      1 * abc.getId() >> "abc"
+      1 * mockService.loadCurrentObject("xyz", "applications", Application.class) >> xyz
+      1 * xyz.getId() >> "XYZ"
+      result.sort() == [abc, xyz].sort()
+      dao.cache() == [abc, xyz] as Set
+  }
+
+  void "all fresh cache"() {
+    Application abc = Mock(Application)
+    Application xyz = Mock(Application)
+    dao.setCache([abc, xyz] as Set)
+
+    when:
+    Collection<Application> result = dao.all();
+
+    then:
+    1 * mockService.getLastModified("applications") >> 0
+    result.sort() == [abc, xyz].sort()
+  }
+
+  void "all stale cache"() {
+    long modTime = 12345L
+    Application oldFresh = Mock(Application)
+    Application oldGone = Mock(Application)
+    Application oldStale = Mock(Application)
+    Application newStale = Mock(Application)
+    Application newNew = Mock(Application)
+
+    Map foundMap = ["fresh":123L, "stale":modTime, "new":modTime - 1]
+    dao.setCache([oldFresh, oldStale, oldGone] as Set)
+
+    when:
+    Collection<Application> result = dao.all();
+
+    then:
+    1 * mockService.getLastModified("applications") >> modTime
+    1 * oldFresh.getId() >> "fresh"
+    1 * oldStale.getId() >> "stale"
+    1 * oldGone.getId() >> "gone"
+
+    then:
+    1 * mockService.listObjectKeys("applications") >> foundMap
+    2 * oldFresh.getId() >> "fresh"  // lookup in filter, insert into map
+    2 * oldStale.getId() >> "stale"  // lookup in filter, insert into map
+    1 * oldGone.getId() >> "gone"    // lookup in filter
+    1 * oldFresh.getLastModified() >> 123L  // same as our scan
+    1 * oldStale.getLastModified() >> 123L  // older than our scan
+
+    then:
+    1 * mockService.loadCurrentObject("stale", "applications", Application.class) >> newStale
+    1 * newStale.getId() >> "stale"
+    1 * mockService.loadCurrentObject("new", "applications", Application.class) >> newNew
+    1 * newNew.getId() >> "new"
+    _ * oldFresh.hashCode() >> 123
+    _ * newStale.hashCode() >> 234
+    _ * mockService.toString()
+    _ * oldFresh.toString()
+    _ * oldGone.toString()
+    _ * oldStale.toString()
+    _ * newStale.toString()
+
+    result.sort() == [oldFresh, newNew, newStale].sort()
+    dao.cache() == result.toSet()
+  }
+}

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -47,6 +47,7 @@ jar {
 dependencies {
   compile project(":front50-core")
   compile project(":front50-cassandra")
+  compile project(":front50-gcs")
   compile project(":front50-redis")
   compile project(":front50-s3")
   compile project(":front50-pipelines")


### PR DESCRIPTION
@ajordens 
This is another take on the previous GCS PR but assumes a refactoring.
I put the refactoring in the google-gcs package here, because I'm not sure where to put it and want to run it by you before pursuing it further. I left S3 alone, but it is based on what you did so should be straight forward to refactor.

The design uses a base BucketDAO class with the item subclasses as before, except that you inject a StorageService into the BucketDAO constructor where the StorageService is specialized for the underlying service implementation.

In the BucketDAO I cut out this block https://github.com/spinnaker/front50/blob/master/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3Support.java#L256
because it seemed superfluous. I suspect it really is not and there is an extra bit of concurrency in there. If that is the case, then I need to add another method into the StorageService to get at the metadata and another one to load an object from a metadata specification. If that is the case then the metadata type would be another class parameter to the StorageService and maybe there is a marker interface or something to pass through the BucketDAO so it can mediate between the two StorageService APIs.

The interface doesnt really support versioning because I dont think the existing data model supports it. I have some comments in there about how it could be moved forward, but doing so is outside the scope of this PR.

Note that to keep it simpler I'm using the same filename for all the types, but restricting search on the path that branches at the root depending on the type. Since I assume you want to preserve compatability with what you've already deployed, I was imaging that the S3StorageService would map from the daoTypeName into the file name to use, and encapsulate that mapping. If you add new types, then you could either extend the mapping, or default to some standard filename.
