### PR TITLE
chore(fiat): Bumps Fiat API, adding EnableFiatAutoConfig annotation

### DIFF
--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -44,7 +44,7 @@ dependencies {
 
 // Replace below with this line when fiat becomes stable.
 //  spinnaker.group "fiat"
-  compile "com.netflix.spinnaker.fiat:fiat-api:0.21.0"
+  compile "com.netflix.spinnaker.fiat:fiat-api:0.22.0"
   spinnaker.dependency("bootActuator")
   spinnaker.dependency("bootWeb")
   spinnaker.dependency("bootDataRest")

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -18,26 +18,14 @@ package com.netflix.spinnaker.front50.config
 
 import com.netflix.hystrix.exception.HystrixRuntimeException
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
-import com.netflix.spinnaker.front50.model.StorageService
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO
-import com.netflix.spinnaker.front50.model.application.DefaultApplicationDAO
-import com.netflix.spinnaker.front50.model.application.DefaultApplicationPermissionDAO
-import com.netflix.spinnaker.front50.model.notification.DefaultNotificationDAO
-import com.netflix.spinnaker.front50.model.notification.NotificationDAO
-import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineDAO
-import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineStrategyDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
-import com.netflix.spinnaker.front50.model.project.DefaultProjectDAO
 import com.netflix.spinnaker.front50.model.project.ProjectDAO
-import com.netflix.spinnaker.front50.model.serviceaccount.DefaultServiceAccountDAO
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
-import com.netflix.spinnaker.front50.model.snapshot.DefaultSnapshotDAO
-import com.netflix.spinnaker.front50.model.snapshot.SnapshotDAO
-import com.netflix.spinnaker.front50.model.tag.DefaultEntityTagsDAO
-import com.netflix.spinnaker.front50.model.tag.EntityTagsDAO
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -52,20 +40,17 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
-import rx.schedulers.Schedulers
-
-import java.util.concurrent.Executors
 
 @Configuration
 @ComponentScan
-public class Front50WebConfig extends WebMvcConfigurerAdapter {
+@EnableFiatAutoConfig
+class Front50WebConfig extends WebMvcConfigurerAdapter {
   @Autowired
   Registry registry
 
   @Override
-  public void addInterceptors(InterceptorRegistry registry) {
+  void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(
         new MetricsInterceptor(
             this.registry, "controller.invocations", ["account", "application"], ["BasicErrorController"]
@@ -122,7 +107,7 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
     @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
     @ResponseBody
     @ExceptionHandler(HystrixRuntimeException)
-    public Map handleHystrix(HystrixRuntimeException exception) {
+    Map handleHystrix(HystrixRuntimeException exception) {
       return [
           fallbackException: exception.fallbackException.toString(),
           failureType      : exception.failureType,

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.front50.controllers
 
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.front50.model.application.Application
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.front50.controllers
 
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO


### PR DESCRIPTION
This is an example of what needs to be done in the rest of the non-Gate components that utilize the Fiat API module - basically a version bump + adding `@EnableFiatAutoConfig`.

@cfieber @jtk54 - PTAL.

Tests won't pass until spinnaker/fiat#154 is submitted and released.