### PR TITLE
provider/google: added support for saving infrastructure definitions to gcs buckets

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/Snapshot.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/Snapshot.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.snapshot
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.front50.model.Timestamped
+
+/*
+ * A snapshot contains a description of the server groups, load balancers, autoscalers
+ * and security groups in the scope of the account and application. These resources are stored in a string
+ * using a config language such as Terraform, CloudFormation or Heat.
+ */
+class Snapshot implements Timestamped {
+
+    enum Type {
+        TERRAFORM,
+    }
+
+    String id
+    String application
+    String account
+    // Describes the resources deployed in the cloud of the application and account
+    String infrastructure
+    // Resources are described using this config language, used for deserialization
+    Type configLang
+
+    Long lastModified
+    Long timestamp
+
+    @Override
+    @JsonIgnore
+    Long getLastModified() {
+        return lastModified
+    }
+
+    @Override
+    void setLastModified(Long lastModified) {
+        this.lastModified = lastModified
+    }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/SnapshotDAO.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/SnapshotDAO.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.snapshot
+
+import com.netflix.spinnaker.front50.model.ItemDAO
+
+interface SnapshotDAO extends ItemDAO<Snapshot> {
+    Collection<Snapshot> getHistory(String id, int limit)
+}

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -146,4 +146,12 @@ public class GcsConfig {
                                  Schedulers.from(Executors.newFixedThreadPool(5)),
                                  PIPELINE_REFRESH_MS);
   }
+
+  @Bean
+  public SnapshotBucketDAO snapshotBucketDAO(GcsStorageService service) {
+    return new SnapshotBucketDAO(rootFolder,
+                                                 service,
+                                                 Schedulers.from(Executors.newFixedThreadPool(5)),
+                                                 PIPELINE_REFRESH_MS);
+  }
 }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/SnapshotBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/SnapshotBucketDAO.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.netflix.spinnaker.front50.model.snapshot.Snapshot;
+import com.netflix.spinnaker.front50.model.snapshot.SnapshotDAO;
+import org.springframework.util.Assert;
+import rx.Scheduler;
+
+import java.util.Collection;
+
+public class SnapshotBucketDAO extends BucketDAO<Snapshot> implements SnapshotDAO {
+
+    public SnapshotBucketDAO(String basePath,
+                             StorageService service,
+                             Scheduler scheduler,
+                             int refreshIntervalMs) {
+        super(Snapshot.class, "snapshots",
+                basePath, service, scheduler, refreshIntervalMs);
+    }
+
+    @Override
+    public Collection<Snapshot> getHistory(String id, int maxResults) {
+        return allVersionsOf(id, maxResults);
+    }
+
+    @Override
+    public Snapshot create(String id, Snapshot item) {
+        Assert.notNull(item.getApplication(), "application field must NOT be null!");
+        Assert.notNull(item.getAccount(), "account field must NOT be null!");
+        if (id == null) {
+            id = item.getApplication() + "-" + item.getAccount();
+        }
+        item.setId(id);
+        item.setTimestamp(System.currentTimeMillis());
+
+        super.update(id, item);
+        return findById(id);
+    }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -121,4 +121,9 @@ public class S3Config {
   public S3PipelineDAO s3PipelineDAO(ObjectMapper objectMapper, AmazonS3 amazonS3) {
     return new S3PipelineDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(25)), 10000, bucket, rootFolder);
   }
+
+  @Bean
+  public S3SnapshotDAO s3SnapshotDAO(ObjectMapper objectMapper, AmazonS3 amazonS3) {
+    return new S3SnapshotDAO(objectMapper, amazonS3, Schedulers.from(Executors.newFixedThreadPool(5)), 10000, bucket, rootFolder);
+  }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3SnapshotDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3SnapshotDAO.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.model.snapshot.Snapshot;
+import com.netflix.spinnaker.front50.model.snapshot.SnapshotDAO;
+import org.springframework.util.Assert;
+import rx.Scheduler;
+
+import java.util.Collection;
+
+public class S3SnapshotDAO extends S3Support<Snapshot> implements SnapshotDAO {
+
+    public S3SnapshotDAO(ObjectMapper objectMapper,
+                         AmazonS3 amazonS3,
+                         Scheduler scheduler,
+                         int refreshIntervalMs,
+                         String bucket,
+                         String rootFolder) {
+        super(objectMapper, amazonS3, scheduler, refreshIntervalMs, bucket, (rootFolder + "/snapshots/").replaceAll("//", "/"));
+    }
+
+    @Override
+    public Collection<Snapshot> getHistory(String id, int maxResults) {
+        return allVersionsOf(id, maxResults);
+    }
+
+
+    @Override
+    public void update(String id, Snapshot item) {
+        if (item.getId() == null) {
+            item.setId(id);
+        }
+        item.setTimestamp(System.currentTimeMillis());
+        super.update(id, item);
+    }
+
+    @Override
+    public Snapshot create(String id, Snapshot item) {
+        Assert.notNull(item.getApplication(), "application field must NOT be null!");
+        Assert.notNull(item.getAccount(), "account field must NOT be null!");
+        if (id == null) {
+            id = item.getApplication() + "-" + item.getAccount();
+        }
+        item.setId(id);
+        item.setTimestamp(System.currentTimeMillis());
+
+        super.update(id, item);
+        return findById(id);
+    }
+
+    @Override
+    public String getMetadataFilename() {
+        return "snapshot.json";
+    }
+
+    @Override
+    Class<Snapshot> getSerializedClass() {
+        return Snapshot.class;
+    }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/SnapshotsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/SnapshotsController.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.netflix.spinnaker.front50.model.snapshot.Snapshot
+import com.netflix.spinnaker.front50.model.snapshot.SnapshotDAO
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
+
+@RestController
+@RequestMapping("/snapshots")
+@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false}')
+class SnapshotsController {
+
+    @Autowired
+    SnapshotDAO snapshotDAO
+
+    @RequestMapping(value = "/{id:.+}/history", method = RequestMethod.GET)
+    Collection<Snapshot> getHistory(@PathVariable String id,
+                                    @RequestParam(value = "limit", defaultValue = "10") int limit) {
+        return snapshotDAO.getHistory(id, limit)
+    }
+
+    @RequestMapping(value = "/{id:.+}", method = RequestMethod.GET)
+    Snapshot getCurrent(@PathVariable String id) {
+        return snapshotDAO.findById(id)
+    }
+
+    @RequestMapping(value = "", method = RequestMethod.POST)
+    void save(@RequestBody Snapshot snapshot) {
+        if (!snapshot.application || !snapshot.account) {
+            throw new InvalidSnapshotDefinition()
+        }
+        String id = "$snapshot.application-$snapshot.account"
+        snapshotDAO.create(id, snapshot)
+    }
+
+    @ExceptionHandler(InvalidSnapshotDefinition)
+    @ResponseStatus(UNPROCESSABLE_ENTITY)
+    Map handleInvalidSnapshotDefinition() {
+        return [error: "A snapshot requires application and account fields", status: UNPROCESSABLE_ENTITY]
+    }
+
+    static class InvalidSnapshotDefinition extends Exception {}
+}


### PR DESCRIPTION
Added an infrastructure definition model and DAO for saving the state of the infrastructure. Created a controller endpoint for saving infrastructure to a gcs bucket and querying for previous versions. To test, gcs must be enabled in front50.yml with the necessary fields populated for finding a bucket. PTAL @lwander @duftler 