### PR TITLE
Add Spring Cloud Config Server as optional source of properties

### DIFF
--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -50,6 +50,9 @@ dependencies {
   compile "org.springframework.security:spring-security-config:3.2.9.RELEASE"
   compile "org.springframework.security:spring-security-core:3.2.9.RELEASE"
   compile "org.springframework.security:spring-security-web:3.2.9.RELEASE"
+  compile "org.springframework.cloud:spring-cloud-starter-config:1.0.6.RELEASE"
+  compile "org.springframework.cloud:spring-cloud-config-server:1.0.4.RELEASE"
+
 
   compile spinnaker.dependency("korkWeb")
   compile spinnaker.dependency("korkStackdriver")

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/SpringCloudConfigServerConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/SpringCloudConfigServerConfig.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.cloud.config.server.EnableConfigServer
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Create an embedded config server.
+ *
+ * NOTE: It's opt-in via spring.cloud.config.server.bootstrap=true. Also requires
+ *       spring.cloud.config.server.git.uri or spring.cloud.config.server.svn.uri
+ */
+@Configuration
+@ConditionalOnProperty('spring.cloud.config.server.bootstrap')
+class SpringCloudConfigServerConfig {
+
+  @EnableConfigServer
+  static class SpringCloudEmbeddedConfigServer {}
+
+}

--- a/front50-web/src/main/resources/bootstrap.yml
+++ b/front50-web/src/main/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: front50 # Embedded config server needs this setting sooner than can be reached via DEFAULT_PROPS
+  cloud:
+    config:
+      server:
+        bootstrap: false # Disabled by default
+        prefix: /config


### PR DESCRIPTION
* By default, config server is disabled. Enable with spring.cloud.config.server.bootstrap=true
* It defaults to being served underneath /config, but that can be optionally overridden.