### PR TITLE
Removing unused loadObjectVersion storage API

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
@@ -37,10 +37,6 @@ public interface StorageService {
 
   <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) throws NotFoundException;
 
-  <T extends Timestamped> T loadObjectVersion(ObjectType objectType,
-                                              String objectKey,
-                                              String versionId) throws NotFoundException;
-
   void deleteObject(ObjectType objectType, String objectKey);
 
   <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T item);

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -280,11 +280,6 @@ public class GcsStorageService implements StorageService {
   }
 
   @Override
-  public <T extends Timestamped> T loadObjectVersion(ObjectType objectType, String objectKey, String versionId) throws NotFoundException {
-      return null;
-  }
-
-  @Override
   public void deleteObject(ObjectType objectType, String objectKey) {
     String path = keyToPath(objectKey, objectType.group);
     try {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -114,13 +114,6 @@ public class S3StorageService implements StorageService {
   }
 
   @Override
-  public <T extends Timestamped> T loadObjectVersion(ObjectType objectType,
-                                                     String objectKey,
-                                                     String versionId) throws NotFoundException {
-    throw new UnsupportedOperationException("loadObjectVersion() is not supported");
-  }
-
-  @Override
   public void deleteObject(ObjectType objectType, String objectKey) {
     if (readOnlyMode) {
       throw new ReadOnlyModeException();


### PR DESCRIPTION
No sense in having an API we don't use.

@spinnaker/reviewers @scotmoor  PTAL