### PR TITLE
Ability to retrieve most recently cached objects w/o an explicit refresh

### DIFF
--- a/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAO.groovy
+++ b/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/application/CassandraApplicationDAO.groovy
@@ -107,6 +107,11 @@ class CassandraApplicationDAO implements ApplicationDAO {
 
   @Override
   Set<Application> all() {
+    return all(true)
+  }
+
+  @Override
+  Collection<Application> all(boolean refresh) {
     def applications = unmarshallResults(runQuery('SELECT * FROM application;'))
     if (!applications) {
       throw new NotFoundException("No applications available")

--- a/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/project/CassandraProjectDAO.groovy
+++ b/front50-cassandra/src/main/groovy/com/netflix/spinnaker/front50/model/project/CassandraProjectDAO.groovy
@@ -102,6 +102,11 @@ class CassandraProjectDAO implements ProjectDAO {
 
   @Override
   Set<Project> all() {
+    all(true)
+  }
+
+  @Override
+  Collection<Project> all(boolean refresh) {
     return unmarshallResults(runQuery('SELECT * FROM project;'))
   }
 

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ItemDAO.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ItemDAO.groovy
@@ -22,6 +22,14 @@ import com.netflix.spinnaker.front50.exception.NotFoundException
 interface ItemDAO<T> {
   T findById(String id) throws NotFoundException
   Collection<T> all()
+
+  /**
+   * It can be expensive to refresh a bucket containing a large number of objects.
+   *
+   * When {@code refresh} is false, the most recently cached set of objects will be returned.
+   */
+  Collection<T> all(boolean refresh)
+
   Collection<T> history(String id, int maxResults)
 
   T create(String id, T item)

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -128,17 +128,25 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
   }
 
   public Collection<T> all() {
-    long lastModified = readLastModified();
-    if (lastModified > lastRefreshedTime.get() || allItemsCache.get() == null) {
-        // only refresh if there was a modification since our last refresh cycle
-        log.debug("all() forcing refresh");
-        long startTime = System.nanoTime();
-        refresh();
-        long elapsed = System.nanoTime() - startTime;
-        autoRefreshTimer.record(elapsed, TimeUnit.NANOSECONDS);
+    return all(true);
+  }
+
+  public Collection<T> all(boolean refresh) {
+    if (!refresh) {
+      return new ArrayList<>(allItemsCache.get());
     }
 
-    return allItemsCache.get().stream().collect(Collectors.toList());
+    long lastModified = readLastModified();
+    if (lastModified > lastRefreshedTime.get() || allItemsCache.get() == null) {
+      // only refresh if there was a modification since our last refresh cycle
+      log.debug("all() forcing refresh");
+      long startTime = System.nanoTime();
+      refresh();
+      long elapsed = System.nanoTime() - startTime;
+      autoRefreshTimer.record(elapsed, TimeUnit.NANOSECONDS);
+    }
+
+    return new ArrayList<>(allItemsCache.get());
   }
 
   public Collection<T> all(String prefix, int maxResults) {

--- a/front50-pipelines/src/main/groovy/com/netflix/spinnaker/front50/pipeline/PipelineRepository.groovy
+++ b/front50-pipelines/src/main/groovy/com/netflix/spinnaker/front50/pipeline/PipelineRepository.groovy
@@ -89,9 +89,14 @@ class PipelineRepository implements PipelineDAO {
     }
 
     List<Pipeline> all() {
-        def result = runQuery("""SELECT id, name, definition FROM pipeline;""", true)
-        resolvePipelines(result)
+        return all(true)
     }
+
+  @Override
+  Collection<Pipeline> all(boolean refresh) {
+    def result = runQuery("""SELECT id, name, definition FROM pipeline;""", true)
+    resolvePipelines(result)
+  }
 
   @Override
   Collection<Pipeline> history(String id, int maxResults) {

--- a/front50-pipelines/src/main/groovy/com/netflix/spinnaker/front50/pipeline/StrategyRepository.groovy
+++ b/front50-pipelines/src/main/groovy/com/netflix/spinnaker/front50/pipeline/StrategyRepository.groovy
@@ -89,9 +89,14 @@ class StrategyRepository implements PipelineStrategyDAO {
     }
 
     List<Pipeline> all() {
-        def result = runQuery("""SELECT id, name, definition FROM strategy;""", true)
-        resolvePipelines(result)
+      return all(true)
     }
+
+  @Override
+  Collection<Pipeline> all(boolean refresh) {
+    def result = runQuery("""SELECT id, name, definition FROM strategy;""", true)
+    resolvePipelines(result)
+  }
 
   @Override
   Collection<Pipeline> history(String id, int maxResults) {

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisApplicationDAO.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisApplicationDAO.groovy
@@ -52,8 +52,13 @@ class RedisApplicationDAO implements ApplicationDAO {
 
   @Override
   Collection<Application> all() {
+    return all(true)
+  }
+
+  @Override
+  Collection<Application> all(boolean refresh) {
     def applications = redisTemplate.opsForHash().scan(BOOK_KEEPING_KEY, ScanOptions.scanOptions().match('*').build())
-        .collect { it.value }
+      .collect { it.value }
 
     if (!applications) {
       throw new NotFoundException("No applications available")

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineDAO.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineDAO.groovy
@@ -53,8 +53,13 @@ class RedisPipelineDAO implements PipelineDAO {
 
   @Override
   Collection<Pipeline> all() {
+    return all(true)
+  }
+
+  @Override
+  Collection<Pipeline> all(boolean refresh) {
     redisTemplate.opsForHash().scan(BOOK_KEEPING_KEY, ScanOptions.scanOptions().match('*').build())
-        .collect { it.value }
+      .collect { it.value }
   }
 
   @Override

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineStrategyDAO.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineStrategyDAO.groovy
@@ -54,8 +54,13 @@ class RedisPipelineStrategyDAO implements PipelineStrategyDAO {
 
   @Override
   Collection<Pipeline> all() {
+    return all(true)
+  }
+
+  @Override
+  Collection<Pipeline> all(boolean refresh) {
     redisTemplate.opsForHash().scan(BOOK_KEEPING_KEY, ScanOptions.scanOptions().match('*').build())
-        .collect { it.value }
+      .collect { it.value }
   }
 
   @Override

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisProjectDAO.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisProjectDAO.groovy
@@ -48,8 +48,13 @@ class RedisProjectDAO implements ProjectDAO {
 
   @Override
   Collection<Project> all() {
+    return all(true)
+  }
+
+  @Override
+  Collection<Project> all(boolean refresh) {
     redisTemplate.opsForHash().scan(BOOK_KEEPING_KEY, ScanOptions.scanOptions().match('*').build())
-        .collect { it.value }
+      .collect { it.value }
   }
 
   @Override

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
@@ -46,7 +46,8 @@ class EntityTagsController {
 
   @RequestMapping(method = RequestMethod.GET)
   Set<EntityTags> tags(@RequestParam(value = "prefix", required = false) String prefix,
-                       @RequestParam(value = "ids", required = false) Collection<String> ids) {
+                       @RequestParam(value = "ids", required = false) Collection<String> ids,
+                       @RequestParam(value = "refresh", required = false) Boolean refresh) {
     if (prefix == null && !ids) {
       throw new BadRequestException("Either 'prefix' or 'ids' parameter is required")
     }
@@ -55,7 +56,8 @@ class EntityTagsController {
       return findAllByIds(ids)
     }
 
-    return taggedEntityDAO?.all()?.findAll { prefix ? it.id.startsWith(prefix) : true }
+    refresh = (refresh == null) ? true : refresh
+    return taggedEntityDAO?.all(refresh)?.findAll { prefix ? it.id.startsWith(prefix) : true }
   }
 
   @RequestMapping(value = "/**", method = RequestMethod.GET)


### PR DESCRIPTION
This is particularly important for EntityTags wherein there can be many
10s of thousands of objects.

The `reindex` API in `clouddriver` will updated such that it passes
`?refresh=false` when retrieving all EntityTags from Front50.

Otherwise this call runs the risk of timing out / failing.
