### PR TITLE
Remove rootFolder from AZS config

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
@@ -64,10 +64,7 @@ public class AzureStorageConfig {
   @Bean
   public AzureStorageService azureStorageService(AzureStorageProperties azureStorageProperties) {
     // This is where we create the service
-    return new AzureStorageService(azureStorageProperties.getStorageConnectionString(),
-      azureStorageProperties.getStorageAccountName(),
-      azureStorageProperties.getStorageContainerName(),
-      azureStorageProperties.getRootFolder());
+    return new AzureStorageService(azureStorageProperties.getStorageConnectionString(), azureStorageProperties.getStorageContainerName());
   }
 
   @Bean

--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageProperties.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageProperties.java
@@ -23,7 +23,6 @@ public class AzureStorageProperties {
   private String storageAccountKey;
   private String storageAccountName;
   private String storageContainerName;
-  private String rootFolder;
 
   public String getStorageConnectionString() {
     return "DefaultEndpointsProtocol=https;"
@@ -39,8 +38,4 @@ public class AzureStorageProperties {
 
   public String getStorageContainerName() { return this.storageContainerName; }
   public void setStorageContainerName(String storageContainerName) { this.storageContainerName = storageContainerName; }
-
-  public String getRootFolder() { return this.rootFolder; }
-  public void setRootFolder(String rootFolder) { this.rootFolder = rootFolder; }
-
 }


### PR DESCRIPTION
For a few reasons:
1. Simplify the config
2. Match the folder structure for other providers, which are only 2 levels deep not 3 (in front50.yml, s3.bucket == azs.storageAccountName and s3.rootFolder == azs.storageContainerName)
3. Fix a bug where the 'last_modified' files were stored at the container level and everything else was stored at the (now removed) rootFolder level. Now everything is at the container level.