### PR TITLE
Added web interfaces getById and getByName for pipeline and strategy

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -44,6 +44,18 @@ class PipelineController {
     pipelineDAO.getPipelinesByApplication(application)
   }
 
+  @RequestMapping(value = 'getById/{id:.+}', method = RequestMethod.GET)
+  Pipeline findById(@PathVariable String id) {
+    pipelineDAO.findById(id)
+  }
+
+  @RequestMapping(value = 'getByName/{application:.+}/{name:.+}', method = RequestMethod.GET)
+  Pipeline findByName(@PathVariable String application, @PathVariable String name) {
+    pipelineDAO.findById(
+            pipelineDAO.getPipelineId(application, name)
+    )
+  }
+
   @RequestMapping(value = '{id:.+}/history', method = RequestMethod.GET)
   Collection<Pipeline> getHistory(@PathVariable String id,
                                   @RequestParam(value = "limit", defaultValue = "20") int limit) {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/StrategyController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/StrategyController.groovy
@@ -49,6 +49,18 @@ class StrategyController {
         pipelineStrategyDAO.getPipelinesByApplication(application)
     }
 
+    @RequestMapping(value = 'getById/{id:.+}', method = RequestMethod.GET)
+    Pipeline findById(@PathVariable String id) {
+        pipelineStrategyDAO.findById(id)
+    }
+
+    @RequestMapping(value = 'getByName/{application:.+}/{strategy:.+}', method = RequestMethod.GET)
+    Pipeline findByName(@PathVariable String application, @PathVariable String strategy) {
+        pipelineStrategyDAO.findById(
+                pipelineStrategyDAO.getPipelineId(application, strategy)
+        )
+    }
+
     @RequestMapping(value = '{id:.+}/history', method = RequestMethod.GET)
     Collection<Pipeline> getHistory(@PathVariable String id,
                                     @RequestParam(value = "limit", defaultValue = "20") int limit) {


### PR DESCRIPTION
@ajordens This is the front50 fix for the issue I raised last week.

I dont know where the consumers for this would be. I'd like deck to ask for pipelines similar to applications so that it hits the storage service to check cache freshness. I assume orca would want to do something similar as well.