### PR TITLE
AuthorizationSupport conditional on FiatPermissionEvaluator

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/AuthorizationSupport.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/AuthorizationSupport.groovy
@@ -19,12 +19,14 @@ package com.netflix.spinnaker.front50.controllers
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
 import org.springframework.stereotype.Component
 
 @Component
+@ConditionalOnBean(FiatPermissionEvaluator)
 class AuthorizationSupport {
 
   @Autowired


### PR DESCRIPTION
in the case where `fiat.autoConfigure = false` the `FiatPermissionEvaluator` bean is not present and this component causes startup errors