### PR TITLE
feat(tagging): allow POST operations for multi-tag fetch/delete

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
@@ -58,6 +58,18 @@ class EntityTagsController {
     return taggedEntityDAO?.all()?.findAll { prefix ? it.id.startsWith(prefix) : true }
   }
 
+  @RequestMapping(value = "/bulkFetch", method = RequestMethod.POST)
+  Set<EntityTags> bulkFetch(@RequestBody final Collection<String> ids) {
+    return findAllByIds(ids)
+  }
+
+  @RequestMapping(value = "/bulkDelete", method = RequestMethod.POST)
+  void bulkDelete(@RequestBody final Collection<String> ids) {
+    ids.each {
+      taggedEntityDAO.delete(it)
+    }
+  }
+
   @RequestMapping(value = "/**", method = RequestMethod.GET)
   EntityTags tag(HttpServletRequest request) {
     String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);


### PR DESCRIPTION
This is a very un-REST-y pair of endpoints that would allow bulk operations against tags to operate much more efficiently. The current endpoint to get a list of tags requires a GET, with the tag IDs in the URL as query parameters. Since tag IDs can get very long, and servers have a limit on the length of URL they're able to process, we can safely only fetch < 100 tags at a time. The same applies to DELETEs.

@ajordens WDYT - the purpose here is to allow big optimizations to bulk operations (a separate clouddriver PR would be necessary to use these endpoints).