### PR TITLE
Rename azure storage to azs

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
@@ -48,7 +48,7 @@ import rx.schedulers.Schedulers;
 import java.util.concurrent.Executors;
 
 @Configuration
-@ConditionalOnExpression("${spinnaker.azure.enabled:false}")
+@ConditionalOnExpression("${spinnaker.azs.enabled:false}")
 @EnableConfigurationProperties(AzureStorageProperties.class)
 public class AzureStorageConfig {
 

--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageProperties.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageProperties.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.front50.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties("spinnaker.azure")
+@ConfigurationProperties("spinnaker.azs")
 public class AzureStorageProperties {
   private String storageAccountKey;
   private String storageAccountName;

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
@@ -35,7 +35,7 @@ import retrofit.RetrofitError
 @Slf4j
 @RestController
 @RequestMapping("/permissions")
-@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false} || ${spinnaker.azure.enabled:false}')
+@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false} || ${spinnaker.azs.enabled:false}')
 public class PermissionsController {
 
   @Autowired

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -34,7 +34,7 @@ import retrofit.RetrofitError
 @Slf4j
 @RestController
 @RequestMapping("/serviceAccounts")
-@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false} || ${spinnaker.azure.enabled:false}')
+@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false} || ${spinnaker.azs.enabled:false}')
 public class ServiceAccountsController {
 
   @Autowired

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/SnapshotsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/SnapshotsController.groovy
@@ -38,7 +38,7 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 
 @RestController
 @RequestMapping("/snapshots")
-@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false} || ${spinnaker.azure.enabled:false}')
+@ConditionalOnExpression('${spinnaker.gcs.enabled:false} || ${spinnaker.s3.enabled:false} || ${spinnaker.azs.enabled:false}')
 class SnapshotsController {
 
     @Autowired


### PR DESCRIPTION
'spinnaker.azure.enabled' conflicted with the environment variable used for the Azure cloudprovider config. Since azure storage can be used with other providers (like Kubernetes) we want the names to be independent.