### PR TITLE
Adds ApplicationPermission model object, DAO for GCS/S3, and controller.

### DIFF
--- a/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAO.groovy
+++ b/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAO.groovy
@@ -39,9 +39,13 @@ import org.springframework.stereotype.Component
 
 import javax.annotation.PostConstruct
 
+/**
+ * @deprecated - Use GCS or S3 bucket implementations instead.
+ */
 @Slf4j
 @Component
 @ConditionalOnExpression('${cassandra.enabled:false}')
+@Deprecated
 class CassandraApplicationDAO implements ApplicationDAO {
 
   private static final MapSerializer<String, String> mapSerializer = new MapSerializer<String, String>(UTF8Type.instance, UTF8Type.instance)

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -305,4 +305,16 @@ class Application implements Timestamped {
   static class ValidationException extends RuntimeException {
     Errors errors
   }
+
+  static class Permission implements Timestamped {
+    String name
+    Long lastModified
+    List<String> requiredGroupMembership
+
+    @Override
+    @JsonIgnore()
+    String getId() {
+      return name.toLowerCase()
+    }
+  }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAO.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAO.groovy
@@ -19,8 +19,9 @@
 package com.netflix.spinnaker.front50.model.application
 
 import com.netflix.spinnaker.front50.exception.NotFoundException
+import com.netflix.spinnaker.front50.model.ItemDAO
 
-public interface ApplicationDAO extends com.netflix.spinnaker.front50.model.ItemDAO<Application> {
+public interface ApplicationDAO extends ItemDAO<Application> {
   Application findByName(String name) throws NotFoundException
 
   Collection<Application> search(Map<String, String> attributes)

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationPermissionDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/ApplicationPermissionDAO.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.application;
+
+import com.netflix.spinnaker.front50.model.ItemDAO;
+
+public interface ApplicationPermissionDAO extends ItemDAO<Application.Permission> {
+  String DEFAULT_DATA_FILENAME = "permission.json";
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -17,15 +17,15 @@
 package com.netflix.spinnaker.front50.config;
 
 import com.netflix.spinnaker.front50.model.*;
-
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import rx.schedulers.Schedulers;
 
 import java.util.concurrent.Executors;
@@ -61,9 +61,17 @@ public class GcsConfig {
   private String applicationVersion;
 
   @Bean
-  public GcsStorageService googleCloudStorageService() {
+  public GcsStorageService defaultGoogleCloudStorageService() {
+    return googleCloudStorageService(null /*dataFilename*/);
+  }
+
+  private GcsStorageService googleCloudStorageService(String dataFilename) {
     GcsStorageService service;
-    service = new GcsStorageService(bucket, rootFolder, project, jsonPath, applicationVersion);
+    if (dataFilename == null || dataFilename.isEmpty()) {
+      service = new GcsStorageService(bucket, rootFolder, project, jsonPath, applicationVersion);
+    } else {
+      service = new GcsStorageService(bucket, rootFolder, project, jsonPath, applicationVersion, dataFilename);
+    }
     service.ensureBucketExists();
     log.info("Using Google Cloud Storage bucket={} in project={}",
              bucket, project);
@@ -80,39 +88,49 @@ public class GcsConfig {
 
   @Bean
   public ApplicationBucketDAO applicationDAO(GcsStorageService service) {
-    return new ApplicationBucketDAO(
-                           rootFolder, service,
-                           Schedulers.from(Executors.newFixedThreadPool(5)),
-                           APPLICATION_REFRESH_MS);
+    return new ApplicationBucketDAO(rootFolder,
+                                    service,
+                                    Schedulers.from(Executors.newFixedThreadPool(5)),
+                                    APPLICATION_REFRESH_MS);
+  }
+
+  @Bean
+  public ApplicationPermissionBucketDAO applicationPermissionDAO() {
+    GcsStorageService service = googleCloudStorageService(ApplicationPermissionDAO.DEFAULT_DATA_FILENAME);
+    return new ApplicationPermissionBucketDAO(rootFolder,
+                                              service,
+                                              Schedulers.from(Executors.newFixedThreadPool(5)),
+                                              APPLICATION_REFRESH_MS);
   }
 
   @Bean
   public ProjectBucketDAO projectDAO(GcsStorageService service) {
-    return new ProjectBucketDAO(
-                           rootFolder, service,
-                           Schedulers.from(Executors.newFixedThreadPool(5)),
-                           PROJECT_REFRESH_MS);
+    return new ProjectBucketDAO(rootFolder,
+                                service,
+                                Schedulers.from(Executors.newFixedThreadPool(5)),
+                                PROJECT_REFRESH_MS);
   }
 
   @Bean
   public NotificationBucketDAO notificationDAO(GcsStorageService service) {
-    return new NotificationBucketDAO(
-                             rootFolder, service,
-                             Schedulers.from(Executors.newFixedThreadPool(5)),
-                             NOTIFICATION_REFRESH_MS);
+    return new NotificationBucketDAO(rootFolder,
+                                     service,
+                                     Schedulers.from(Executors.newFixedThreadPool(5)),
+                                     NOTIFICATION_REFRESH_MS);
   }
 
   @Bean
   public PipelineStrategyBucketDAO pipelineStrategyDAO(GcsStorageService service) {
-      return new PipelineStrategyBucketDAO(
-                             rootFolder, service,
-                             Schedulers.from(Executors.newFixedThreadPool(5)),
-                             PIPELINE_STRATEGY_REFRESH_MS);
+    return new PipelineStrategyBucketDAO(rootFolder,
+                                         service,
+                                         Schedulers.from(Executors.newFixedThreadPool(5)),
+                                         PIPELINE_STRATEGY_REFRESH_MS);
   }
 
   @Bean
   public PipelineBucketDAO pipelineDAO(GcsStorageService service) {
-    return new PipelineBucketDAO(rootFolder, service,
+    return new PipelineBucketDAO(rootFolder,
+                                 service,
                                  Schedulers.from(Executors.newFixedThreadPool(5)),
                                  PIPELINE_REFRESH_MS);
   }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ApplicationBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ApplicationBucketDAO.java
@@ -17,14 +17,13 @@
 
 package com.netflix.spinnaker.front50.model;
 
-import com.google.api.services.storage.Storage;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.application.Application;
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import rx.Scheduler;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
 
 public class ApplicationBucketDAO extends BucketDAO<Application> implements ApplicationDAO {
    public ApplicationBucketDAO(String basePath,

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ApplicationPermissionBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ApplicationPermissionBucketDAO.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
+import rx.Scheduler;
+
+public class ApplicationPermissionBucketDAO extends BucketDAO<Application.Permission> implements ApplicationPermissionDAO {
+
+  public ApplicationPermissionBucketDAO(String basePath,
+                                        StorageService service,
+                                        Scheduler scheduler,
+                                        int refreshIntervalMs) {
+    // Using "applications" daoTypeName here in order to keep the permission.json file under the
+    // applications directory.
+    super(Application.Permission.class, "applications", basePath, service, scheduler, refreshIntervalMs);
+  }
+
+  @Override
+  public Application.Permission create(String id, Application.Permission permission) {
+    return upsert(id, permission);
+  }
+
+  @Override
+  public void update(String id, Application.Permission permission) {
+    upsert(id, permission);
+  }
+
+  private Application.Permission upsert(String id, Application.Permission permission) {
+    permission.setName(id);
+    permission.setLastModified(System.currentTimeMillis());
+    super.update(id, permission);
+    return findById(id);
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -68,6 +68,11 @@ public class S3Config {
   }
 
   @Bean
+  public S3ApplicationPermissionDAO s3ApplicationPermissionDAO(ObjectMapper objectMapper, AmazonS3 amazonS3) {
+    return new S3ApplicationPermissionDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(20)), 15000, bucket, rootFolder);
+  }
+
+  @Bean
   public S3ProjectDAO s3ProjectDAO(ObjectMapper objectMapper, AmazonS3 amazonS3) {
     return new S3ProjectDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(10)), 30000, bucket, rootFolder);
   }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3ApplicationPermissionDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3ApplicationPermissionDAO.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.front50.model;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
+import rx.Scheduler;
+
+public class S3ApplicationPermissionDAO extends S3Support<Application.Permission> implements ApplicationPermissionDAO {
+  public S3ApplicationPermissionDAO(ObjectMapper objectMapper,
+                                    AmazonS3 amazonS3,
+                                    Scheduler scheduler,
+                                    int refreshIntervalMs,
+                                    String bucket,
+                                    String rootFolder) {
+    super(objectMapper, amazonS3, scheduler, refreshIntervalMs, bucket, (rootFolder + "/applications/").replaceAll("//", "/"));
+  }
+
+  @Override
+  public Application.Permission create(String id, Application.Permission permission) {
+    return upsert(id, permission);
+  }
+
+  @Override
+  public void update(String id, Application.Permission permission) {
+    upsert(id, permission);
+  }
+
+  private Application.Permission upsert(String id, Application.Permission permission) {
+    permission.setName(id);
+    permission.setLastModified(System.currentTimeMillis());
+    super.update(id, permission);
+    return findById(id);
+  }
+
+  @Override
+  Class<Application.Permission> getSerializedClass() {
+    return Application.Permission.class;
+  }
+
+  @Override
+  String getMetadataFilename() {
+    return "application-permission.json";
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO
+import io.swagger.annotations.ApiOperation
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/permissions")
+@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false}')
+public class PermissionsController {
+
+  @Autowired
+  ApplicationPermissionDAO applicationPermissionDAO;
+
+  @ApiOperation(value = "", notes = "Get all application permissions. Internal use only.")
+  @RequestMapping(method = RequestMethod.GET, value = "/applications")
+  Set<Application.Permission> getAllApplicationPermissions() {
+    applicationPermissionDAO.all();
+  }
+
+  @ApiOperation(value = "", notes = "Create an application permission.")
+  @RequestMapping(method = RequestMethod.POST, value = "/applications")
+  Application.Permission createApplicationPermission(
+      @RequestBody Application.Permission permission) {
+    return applicationPermissionDAO.create(permission.id, permission)
+  }
+
+  @RequestMapping(method = RequestMethod.PUT, value = "/applications/{appName:.+}")
+  Application.Permission updateApplicationPermission(
+      @PathVariable String appName,
+      @RequestBody Application.Permission permission) {
+    applicationPermissionDAO.update(appName, permission)
+    return applicationPermissionDAO.findById(appName);
+  }
+}


### PR DESCRIPTION
New endpoint will be used by Fiat when starting up to load applications and periodically update its cache.  POST/PUT endpoints can be used by Orca when new applications are created.

Deprecates CassandraDAO since NFLX is no longer using it and we're encouraging new customers to go the GCS/S3 bucket route.

@ajordens @cfieber @jtk54 @duftler PTAL.