### PR TITLE
feat(core/model): Add category to EntityTag model

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/EntityTags.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/EntityTags.groovy
@@ -63,6 +63,7 @@ class EntityTags implements Timestamped {
   static class EntityTag {
     String name
     String namespace
+    String category
     Object value
     String valueType
   }


### PR DESCRIPTION
This allows a tag to be assigned a category. Alerts/notifications will then be grouped by category in deck.