### PR TITLE
Introduce a new `namespace` attribute to `EntityTag`

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/EntityTags.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/EntityTags.groovy
@@ -62,6 +62,7 @@ class EntityTags implements Timestamped {
 
   static class EntityTag {
     String name
+    String namespace
     Object value
     String valueType
   }


### PR DESCRIPTION
The idea being that tag name's could be re-used across namespaces, either
intentionally or accidentally.

Permissions / restrictions could also be applied to namespaces vs. individual
tag names.