### PR TITLE
try to reconcile dependencies

### DIFF
--- a/front50-s3/front50-s3.gradle
+++ b/front50-s3/front50-s3.gradle
@@ -17,7 +17,7 @@
 dependencies {
   compile project(":front50-core")
 
-  compile 'com.netflix.spinnaker.clouddriver:clouddriver-aws:1.488.0'
+  compile spinnaker.dependency("clouddriverAws")
 //  compile 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.15'
 
   testCompile project(":front50-test")

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -45,12 +45,12 @@ dependencies {
 // Replace below with this line when fiat becomes stable.
 //  spinnaker.group "fiat"
   compile "com.netflix.spinnaker.fiat:fiat-api:0.21.0"
-  compile "org.springframework.boot:spring-boot-starter-actuator:1.2.8.RELEASE"
-  compile "org.springframework.boot:spring-boot-starter-web:1.2.8.RELEASE"
-  compile "org.springframework.boot:spring-boot-starter-data-rest:1.2.8.RELEASE"
-  compile "org.springframework.security:spring-security-config:3.2.9.RELEASE"
-  compile "org.springframework.security:spring-security-core:3.2.9.RELEASE"
-  compile "org.springframework.security:spring-security-web:3.2.9.RELEASE"
+  spinnaker.dependency("bootActuator")
+  spinnaker.dependency("bootWeb")
+  spinnaker.dependency("bootDataRest")
+  spinnaker.dependency("springSecurityConfig")
+  spinnaker.dependency("springSecurityCore")
+  spinnaker.dependency("springSecurityWeb")
 
   compile spinnaker.dependency("korkWeb")
   compile spinnaker.dependency("korkStackdriver")


### PR DESCRIPTION
front50-nflx is pulling in a newer version of AWS SDK transitively and breaking Front50 on startup. I'm trying to upgrade to the newer spinnaker-dependencies version that will bring in the same AWS version here but it also brings in a newer version of `clouddriver-google-common`.

Also a few things weren't using spinnaker-dependencies when it seems like they should.