### PR TITLE
fix(azs): Leverage CommonStorageServiceDAOConfig in AZS

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @ConditionalOnExpression("${spinnaker.azs.enabled:false}")
 @EnableConfigurationProperties(AzureStorageProperties.class)
-public class AzureStorageConfig {
+public class AzureStorageConfig extends CommonStorageServiceDAOConfig {
   @Bean
   @ConditionalOnMissingBean(RestTemplate.class)
   public RestTemplate restTemplate() {


### PR DESCRIPTION
We were getting a bunch of 'Bean' exceptions without this

Related to https://github.com/spinnaker/front50/pull/224