### PR TITLE
fix health indicators for ItemDAOs

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.application;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -28,8 +29,9 @@ import java.util.Map;
 public class DefaultApplicationDAO extends StorageServiceSupport<Application> implements ApplicationDAO {
   public DefaultApplicationDAO(StorageService service,
                                Scheduler scheduler,
-                               int refreshIntervalMs) {
-    super(ObjectType.APPLICATION, service, scheduler, refreshIntervalMs);
+                               int refreshIntervalMs,
+                               Registry registry) {
+    super(ObjectType.APPLICATION, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.application;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -24,8 +25,9 @@ import rx.Scheduler;
 public class DefaultApplicationPermissionDAO extends StorageServiceSupport<Application.Permission> implements ApplicationPermissionDAO {
   public DefaultApplicationPermissionDAO(StorageService service,
                                          Scheduler scheduler,
-                                         int refreshIntervalMs) {
-    super(ObjectType.APPLICATION_PERMISSION, service, scheduler, refreshIntervalMs);
+                                         int refreshIntervalMs,
+                                         Registry registry) {
+    super(ObjectType.APPLICATION_PERMISSION, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/notification/DefaultNotificationDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/notification/DefaultNotificationDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.notification;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -25,8 +26,9 @@ import rx.Scheduler;
 public class DefaultNotificationDAO extends StorageServiceSupport<Notification> implements NotificationDAO {
   public DefaultNotificationDAO(StorageService service,
                                 Scheduler scheduler,
-                                int refreshIntervalMs) {
-    super(ObjectType.NOTIFICATION, service, scheduler, refreshIntervalMs);
+                                int refreshIntervalMs,
+                                Registry registry) {
+    super(ObjectType.NOTIFICATION, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.pipeline;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -30,8 +31,9 @@ import java.util.stream.Collectors;
 public class DefaultPipelineDAO extends StorageServiceSupport<Pipeline> implements PipelineDAO {
   public DefaultPipelineDAO(StorageService service,
                             Scheduler scheduler,
-                            int refreshIntervalMs) {
-    super(ObjectType.PIPELINE, service, scheduler, refreshIntervalMs);
+                            int refreshIntervalMs,
+                            Registry registry) {
+    super(ObjectType.PIPELINE, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.pipeline;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -28,9 +29,10 @@ import java.util.stream.Collectors;
 
 public class DefaultPipelineStrategyDAO extends StorageServiceSupport<Pipeline> implements PipelineStrategyDAO {
   public DefaultPipelineStrategyDAO(StorageService service,
-                            Scheduler scheduler,
-                            int refreshIntervalMs) {
-    super(ObjectType.STRATEGY, service, scheduler, refreshIntervalMs);
+                                    Scheduler scheduler,
+                                    int refreshIntervalMs,
+                                    Registry registry) {
+    super(ObjectType.STRATEGY, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.project;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -26,9 +27,10 @@ import java.util.UUID;
 
 public class DefaultProjectDAO extends StorageServiceSupport<Project> implements ProjectDAO {
   public DefaultProjectDAO(StorageService service,
-                                Scheduler scheduler,
-                                int refreshIntervalMs) {
-    super(ObjectType.PROJECT, service, scheduler, refreshIntervalMs);
+                           Scheduler scheduler,
+                           int refreshIntervalMs,
+                           Registry registry) {
+    super(ObjectType.PROJECT, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.serviceaccount;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -23,9 +24,10 @@ import rx.Scheduler;
 
 public class DefaultServiceAccountDAO extends StorageServiceSupport<ServiceAccount> implements ServiceAccountDAO {
   public DefaultServiceAccountDAO(StorageService service,
-                                Scheduler scheduler,
-                                int refreshIntervalMs) {
-    super(ObjectType.SERVICE_ACCOUNT, service, scheduler, refreshIntervalMs);
+                                  Scheduler scheduler,
+                                  int refreshIntervalMs,
+                                  Registry registry) {
+    super(ObjectType.SERVICE_ACCOUNT, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.snapshot;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -27,8 +28,9 @@ import java.util.Collection;
 public class DefaultSnapshotDAO extends StorageServiceSupport<Snapshot> implements SnapshotDAO {
   public DefaultSnapshotDAO(StorageService service,
                             Scheduler scheduler,
-                            int refreshIntervalMs) {
-    super(ObjectType.SNAPSHOT, service, scheduler, refreshIntervalMs);
+                            int refreshIntervalMs,
+                            Registry registry) {
+    super(ObjectType.SNAPSHOT, service, scheduler, refreshIntervalMs, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.front50.model.tag;
 
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -27,9 +29,9 @@ import java.util.Objects;
 
 public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags> implements EntityTagsDAO {
   public DefaultEntityTagsDAO(StorageService service,
-                            Scheduler scheduler,
-                            int refreshIntervalMs) {
-    super(ObjectType.ENTITY_TAGS, service, scheduler, refreshIntervalMs);
+                              Scheduler scheduler,
+                              int refreshIntervalMs) {
+    super(ObjectType.ENTITY_TAGS, service, scheduler, refreshIntervalMs, new NoopRegistry());
   }
 
   @Override
@@ -57,5 +59,10 @@ public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags> impl
   @Override
   protected void refresh() {
     // avoid loading all tagged entities into memory
+  }
+
+  @Override
+  public boolean isHealthy() {
+    return true;
   }
 }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.config;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.*;
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
@@ -91,43 +92,43 @@ public class GcsConfig {
   }
 
   @Bean
-  public ApplicationDAO applicationDAO(GcsStorageService service) {
-    return new DefaultApplicationDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), APPLICATION_REFRESH_MS);
+  public ApplicationDAO applicationDAO(GcsStorageService service, Registry registry) {
+    return new DefaultApplicationDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), APPLICATION_REFRESH_MS, registry);
   }
 
   @Bean
-  public ApplicationPermissionDAO applicationPermissionDAO(GcsProperties gcsProperties) {
+  public ApplicationPermissionDAO applicationPermissionDAO(GcsProperties gcsProperties, Registry registry) {
     GcsStorageService service = googleCloudStorageService(ApplicationPermissionDAO.DEFAULT_DATA_FILENAME, gcsProperties);
-    return new DefaultApplicationPermissionDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), APPLICATION_REFRESH_MS);
+    return new DefaultApplicationPermissionDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), APPLICATION_REFRESH_MS, registry);
   }
 
   @Bean
-  public ServiceAccountDAO serviceAccountDAO(GcsStorageService service) {
-    return new DefaultServiceAccountDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), SERVICE_ACCOUNT_REFRESH_MS);
+  public ServiceAccountDAO serviceAccountDAO(GcsStorageService service, Registry registry) {
+    return new DefaultServiceAccountDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), SERVICE_ACCOUNT_REFRESH_MS, registry);
   }
 
   @Bean
-  public ProjectDAO projectDAO(GcsStorageService service) {
-    return new DefaultProjectDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PROJECT_REFRESH_MS);
+  public ProjectDAO projectDAO(GcsStorageService service, Registry registry) {
+    return new DefaultProjectDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PROJECT_REFRESH_MS, registry);
   }
 
   @Bean
-  public NotificationDAO notificationDAO(GcsStorageService service) {
-    return new DefaultNotificationDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), NOTIFICATION_REFRESH_MS);
+  public NotificationDAO notificationDAO(GcsStorageService service, Registry registry) {
+    return new DefaultNotificationDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), NOTIFICATION_REFRESH_MS, registry);
   }
 
   @Bean
-  public PipelineStrategyDAO pipelineStrategyDAO(GcsStorageService service) {
-    return new DefaultPipelineStrategyDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PIPELINE_STRATEGY_REFRESH_MS);
+  public PipelineStrategyDAO pipelineStrategyDAO(GcsStorageService service, Registry registry) {
+    return new DefaultPipelineStrategyDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PIPELINE_STRATEGY_REFRESH_MS, registry);
   }
 
   @Bean
-  public PipelineDAO pipelineDAO(GcsStorageService service) {
-    return new DefaultPipelineDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PIPELINE_REFRESH_MS);
+  public PipelineDAO pipelineDAO(GcsStorageService service, Registry registry) {
+    return new DefaultPipelineDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PIPELINE_REFRESH_MS, registry);
   }
 
   @Bean
-  public SnapshotDAO snapshotDAO(GcsStorageService service) {
-    return new DefaultSnapshotDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PIPELINE_REFRESH_MS);
+  public SnapshotDAO snapshotDAO(GcsStorageService service, Registry registry) {
+    return new DefaultSnapshotDAO(service, Schedulers.from(Executors.newFixedThreadPool(20)), PIPELINE_REFRESH_MS, registry);
   }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.aws.bastion.BastionConfig;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.front50.model.S3StorageService;
@@ -92,43 +93,43 @@ public class S3Config {
   }
 
   @Bean
-  public ApplicationDAO applicationDAO(StorageService storageService) {
-    return new DefaultApplicationDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 15000);
+  public ApplicationDAO applicationDAO(StorageService storageService, Registry registry) {
+    return new DefaultApplicationDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 15000, registry);
   }
 
   @Bean
-  public ApplicationPermissionDAO applicationPermissionDAO(StorageService storageService) {
-    return new DefaultApplicationPermissionDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 45000);
+  public ApplicationPermissionDAO applicationPermissionDAO(StorageService storageService, Registry registry) {
+    return new DefaultApplicationPermissionDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 45000, registry);
   }
 
   @Bean
-  public ServiceAccountDAO serviceAccountDAO(StorageService storageService) {
-    return new DefaultServiceAccountDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 30000);
+  public ServiceAccountDAO serviceAccountDAO(StorageService storageService, Registry registry) {
+    return new DefaultServiceAccountDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 30000, registry);
   }
 
   @Bean
-  public ProjectDAO projectDAO(StorageService storageService) {
-    return new DefaultProjectDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 30000);
+  public ProjectDAO projectDAO(StorageService storageService, Registry registry) {
+    return new DefaultProjectDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 30000, registry);
   }
 
   @Bean
-  public NotificationDAO notificationDAO(StorageService storageService) {
-    return new DefaultNotificationDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 30000);
+  public NotificationDAO notificationDAO(StorageService storageService, Registry registry) {
+    return new DefaultNotificationDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 30000, registry);
   }
 
   @Bean
-  public PipelineStrategyDAO pipelineStrategyDAO(StorageService storageService) {
-    return new DefaultPipelineStrategyDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 20000);
+  public PipelineStrategyDAO pipelineStrategyDAO(StorageService storageService, Registry registry) {
+    return new DefaultPipelineStrategyDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 20000, registry);
   }
 
   @Bean
-  public PipelineDAO pipelineDAO(StorageService storageService) {
-    return new DefaultPipelineDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(25)), 10000);
+  public PipelineDAO pipelineDAO(StorageService storageService, Registry registry) {
+    return new DefaultPipelineDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(25)), 10000, registry);
   }
 
   @Bean
-  public SnapshotDAO snapshotDAO(StorageService storageService) {
-    return new DefaultSnapshotDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 60000);
+  public SnapshotDAO snapshotDAO(StorageService storageService, Registry registry) {
+    return new DefaultSnapshotDAO(storageService, Schedulers.from(Executors.newFixedThreadPool(20)), 60000, registry);
   }
 
   @Bean

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.front50.controllers
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.s3.AmazonS3Client
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.model.S3StorageService
 import com.netflix.spinnaker.front50.model.notification.DefaultNotificationDAO
 import com.netflix.spinnaker.front50.model.notification.HierarchicalLevel
@@ -198,7 +199,7 @@ class S3NotificationControllerTck extends NotificationControllerTck {
     S3TestHelper.setupBucket(amazonS3, "front50")
 
     def storageService = new S3StorageService(new ObjectMapper(), amazonS3, "front50", "test")
-    notificationDAO = new DefaultNotificationDAO(storageService, scheduler, 0)
+    notificationDAO = new DefaultNotificationDAO(storageService, scheduler, 0, new NoopRegistry())
 
     return notificationDAO
   }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.controllers
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.model.S3StorageService
 import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineDAO
 
@@ -241,7 +242,7 @@ class S3PipelineControllerTck extends PipelineControllerTck {
     S3TestHelper.setupBucket(amazonS3, "front50")
 
     def storageService = new S3StorageService(new ObjectMapper(), amazonS3, "front50", "test")
-    pipelineDAO = new DefaultPipelineDAO(storageService, scheduler, 0)
+    pipelineDAO = new DefaultPipelineDAO(storageService, scheduler, 0, new NoopRegistry())
 
     return pipelineDAO
   }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.front50.controllers
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.s3.AmazonS3Client
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.model.S3StorageService
 import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineStrategyDAO
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline
@@ -229,7 +230,7 @@ class S3StrategyControllerTck extends StrategyControllerTck {
     S3TestHelper.setupBucket(amazonS3, "front50")
 
     def storageService = new S3StorageService(new ObjectMapper(), amazonS3, "front50", "test")
-    pipelineStrategyDAO = new DefaultPipelineStrategyDAO(storageService, scheduler, 0)
+    pipelineStrategyDAO = new DefaultPipelineStrategyDAO(storageService, scheduler, 0, new NoopRegistry())
 
     return pipelineStrategyDAO
   }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsControllerTck.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.front50.controllers.v2
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.s3.AmazonS3Client
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.config.CassandraConfigProps
 import com.netflix.spinnaker.front50.exception.NotFoundException
 import com.netflix.spinnaker.front50.model.S3StorageService
@@ -396,7 +397,7 @@ class S3ApplicationsControllerTck extends ApplicationsControllerTck {
     S3TestHelper.setupBucket(amazonS3, "front50")
 
     def storageService = new S3StorageService(new ObjectMapper(), amazonS3, "front50", "test", false)
-    applicationDAO = new DefaultApplicationDAO(storageService, scheduler, 0)
+    applicationDAO = new DefaultApplicationDAO(storageService, scheduler, 0, new NoopRegistry())
     return applicationDAO
   }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.front50.controllers.v2
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.s3.AmazonS3Client
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.config.CassandraConfigProps
 import com.netflix.spinnaker.front50.exception.NotFoundException
 import com.netflix.spinnaker.front50.model.S3StorageService
@@ -235,7 +236,7 @@ class S3ProjectsControllerTck extends ProjectsControllerTck {
     S3TestHelper.setupBucket(amazonS3, "front50")
 
     def storageService = new S3StorageService(new ObjectMapper(), amazonS3, "front50", "test")
-    projectDAO = new DefaultProjectDAO(storageService, scheduler, 0)
+    projectDAO = new DefaultProjectDAO(storageService, scheduler, 0, new NoopRegistry())
 
     return projectDAO
   }


### PR DESCRIPTION
increased health check timeout to 90s and fail if a poll interval larger than that is requested
instrumented StorageServiceSupport to add
`storageServiceSupport.cacheAge` gauge
`storageServiceSupport.cacheRefreshTime` timer
