### PR TITLE
Adds ability to specify location of GCS auto-created bucket.

### DIFF
--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -48,6 +48,9 @@ public class GcsConfig {
   @Value("${spinnaker.gcs.bucket}")
   private String bucket;
 
+  @Value("${spinnaker.gcs.bucketLocation}")
+  private String bucketLocation;
+
   @Value("${spinnaker.gcs.rootFolder}")
   private String rootFolder;
 
@@ -68,9 +71,9 @@ public class GcsConfig {
   private GcsStorageService googleCloudStorageService(String dataFilename) {
     GcsStorageService service;
     if (dataFilename == null || dataFilename.isEmpty()) {
-      service = new GcsStorageService(bucket, rootFolder, project, jsonPath, applicationVersion);
+      service = new GcsStorageService(bucket, bucketLocation, rootFolder, project, jsonPath, applicationVersion);
     } else {
-      service = new GcsStorageService(bucket, rootFolder, project, jsonPath, applicationVersion, dataFilename);
+      service = new GcsStorageService(bucket, bucketLocation, rootFolder, project, jsonPath, applicationVersion, dataFilename);
     }
     service.ensureBucketExists();
     log.info("Using Google Cloud Storage bucket={} in project={}",

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -38,6 +38,7 @@ import java.io.FileInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ public class GcsStorageService implements StorageService {
   private ObjectMapper objectMapper = new ObjectMapper();
   private String projectName;
   private String bucketName;
+  private String bucketLocation;
   private String basePath;
   private Storage storage;
   private Storage.Objects obj_api;
@@ -82,8 +84,13 @@ public class GcsStorageService implements StorageService {
   }
 
   @VisibleForTesting
-  GcsStorageService(String bucketName, String basePath, String projectName, Storage storage) {
+  GcsStorageService(String bucketName,
+                    String bucketLocation,
+                    String basePath,
+                    String projectName,
+                    Storage storage) {
     this.bucketName = bucketName;
+    this.bucketLocation = bucketLocation;
     this.basePath = basePath;
     this.projectName = projectName;
     this.storage = storage;
@@ -91,11 +98,13 @@ public class GcsStorageService implements StorageService {
   }
 
   public GcsStorageService(String bucketName,
+                           String bucketLocation,
                            String basePath,
                            String projectName,
                            String credentialsPath,
                            String applicationVersion) {
     this(bucketName,
+         bucketLocation,
          basePath,
          projectName,
          credentialsPath,
@@ -104,6 +113,7 @@ public class GcsStorageService implements StorageService {
   }
 
   public GcsStorageService(String bucketName,
+                           String bucketLocation,
                            String basePath,
                            String projectName,
                            String credentialsPath,
@@ -126,6 +136,7 @@ public class GcsStorageService implements StorageService {
     }
 
     this.bucketName = bucketName;
+    this.bucketLocation = bucketLocation;
     this.basePath = basePath;
     this.projectName = projectName;
     this.storage = storage;
@@ -145,6 +156,9 @@ public class GcsStorageService implements StorageService {
                  bucketName, projectName);
         Bucket.Versioning versioning = new Bucket.Versioning().setEnabled(true);
         Bucket bucket = new Bucket().setName(bucketName).setVersioning(versioning);
+        if (StringUtils.isNotBlank(bucketLocation)) {
+          bucket.setLocation(bucketLocation);
+        }
         try {
             storage.buckets().insert(projectName, bucket).execute();
         } catch (IOException e2) {

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -57,11 +57,16 @@ public class GcsStorageService implements StorageService {
   private ObjectMapper objectMapper = new ObjectMapper();
   private String projectName;
   private String bucketName;
-  private String bucketLocation;
   private String basePath;
   private Storage storage;
   private Storage.Objects obj_api;
   private String dataFilename = DEFAULT_DATA_FILENAME;
+
+  /**
+   * Bucket location for when a missing bucket is created. Has no effect if the bucket already
+   * exists.
+   */
+  private String bucketLocation;
 
   public Storage getStorage() { return this.storage; }
   public ObjectMapper getObjectMapper() { return this.objectMapper; }

--- a/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/GoogleStorageServiceSpec.groovy
+++ b/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/GoogleStorageServiceSpec.groovy
@@ -38,6 +38,9 @@ class GoogleStorageServiceSpec extends Specification {
   String BUCKET_NAME = "TestBucket"
 
   @Shared
+  String BUCKET_LOCATION = "US"
+
+  @Shared
   String BASE_PATH = "/A/B/C"
   
   @Shared
@@ -48,8 +51,7 @@ class GoogleStorageServiceSpec extends Specification {
   GcsStorageService gcs
 
   GcsStorageService makeGcs() {
-    return new GcsStorageService(BUCKET_NAME, BASE_PATH, PROJECT_NAME,
-                                 mockStorage)    
+    return new GcsStorageService(BUCKET_NAME, BUCKET_LOCATION, BASE_PATH, PROJECT_NAME, mockStorage)
   }
 
   def "ensureBucketExists make bucket"() {
@@ -58,7 +60,10 @@ class GoogleStorageServiceSpec extends Specification {
      Storage.Buckets.Get mockGetBucket = Mock(Storage.Buckets.Get)
      Storage.Buckets.Insert mockInsertBucket = Mock(Storage.Buckets.Insert)
      Bucket.Versioning ver = new Bucket.Versioning().setEnabled(true)
-     Bucket bucketSpec = new Bucket().setName(BUCKET_NAME).setVersioning(ver)
+     Bucket bucketSpec = new Bucket()
+         .setName(BUCKET_NAME)
+         .setVersioning(ver)
+         .setLocation(BUCKET_LOCATION)
 
     when:
      gcs = makeGcs()
@@ -104,9 +109,6 @@ class GoogleStorageServiceSpec extends Specification {
     given:
      Storage.Buckets mockBucketApi = Mock(Storage.Buckets)
      Storage.Buckets.Get mockGetBucket = Mock(Storage.Buckets.Get)
-     Storage.Buckets.Insert mockInsertBucket = Mock(Storage.Buckets.Insert)
-     Bucket.Versioning ver = new Bucket.Versioning().setEnabled(true)
-     Bucket bucketSpec = new Bucket().setName(BUCKET_NAME).setVersioning(ver)
      HttpResponseException exception = new HttpResponseException.Builder(
          403, 'Oops', new HttpHeaders()).build()
 


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/1002. Buckets already created cannot have their location changed - you must move the data, delete it and have Front50 recreate the bucket. See https://cloud.google.com/storage/docs/managing-buckets#manage-class-location

@ewiseblatt @duftler @lwander PTAL

CC: @leelasharma

