### PR TITLE
Changes getByName getter to return 404s if the app (NB: it's permissi…

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ApplicationsController.groovy
@@ -34,6 +34,7 @@ import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.Errors
@@ -119,7 +120,9 @@ public class ApplicationsController {
     response.setStatus(HttpStatus.ACCEPTED.value())
   }
 
-  @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
+  // This method uses @PostAuthorize in order to throw 404s if the application doesn't exist,
+  // vs. 403s if the app exists, but the user doesn't have access to it.
+  @PostAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
   @ApiOperation(value = "", notes = "Fetch a single application by name within a specific `account`")
   @RequestMapping(method = RequestMethod.GET, value = "/name/{application:.+}")
   Application getByName(@PathVariable final String application) {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -18,6 +18,7 @@ import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.Errors
@@ -103,7 +104,9 @@ public class ApplicationsController {
     return app
   }
 
-  @PreAuthorize("hasPermission(#applicationName, 'APPLICATION', 'READ')")
+  // This method uses @PostAuthorize in order to throw 404s if the application doesn't exist,
+  // vs. 403s if the app exists, but the user doesn't have access to it.
+  @PostAuthorize("hasPermission(#applicationName, 'APPLICATION', 'READ')")
   @ApiOperation(value = "", notes = "Fetch a single application by name")
   @RequestMapping(method = RequestMethod.GET, value = "/{applicationName}")
   Application get(@PathVariable final String applicationName) {


### PR DESCRIPTION
…on) is not found, as opposed to 403s when the app's permission doesn't exist.

This is necessary because Orca's UpsertApplicationTask first queries for the existence of an application (using the getByName() method) before invoking either the update() or create() endpoints on Front50.

tag: https://github.com/spinnaker/fiat/issues/51

@duftler @jtk54 PTAL