### PR TITLE
include tagsMetadata in EntityTags object

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/EntityTags.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/EntityTags.groovy
@@ -30,6 +30,7 @@ class EntityTags implements Timestamped {
   String lastModifiedBy
 
   Map<String, Object> tags = [:]
+  Map<String, Object> tagsMetadata = [:]
   EntityRef entityRef
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -41,12 +42,12 @@ class EntityTags implements Timestamped {
 
     @JsonAnyGetter
      Map<String,Object> attributes() {
-      return attributes;
+      return attributes
     }
 
     @JsonAnySetter
     void set(String name, Object value) {
-      attributes.put(name, value);
+      attributes.put(name, value)
     }
   }
 }


### PR DESCRIPTION
@ajordens PTAL

I tried removing the top level `lastModified` and `lastModifiedBy` fields, but those are required to satisfy the `Timestamped` interface, which is required by `StorageServiceSupport` class, so left them in.