### PR TITLE
validate pipelines have applications and names

### DIFF
--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/PipelineBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/PipelineBucketDAO.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
+import org.springframework.util.Assert;
 import rx.Scheduler;
 
 import java.util.Collection;
@@ -68,6 +69,9 @@ public class PipelineBucketDAO extends BucketDAO<Pipeline> implements PipelineDA
       id = UUID.randomUUID().toString();
     }
     item.setId(id);
+
+    Assert.notNull(item.getApplication(), "application field must NOT be null!");
+    Assert.notNull(item.getName(), "name field must NOT be null!");
 
     update(id, item);
     return findById(id);

--- a/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/PipelineBucketDAOSpec.groovy
+++ b/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/PipelineBucketDAOSpec.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model
+
+import com.netflix.spinnaker.front50.pipeline.PipelineDAOSpec
+import static rx.schedulers.Schedulers.immediate
+
+class PipelineBucketDAOSpec extends PipelineDAOSpec<PipelineBucketDAO> {
+
+  def storageService = Stub(StorageService)
+
+  @Override
+  PipelineBucketDAO getInstance() {
+    return new PipelineBucketDAO("basePath", storageService, immediate(), 10000)
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3PipelineDAO.java
@@ -16,16 +16,16 @@
 
 package com.netflix.spinnaker.front50.model;
 
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
+import org.springframework.util.Assert;
 import rx.Scheduler;
-
-import java.util.Collection;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class S3PipelineDAO extends S3Support<Pipeline> implements PipelineDAO {
   public S3PipelineDAO(ObjectMapper objectMapper,
@@ -69,6 +69,9 @@ public class S3PipelineDAO extends S3Support<Pipeline> implements PipelineDAO {
       id = UUID.randomUUID().toString();
     }
     item.setId(id);
+
+    Assert.notNull(item.getApplication(), "application field must NOT be null!");
+    Assert.notNull(item.getName(), "name field must NOT be null!");
 
     update(id, item);
     return findById(id);

--- a/front50-s3/src/test/groovy/com/netflix/spinnaker/front50/model/S3PipelineDAOSpec.groovy
+++ b/front50-s3/src/test/groovy/com/netflix/spinnaker/front50/model/S3PipelineDAOSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model
+
+import com.amazonaws.services.s3.AmazonS3
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.pipeline.PipelineDAOSpec
+import static rx.schedulers.Schedulers.immediate
+
+class S3PipelineDAOSpec extends PipelineDAOSpec<S3PipelineDAO> {
+
+  def amazonS3 = Stub(AmazonS3)
+  def objectMapper = new ObjectMapper()
+
+  @Override
+  S3PipelineDAO getInstance() {
+    return new S3PipelineDAO(objectMapper, amazonS3, immediate(), 10000, "bucket", "rootFolder")
+  }
+}

--- a/front50-test/src/main/groovy/com/netflix/spinnaker/front50/pipeline/PipelineDAOSpec.groovy
+++ b/front50-test/src/main/groovy/com/netflix/spinnaker/front50/pipeline/PipelineDAOSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.pipeline
+
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import spock.lang.*
+
+abstract class PipelineDAOSpec<T extends PipelineDAO> extends Specification {
+
+  abstract T getInstance()
+
+  def "cannot create a pipeline without an application"() {
+    when:
+    instance.create("1", new Pipeline(name: "I have no application"))
+
+    then:
+    thrown IllegalArgumentException
+  }
+
+  def "cannot create a pipeline without a name"() {
+    when:
+    instance.create("1", new Pipeline(application: "foo"))
+
+    then:
+    thrown IllegalArgumentException
+  }
+
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -19,15 +19,9 @@ package com.netflix.spinnaker.front50.controllers
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import static org.springframework.http.HttpStatus.BAD_REQUEST
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 
 /**
  * Controller for presets
@@ -36,83 +30,98 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping('pipelines')
 class PipelineController {
 
-    @Autowired
-    PipelineDAO pipelineDAO
+  @Autowired
+  PipelineDAO pipelineDAO
 
-    @RequestMapping(value = '', method = RequestMethod.GET)
-    List<Pipeline> list() {
-        pipelineDAO.all()
+  @RequestMapping(value = '', method = RequestMethod.GET)
+  List<Pipeline> list() {
+    pipelineDAO.all()
+  }
+
+  @RequestMapping(value = '{application:.+}', method = RequestMethod.GET)
+  List<Pipeline> listByApplication(
+    @PathVariable(value = 'application') String application) {
+    pipelineDAO.getPipelinesByApplication(application)
+  }
+
+  @RequestMapping(value = '{id:.+}/history', method = RequestMethod.GET)
+  Collection<Pipeline> getHistory(@PathVariable String id,
+                                  @RequestParam(value = "limit", defaultValue = "20") int limit) {
+    return pipelineDAO.getPipelineHistory(id, limit)
+  }
+
+  @RequestMapping(value = '', method = RequestMethod.POST)
+  void save(@RequestBody Pipeline pipeline) {
+    if (!pipeline.application || !pipeline.name) {
+      throw new InvalidPipelineDefinition()
     }
 
-    @RequestMapping(value = '{application:.+}', method = RequestMethod.GET)
-    List<Pipeline> listByApplication(@PathVariable(value = 'application') String application) {
-        pipelineDAO.getPipelinesByApplication(application)
+    if (!pipeline.id) {
+      checkForDuplicatePipeline(pipeline.getApplication(), pipeline.getName())
+      // ensure that cron triggers are assigned a unique identifier for new pipelines
+      def triggers = (pipeline.triggers ?: []) as List<Map>
+      triggers.findAll { it.type == "cron" }.each { Map trigger ->
+        trigger.id = UUID.randomUUID().toString()
+      }
     }
 
-    @RequestMapping(value = '{id:.+}/history', method = RequestMethod.GET)
-    Collection<Pipeline> getHistory(@PathVariable String id,
-                                    @RequestParam(value = "limit", defaultValue = "20") int limit) {
-        return pipelineDAO.getPipelineHistory(id, limit)
+    pipelineDAO.create(pipeline.id as String, pipeline)
+  }
+
+  @RequestMapping(value = 'batchUpdate', method = RequestMethod.POST)
+  void batchUpdate(@RequestBody List<Pipeline> pipelines) {
+    pipelineDAO.bulkImport(pipelines)
+  }
+
+  @RequestMapping(value = '{application}/{pipeline:.+}', method = RequestMethod.DELETE)
+  void delete(@PathVariable String application, @PathVariable String pipeline) {
+    pipelineDAO.delete(
+      pipelineDAO.getPipelineId(application, pipeline)
+    )
+  }
+
+  @RequestMapping(value = 'deleteById/{id:.+}', method = RequestMethod.DELETE)
+  void delete(@PathVariable String id) {
+    pipelineDAO.delete(id)
+  }
+
+  @RequestMapping(value = 'move', method = RequestMethod.POST)
+  void rename(@RequestBody RenameCommand command) {
+    checkForDuplicatePipeline(command.application, command.to)
+    def pipelineId = pipelineDAO.getPipelineId(command.application, command.from)
+    def pipeline = pipelineDAO.findById(pipelineId)
+    pipeline.setName(command.to)
+
+    pipelineDAO.update(pipelineId, pipeline)
+  }
+
+  static class RenameCommand {
+    String application
+    String from
+    String to
+  }
+
+  private void checkForDuplicatePipeline(String application, String name) {
+    if (pipelineDAO.getPipelinesByApplication(application).any {
+      it.getName() == name
+    }) {
+      throw new DuplicatePipelineNameException()
     }
+  }
 
-    @RequestMapping(value = '', method = RequestMethod.POST)
-    void save(@RequestBody Pipeline pipeline) {
-        if (!pipeline.id) {
-            checkForDuplicatePipeline(pipeline.getApplication(), pipeline.getName())
-            // ensure that cron triggers are assigned a unique identifier for new pipelines
-            def triggers = (pipeline.triggers ?: []) as List<Map>
-            triggers.findAll { it.type == "cron" }.each { Map trigger ->
-                trigger.id = UUID.randomUUID().toString()
-            }
-        }
+  @ExceptionHandler(DuplicatePipelineNameException)
+  @ResponseStatus(BAD_REQUEST)
+  Map handleDuplicatePipelineNameException() {
+    return [error: "A pipeline with that name already exists in that application", status: BAD_REQUEST]
+  }
 
-        pipelineDAO.create(pipeline.id as String, pipeline)
-    }
+  @ExceptionHandler(InvalidPipelineDefinition)
+  @ResponseStatus(UNPROCESSABLE_ENTITY)
+  Map handleInvalidPipelineDefinition() {
+    return [error: "A pipeline requires name and application fields", status: UNPROCESSABLE_ENTITY]
+  }
 
-    @RequestMapping(value = 'batchUpdate', method = RequestMethod.POST)
-    void batchUpdate(@RequestBody List<Pipeline> pipelines) {
-        pipelineDAO.bulkImport(pipelines)
-    }
+  static class DuplicatePipelineNameException extends Exception {}
 
-    @RequestMapping(value = '{application}/{pipeline:.+}', method = RequestMethod.DELETE)
-    void delete(@PathVariable String application, @PathVariable String pipeline) {
-        pipelineDAO.delete(
-            pipelineDAO.getPipelineId(application, pipeline)
-        )
-    }
-
-    @RequestMapping(value = 'deleteById/{id:.+}', method = RequestMethod.DELETE)
-    void delete(@PathVariable String id) {
-        pipelineDAO.delete(id)
-    }
-
-    @RequestMapping(value = 'move', method = RequestMethod.POST)
-    void rename(@RequestBody RenameCommand command) {
-        checkForDuplicatePipeline(command.application, command.to)
-        def pipelineId = pipelineDAO.getPipelineId(command.application, command.from)
-        def pipeline = pipelineDAO.findById(pipelineId)
-        pipeline.setName(command.to)
-
-        pipelineDAO.update(pipelineId, pipeline)
-    }
-
-    static class RenameCommand {
-        String application
-        String from
-        String to
-    }
-
-    private void checkForDuplicatePipeline(String application, String name) {
-        if (pipelineDAO.getPipelinesByApplication(application).any { it.getName() == name}) {
-            throw new DuplicatePipelineNameException()
-        }
-    }
-
-    @ExceptionHandler(DuplicatePipelineNameException)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    Map handleDuplicatePipelineNameException() {
-        return [error: "A pipeline with that name already exists in that application", status: HttpStatus.BAD_REQUEST]
-    }
-
-    static class DuplicatePipelineNameException extends Exception {}
+  static class InvalidPipelineDefinition extends Exception {}
 }


### PR DESCRIPTION
Saving a pipeline with no `application` property means we can never retrieve any pipelines until the database gets cleaned up. This is quite bad.

PTAL @ajordens 