### PR TITLE
entityTags: add findAllById endpoint, return tags on batchUpdate

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
@@ -50,6 +50,11 @@ class EntityTagsController {
     return taggedEntityDAO?.all(prefix, 100) ?: []
   }
 
+  @RequestMapping(method = RequestMethod.GET)
+  Set<EntityTags> findAllById(@RequestParam(value = "entityIds", required = true) Collection<String> entityIds) {
+    return entityIds.findResults { taggedEntityDAO.findById(it) }
+  }
+
   @RequestMapping(value = "/**", method = RequestMethod.GET)
   EntityTags tag(HttpServletRequest request) {
     String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
@@ -72,13 +77,13 @@ class EntityTagsController {
   }
 
   @RequestMapping(value = "/batchUpdate", method = RequestMethod.POST)
-  void batchUpdate(@RequestBody final Collection<EntityTags> tags, HttpServletResponse response) {
+  Collection<EntityTags> batchUpdate(@RequestBody final Collection<EntityTags> tags) {
     if (!taggedEntityDAO) {
       throw new BadRequestException("Tagging is not supported")
     }
 
     taggedEntityDAO.bulkImport(tags)
-    response.setStatus(HttpStatus.ACCEPTED.value())
+    return findAllById(tags.findResults { it.id })
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/**")


### PR DESCRIPTION
Nothing major here:
 * adding an endpoint to get all tags for a list of `entityId`s
 * returning the results from `/batchUpdate` POSTs so we can take advantage of that endpoint in Clouddriver