### PR TITLE
Allow configurable S3 endpoint

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.front50.config;
 public class S3BucketProperties {
   private String bucket;
   private String region;
+  private String endpoint;
   private String proxyHost;
   private String proxyPort;
   private String proxyProtocol;
@@ -37,6 +38,14 @@ public class S3BucketProperties {
 
   public void setRegion(String region) {
     this.region = region;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 
   public String getProxyHost() {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -7,6 +7,7 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
 import com.netflix.spectator.api.Registry;
@@ -71,10 +72,15 @@ public class S3Config {
     }
 
     AmazonS3Client client = new AmazonS3Client(awsCredentialsProvider, clientConfiguration);
-    Optional.ofNullable(s3Properties.getRegion())
-      .map(Regions::fromName)
-      .map(Region::getRegion)
-      .ifPresent(client::setRegion);
+    if (s3Properties.getEndpoint() != null){
+      client.setEndpoint(s3Properties.getEndpoint());
+      client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build());
+    } else{
+      Optional.ofNullable(s3Properties.getRegion())
+        .map(Regions::fromName)
+        .map(Region::getRegion)
+        .ifPresent(client::setRegion);
+    }
     return client;
   }
 

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -63,6 +63,14 @@ public class S3Properties extends S3BucketProperties {
   }
 
   @Override
+  public String getEndpoint() {
+    if (isFailoverEnabled()) {
+      return failover.getEndpoint();
+    }
+    return super.getEndpoint();
+  }
+
+  @Override
   public String getProxyHost() {
     if (isFailoverEnabled()) {
       return failover.getProxyHost();


### PR DESCRIPTION
This allows alternative S3 implementations such as Minio to be used with Front50.