### PR TITLE
clean up projects when deleting an application

### DIFF
--- a/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/project/CassandraProjectDAO.groovy
+++ b/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/project/CassandraProjectDAO.groovy
@@ -103,6 +103,7 @@ class CassandraProjectDAO implements ProjectDAO {
     return findBy("id", id)
   }
 
+  @Override
   Set<Project> all() {
     return unmarshallResults(runQuery('SELECT * FROM project;'))
   }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/ProjectDAO.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/ProjectDAO.groovy
@@ -22,5 +22,6 @@ import com.netflix.spinnaker.front50.model.ItemDAO
 
 interface ProjectDAO extends ItemDAO<Project> {
   Project findByName(String name) throws NotFoundException
+  Collection<Project> all()
   void truncate()
 }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ProjectBucketDAO.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/ProjectBucketDAO.java
@@ -36,7 +36,7 @@ public class ProjectBucketDAO extends BucketDAO<Project> implements ProjectDAO {
 
     @Override
     public Project findByName(String name) throws NotFoundException {
-        return fetchAllItems(allItemsCache.get())
+        return all()
                 .stream()
                 .filter(project -> project.getName().equalsIgnoreCase(name))
                 .findFirst()
@@ -52,6 +52,11 @@ public class ProjectBucketDAO extends BucketDAO<Project> implements ProjectDAO {
 
         update(id, item);
         return findById(id);
+    }
+
+    @Override
+    public Collection<Project> all() {
+        return fetchAllItems(allItemsCache.get());
     }
 
     @Override

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3ProjectDAO.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3ProjectDAO.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.front50.model;
 
-import com.amazonaws.services.cloudtrail.model.UnsupportedOperationException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
@@ -24,7 +23,7 @@ import com.netflix.spinnaker.front50.model.project.Project;
 import com.netflix.spinnaker.front50.model.project.ProjectDAO;
 import rx.Scheduler;
 
-import java.util.*;
+import java.util.UUID;
 
 public class S3ProjectDAO extends S3Support<Project> implements ProjectDAO {
   public S3ProjectDAO(ObjectMapper objectMapper,

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsController.groovy
@@ -21,7 +21,11 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.front50.events.ApplicationEventListener
 import com.netflix.spinnaker.front50.model.application.Application
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO
+import com.netflix.spinnaker.front50.model.notification.NotificationDAO
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
+import com.netflix.spinnaker.front50.model.project.ProjectDAO
 import com.netflix.spinnaker.front50.validator.ApplicationValidator
 import groovy.util.logging.Slf4j
 import io.swagger.annotations.Api
@@ -46,6 +50,18 @@ public class ApplicationsController {
 
   @Autowired
   ApplicationDAO applicationDAO
+
+  @Autowired
+  ProjectDAO projectDAO
+
+  @Autowired
+  NotificationDAO notificationDAO
+
+  @Autowired
+  PipelineDAO pipelineDAO
+
+  @Autowired
+  PipelineStrategyDAO pipelineStrategyDAO
 
   @Autowired
   List<ApplicationValidator> applicationValidators
@@ -128,6 +144,10 @@ public class ApplicationsController {
   private Application getApplication() {
     return new Application(
         dao: applicationDAO,
+        projectDao: projectDAO,
+        notificationDao: notificationDAO,
+        pipelineDao: pipelineDAO,
+        pipelineStrategyDao: pipelineStrategyDAO,
         validators: applicationValidators,
         applicationEventListeners: applicationEventListeners
     )

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsControllerTck.groovy
@@ -26,6 +26,10 @@ import com.netflix.spinnaker.front50.model.S3ApplicationDAO
 import com.netflix.spinnaker.front50.model.application.Application
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import com.netflix.spinnaker.front50.model.application.CassandraApplicationDAO
+import com.netflix.spinnaker.front50.model.notification.NotificationDAO
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
+import com.netflix.spinnaker.front50.model.project.ProjectDAO
 import com.netflix.spinnaker.front50.utils.CassandraTestHelper
 import com.netflix.spinnaker.front50.utils.S3TestHelper
 import com.netflix.spinnaker.front50.validator.HasEmailValidator
@@ -59,10 +63,26 @@ abstract class ApplicationsControllerTck extends Specification {
   @Subject
   ApplicationDAO dao
 
+  @Shared
+  ProjectDAO projectDAO = Stub(ProjectDAO)
+
+  @Shared
+  NotificationDAO notificationDAO = Stub(NotificationDAO)
+
+  @Shared
+  PipelineDAO pipelineDAO = Stub(PipelineDAO)
+
+  @Shared
+  PipelineStrategyDAO pipelineStrategyDAO = Stub(PipelineStrategyDAO)
+
   void setup() {
     this.dao = createApplicationDAO()
     this.controller = new ApplicationsController(
         applicationDAO: dao,
+        projectDAO: projectDAO,
+        notificationDAO: notificationDAO,
+        pipelineStrategyDAO: pipelineStrategyDAO,
+        pipelineDAO: pipelineDAO,
         applicationValidators: [new HasNameValidator(), new HasEmailValidator()],
         messageSource: new StaticMessageSource()
     )


### PR DESCRIPTION
@ajordens alternative I could see was to implement this as an `ApplicationEventListener`, but we'd have to include the `projectDAO` as one of the properties in the copy of the `Application` object.

Also not sure if we should be deleting the project, although it's probably a safe bet, since someone has explicitly gone in and deleted every application in the project at that point.