### PR TITLE
Enable configuration values for Redis host and port

### DIFF
--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisConfig.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisConfig.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.front50.model.project.Project
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
@@ -31,6 +32,12 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 @Configuration
 @ConditionalOnExpression('${spinnaker.redis.enabled:false}')
 class RedisConfig {
+
+  @Value('${spinnaker.redis.host:localhost}')
+  private String host;
+
+  @Value('${spinnaker.redis.port:6379}')
+  private Integer port;
 
   @Bean
   RedisApplicationDAO redisApplicationDAO(RedisTemplate<String, Application> template) {
@@ -59,7 +66,11 @@ class RedisConfig {
 
   @Bean
   RedisConnectionFactory jedisConnectionFactory() {
-    new JedisConnectionFactory()
+    JedisConnectionFactory factory = new JedisConnectionFactory()
+    factory.setHostName(host)
+    factory.setPort(port)
+
+    factory
   }
 
   @Bean

--- a/front50-web/config/front50.yml
+++ b/front50-web/config/front50.yml
@@ -13,6 +13,8 @@ spinnaker:
     name: default
   redis:
     enabled: false
+    host: localhost
+    port: 6379
 
 swagger:
   enabled: true


### PR DESCRIPTION
The Redis backend defaulted to localhost:6379. This PR enables specifying an arbitrary Redis host/port.