### PR TITLE
redis: Make health checks conditional

### DIFF
--- a/front50-web/config/front50.yml
+++ b/front50-web/config/front50.yml
@@ -1,8 +1,14 @@
 server:
   port: 8080
 
+management:
+  health:
+    redis:
+      enabled: ${spinnaker.redis.enabled}
+
 cassandra:
   enabled: true
+
 
 spinnaker:
   cassandra:

--- a/front50-web/config/front50.yml
+++ b/front50-web/config/front50.yml
@@ -9,7 +9,6 @@ management:
 cassandra:
   enabled: true
 
-
 spinnaker:
   cassandra:
     enabled: true


### PR DESCRIPTION
Spring Boot has a builtin RedisHealthCheck. It must be disabled if redis support is also disabled.

Resolves #1018