### PR TITLE
Cleaning out unused rename endpoint for pipeline & strategy

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -104,17 +104,7 @@ class PipelineController {
     pipelineDAO.delete(id)
   }
 
-  @PreAuthorize("hasPermission(#command.application, 'APPLICATION', 'WRITE')")
-  @RequestMapping(value = 'move', method = RequestMethod.POST)
-  void rename(@RequestBody RenameCommand command) {
-    checkForDuplicatePipeline(command.application, command.to)
-    def pipelineId = pipelineDAO.getPipelineId(command.application, command.from)
-    def pipeline = pipelineDAO.findById(pipelineId)
-    pipeline.setName(command.to)
-
-    pipelineDAO.update(pipelineId, pipeline)
-  }
-
+  @PreAuthorize("hasPermission(#pipeline.application, 'APPLICATION', 'WRITE')")
   @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
   Pipeline update(@PathVariable String id, @RequestBody Pipeline pipeline) {
     Pipeline existingPipeline = pipelineDAO.findById(id)
@@ -130,12 +120,6 @@ class PipelineController {
     pipeline.updateTs = System.currentTimeMillis()
     pipelineDAO.update(id, pipeline)
     return pipeline
-  }
-
-  static class RenameCommand {
-    String application
-    String from
-    String to
   }
 
   private void checkForDuplicatePipeline(String application, String name) {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/StrategyController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/StrategyController.groovy
@@ -22,7 +22,6 @@ import groovy.transform.InheritConstructors
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
-import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -97,6 +96,7 @@ class StrategyController {
         pipelineStrategyDAO.delete(id)
     }
 
+    @PreAuthorize("hasPermission(#strategy.application, 'APPLICATION', 'WRITE')")
     @RequestMapping(value = "/{id}", method = RequestMethod.PUT)
     Pipeline update(@PathVariable String id, @RequestBody Pipeline strategy) {
       Pipeline existingStrategy = pipelineStrategyDAO.findById(id)
@@ -112,17 +112,6 @@ class StrategyController {
       strategy.updateTs = System.currentTimeMillis()
       pipelineStrategyDAO.update(id, strategy)
       return strategy
-    }
-
-    @PreAuthorize("hasPermission(#command.application, 'APPLICATION', 'WRITE')")
-    @RequestMapping(value = 'move', method = RequestMethod.POST)
-    void rename(@RequestBody RenameCommand command) {
-        checkForDuplicatePipeline(command.application, command.to)
-        def pipelineId = pipelineStrategyDAO.getPipelineId(command.application, command.from)
-        def pipeline = pipelineStrategyDAO.findById(pipelineId)
-        pipeline.setName(command.to)
-
-        pipelineStrategyDAO.update(pipelineId, pipeline)
     }
 
     private void checkForDuplicatePipeline(String application, String name) {
@@ -154,10 +143,4 @@ class StrategyController {
 
     @InheritConstructors
     static class DuplicateStrategyException extends RuntimeException {}
-
-    static class RenameCommand {
-        String application
-        String from
-        String to
-    }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -76,25 +76,6 @@ abstract class PipelineControllerTck extends Specification {
     response.status == UNPROCESSABLE_ENTITY
   }
 
-  void 'return 200 for successful rename'() {
-    given:
-    def pipeline = pipelineDAO.create(null, new Pipeline([name: "old-pipeline-name", application: "test"]))
-    def command = [
-        application: 'test',
-        from       : 'old-pipeline-name',
-        to         : 'new-pipeline-name'
-    ]
-
-    when:
-    def response = mockMvc.perform(post('/pipelines/move').
-        contentType(MediaType.APPLICATION_JSON).content(new ObjectMapper().writeValueAsString(command)))
-        .andReturn().response
-
-    then:
-    response.status == OK
-    pipelineDAO.findById(pipeline.getId()).getName() == "new-pipeline-name"
-  }
-
   void 'should update a pipeline'() {
     given:
     def pipeline = pipelineDAO.create(null, new Pipeline([name: "test pipeline", application: "test_application"]))
@@ -220,26 +201,6 @@ abstract class PipelineControllerTck extends Specification {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(new ObjectMapper().writeValueAsString([name: "pipeline1", application: "test"])))
                   .andReturn().response
-
-    then:
-    response.status == BAD_REQUEST
-    response.contentAsString == '{"error":"A pipeline with name pipeline1 already exists in application test","status":"BAD_REQUEST"}'
-  }
-
-  void 'should enforce unique names on rename operations'() {
-    given:
-    pipelineDAO.create(null, new Pipeline([
-            name: "pipeline1", application: "test"
-    ]))
-    pipelineDAO.create(null, new Pipeline([
-            name: "pipeline2", application: "test"
-    ]))
-
-    when:
-    def response = mockMvc.perform(post('/pipelines/move')
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(new ObjectMapper().writeValueAsString([from: "pipeline2", to: "pipeline1", application: "test"])))
-            .andReturn().response
 
     then:
     response.status == BAD_REQUEST

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
@@ -64,25 +64,6 @@ abstract class StrategyControllerTck extends Specification {
 
   abstract PipelineStrategyDAO createPipelineStrategyDAO()
 
-  void 'return 200 for successful rename'() {
-    given:
-    def pipeline = pipelineStrategyDAO.create(null, new Pipeline([name: "old-pipeline-name", application: "test"]))
-    def command = [
-        application: 'test',
-        from       : 'old-pipeline-name',
-        to         : 'new-pipeline-name'
-    ]
-
-    when:
-    def response = mockMvc.perform(post('/strategies/move').
-        contentType(MediaType.APPLICATION_JSON).content(new ObjectMapper().writeValueAsString(command)))
-        .andReturn().response
-
-    then:
-    response.status == OK
-    pipelineStrategyDAO.findById(pipeline.getId()).getName() == "new-pipeline-name"
-  }
-
   @Unroll
   void 'should only (re)generate cron trigger ids for new pipelines'() {
     given:
@@ -207,26 +188,6 @@ abstract class StrategyControllerTck extends Specification {
     def response = mockMvc.perform(post('/strategies')
             .contentType(MediaType.APPLICATION_JSON)
             .content(new ObjectMapper().writeValueAsString([name: "pipeline1", application: "test"])))
-            .andReturn().response
-
-    then:
-    response.status == BAD_REQUEST
-    response.contentAsString == '{"error":"A strategy with name pipeline1 already exists in application test","status":"BAD_REQUEST"}'
-  }
-
-  void 'should enforce unique names on rename operations'() {
-    given:
-    pipelineStrategyDAO.create(null, new Pipeline([
-            name: "pipeline1", application: "test"
-    ]))
-    pipelineStrategyDAO.create(null, new Pipeline([
-            name: "pipeline2", application: "test"
-    ]))
-
-    when:
-    def response = mockMvc.perform(post('/strategies/move')
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(new ObjectMapper().writeValueAsString([from: "pipeline2", to: "pipeline1", application: "test"])))
             .andReturn().response
 
     then:


### PR DESCRIPTION
- Removed `move` endpoint for pipeline/strategy rename in favor of the update endpoint
- spring security annotated the update endpoint for good measure