### PR TITLE
provider/core: Snapshot infrastructure saved as map rather than string

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/Snapshot.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/Snapshot.groovy
@@ -35,7 +35,7 @@ class Snapshot implements Timestamped {
   String account
 
   // Describes the resources deployed in the cloud of the application and account
-  String infrastructure
+  Map infrastructure
 
   // Resources are described using this config language, used for deserialization
   Type configLang


### PR DESCRIPTION
I changed infrastructure to be saved as a map rather than a string. This makes it easier to parse the infrastructure into proper format for the diff view in deck. @lwander @danielpeach 