### PR TITLE
Refined metrics around cache maintainence.

### DIFF
--- a/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/GoogleStorageServiceSpec.groovy
+++ b/front50-gcs/src/test/groovy/com/netflix/spinnaker/front50/model/GoogleStorageServiceSpec.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.front50.model
 import com.netflix.spinnaker.front50.model.application.Application;
 
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.DefaultRegistry;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.HttpHeaders
 import com.google.api.client.util.DateTime;
@@ -29,6 +31,9 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class GoogleStorageServiceSpec extends Specification {
+
+  @Shared
+  Registry registry = new DefaultRegistry()
 
   @Shared
   String BUCKET_NAME = "TestBucket"
@@ -47,7 +52,7 @@ class GoogleStorageServiceSpec extends Specification {
   GcsStorageService gcs
 
   GcsStorageService makeGcs() {
-    return new GcsStorageService(BUCKET_NAME, BUCKET_LOCATION, BASE_PATH, PROJECT_NAME, mockStorage)
+    return new GcsStorageService(BUCKET_NAME, BUCKET_LOCATION, BASE_PATH, PROJECT_NAME, mockStorage, registry)
   }
 
   def "ensureBucketExists make bucket"() {


### PR DESCRIPTION
@cfieber 

I added more instrumentation around front50 cache management because it is a sensitivity point for performance and critical point for the accumulation of knowledge.

I am double counting refreshes only because it is easier that way. All refreshes use your original timer (I changed the implementation a little to be consistent with the others but am happy to change it back. Originally I made the change because I wasnt seeing the objectType breakout but that turned out to be a different issue. In simplifying that, the recorded time is going to be slightly less accurate because it includes updating the atomic reference. However given the latency of network calls and insignificant critical section on that lock, the difference is going to be negligable.

The second set of counts distinguishes scheduled refreshes vs spontaneous refreshes.
The double counting is because the refresh() API is public so it needs to be there anyway unless I start adding new methods. The public ones, if you cared for some reason, would be (total - scheduled - auto)

I also added counters on individual changes to see the rates of changes of resources themselves. I think this might be useful for a variety of reasons. I assume it is ok to do and will not cause contention interfering with the parallel stream processing.

Finally, I added some GCS metrics because our client library doesnt provide any.