### PR TITLE
chore(changelog): Extend changelog commit keywords.

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,4 @@
+[clog]
+
+[sections]
+"Configuration Changes" = ["config", "conf"]


### PR DESCRIPTION
Adds a few new changelog keywords: `bc` for breaking change and `config` or `conf` for configuration changes. @ewiseblatt @ajordens FYI.