### PR TITLE
feat(oraclebmcs): Add Oracle BMCS Storage Service provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ vendor/
 .bundle/
 *.iml
 .idea
+
+front50-oracle-bmcs/bmcs-sdk

--- a/front50-oracle-bmcs/front50-oracle-bmcs.gradle
+++ b/front50-oracle-bmcs/front50-oracle-bmcs.gradle
@@ -1,0 +1,58 @@
+class DownloadTask extends DefaultTask {
+  @Input
+  String sourceUrl
+
+  @OutputFile
+  File target
+
+  @TaskAction
+  void download() {
+    ant.get(src: sourceUrl, dest: target)
+  }
+}
+
+final File sdkDownloadLocation = project.file('build/sdkdownload')
+final File sdkLocation = project.file('build/bmcs-sdk')
+
+// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile deps
+task fetchSdk(type: DownloadTask) {
+  sourceUrl = 'https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.5/oracle-bmcs-java-sdk.zip'
+  target = sdkDownloadLocation
+}
+
+task unpackSdk(type: Sync) {
+  dependsOn('fetchSdk')
+  from zipTree(tasks.fetchSdk.target)
+  into sdkLocation
+  include "**/*.jar"
+  exclude "**/*-sources.jar"
+  exclude "**/*-javadoc.jar"
+  exclude "apidocs/**"
+  exclude "examples/**"
+  exclude "**/*jackson*.jar"
+  exclude "**/*jersey*.jar"
+  exclude "**/hk2*.jar"
+  exclude "**/*guava*.jar"
+  exclude "**/commons*.jar"
+  exclude "**/aopalliance*.jar"
+  exclude "**/javassist*.jar"
+  exclude "**/slf*.jar"
+  exclude "**/osgi*.jar"
+  exclude "**/validation*.jar"
+  exclude "**/jsr305*.jar"
+}
+
+task cleanSdk(type: Delete) {
+  delete sdkLocation, sdkDownloadLocation
+}
+
+tasks.clean.dependsOn('cleanSdk')
+tasks.compileJava.dependsOn('unpackSdk')
+
+dependencies {
+  compile project(":front50-core")
+
+  compile fileTree(sdkLocation)
+
+  testCompile project(":front50-test")
+}

--- a/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/config/OracleBMCSConfig.java
+++ b/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/config/OracleBMCSConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.front50.config;
+
+import com.netflix.spinnaker.front50.model.OracleBMCSStorageService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+@Configuration
+@ConditionalOnExpression("${spinnaker.oraclebmcs.enabled:false}")
+@EnableConfigurationProperties(OracleBMCSProperties.class)
+public class OracleBMCSConfig extends CommonStorageServiceDAOConfig {
+
+  @Bean
+  public OracleBMCSStorageService oracleBMCSStorageService(OracleBMCSProperties oracleBMCSProperties) throws IOException {
+    OracleBMCSStorageService oracleBMCSStorageService = new OracleBMCSStorageService(oracleBMCSProperties);
+    oracleBMCSStorageService.ensureBucketExists();
+    return oracleBMCSStorageService;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(RestTemplate.class)
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+}

--- a/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/config/OracleBMCSProperties.java
+++ b/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/config/OracleBMCSProperties.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.front50.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spinnaker.oraclebmcs")
+public class OracleBMCSProperties {
+
+  private String bucketName = "_spinnaker_front50_data";
+  private String namespace;
+  private String compartmentId;
+  private String region = "us-phoenix-1";
+  private String userId;
+  private String fingerprint;
+  private String sshPrivateKeyFilePath;
+  private String tenancyId;
+
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public void setBucketName(String bucketName) {
+    this.bucketName = bucketName;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  public String getCompartmentId() {
+    return compartmentId;
+  }
+
+  public void setCompartmentId(String compartmentId) {
+    this.compartmentId = compartmentId;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(String region) {
+    this.region = region;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public String getFingerprint() {
+    return fingerprint;
+  }
+
+  public void setFingerprint(String fingerprint) {
+    this.fingerprint = fingerprint;
+  }
+
+  public String getSshPrivateKeyFilePath() {
+    return sshPrivateKeyFilePath;
+  }
+
+  public void setSshPrivateKeyFilePath(String sshPrivateKeyFilePath) {
+    this.sshPrivateKeyFilePath = sshPrivateKeyFilePath;
+  }
+
+  public String getTenancyId() {
+    return tenancyId;
+  }
+
+  public void setTenancyId(String tenancyId) {
+    this.tenancyId = tenancyId;
+  }
+}

--- a/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/LastModified.java
+++ b/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/LastModified.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+
+public class LastModified {
+  private Long lastModified = System.currentTimeMillis();
+
+  public Long getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(Long lastModified) {
+    this.lastModified = lastModified;
+  }
+}

--- a/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/OracleBMCSStorageService.java
+++ b/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/OracleBMCSStorageService.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.front50.model;
+
+import com.google.common.base.Supplier;
+import com.netflix.spinnaker.front50.config.OracleBMCSProperties;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SimplePrivateKeySupplier;
+import com.oracle.bmc.http.signing.DefaultRequestSigner;
+import com.oracle.bmc.http.signing.RequestSigner;
+import com.oracle.bmc.objectstorage.model.CreateBucketDetails;
+import com.oracle.bmc.objectstorage.model.ListObjects;
+import com.oracle.bmc.objectstorage.model.ObjectSummary;
+import com.sun.jersey.api.client.*;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.api.client.filter.ClientFilter;
+import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+public class OracleBMCSStorageService implements StorageService {
+
+  private final Client client;
+  private final String endpoint = "https://objectstorage.{arg0}.oraclecloud.com";
+  private final String region;
+  private final String namespace;
+  private final String compartmentId;
+  private final String bucketName;
+
+
+  private class RequestSigningFilter extends ClientFilter {
+    private final RequestSigner signer;
+
+    public RequestSigningFilter(RequestSigner requestSigner) {
+      this.signer = requestSigner;
+    }
+
+    @Override
+    public ClientResponse handle(ClientRequest cr) throws ClientHandlerException {
+      Map<String, List<String>> stringHeaders = new HashMap<>();
+      for (String key : cr.getHeaders().keySet()) {
+        List<String> vals = new ArrayList<>();
+        for (Object val : cr.getHeaders().get(key)) {
+          vals.add((String) val);
+        }
+        stringHeaders.put(key, vals);
+      }
+
+      Map<String, String> signedHeaders = signer.signRequest(cr.getURI(), cr.getMethod(), stringHeaders, cr.getEntity());
+      for (String key : signedHeaders.keySet()) {
+        cr.getHeaders().putSingle(key, signedHeaders.get(key));
+      }
+
+      return getNext().handle(cr);
+    }
+  }
+
+  public OracleBMCSStorageService(OracleBMCSProperties oracleBMCSProperties) throws IOException {
+    this.region = oracleBMCSProperties.getRegion();
+    this.bucketName = oracleBMCSProperties.getBucketName();
+    this.namespace = oracleBMCSProperties.getNamespace();
+    this.compartmentId = oracleBMCSProperties.getCompartmentId();
+
+    Supplier<InputStream> privateKeySupplier = new SimplePrivateKeySupplier(oracleBMCSProperties.getSshPrivateKeyFilePath());
+    AuthenticationDetailsProvider provider = SimpleAuthenticationDetailsProvider.builder()
+            .userId(oracleBMCSProperties.getUserId())
+            .fingerprint(oracleBMCSProperties.getFingerprint())
+            .privateKeySupplier(privateKeySupplier)
+            .tenantId(oracleBMCSProperties.getTenancyId())
+            .build();
+
+    RequestSigner requestSigner = DefaultRequestSigner.createRequestSigner(provider);
+
+    ClientConfig clientConfig = new DefaultClientConfig();
+    client = new Client(new URLConnectionClientHandler(), clientConfig);
+    client.addFilter(new OracleBMCSStorageService.RequestSigningFilter(requestSigner));
+  }
+
+  @Override
+  public void ensureBucketExists() {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}")
+            .build(region, namespace, bucketName));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    ClientResponse rsp = wr.head();
+    if (rsp.getStatus() == 404) {
+      CreateBucketDetails createBucketDetails = CreateBucketDetails.builder()
+              .name(bucketName)
+              .compartmentId(compartmentId)
+              .build();
+      wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/")
+              .build(region, namespace));
+      wr.accept(MediaType.APPLICATION_JSON_TYPE);
+      wr.post(createBucketDetails);
+    } else if (rsp.getStatus() != 200) {
+      throw new RuntimeException(rsp.toString());
+    }
+  }
+
+  @Override
+  public boolean supportsVersioning() {
+    return false;
+  }
+
+  @Override
+  public <T extends Timestamped> Collection<T> loadObjectsWithPrefix(ObjectType objectType, String prefix, int maxResults) {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o")
+            .queryParam("prefix", prefix)
+            .build(region, namespace, bucketName));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    ListObjects listObjects = wr.get(ListObjects.class);
+
+    Collection<T> objects = new ArrayList<>(listObjects.getObjects().size());
+    for (ObjectSummary summary : listObjects.getObjects()) {
+      if (summary.getName().endsWith(objectType.defaultMetadataFilename)) {
+        objects.add(loadObject(objectType, summary.getName()));
+      }
+    }
+    return objects;
+  }
+
+  @Override
+  public <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) throws NotFoundException {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o/{arg3}")
+            .build(region, namespace, bucketName, buildOSSKey(objectType.group, objectKey, objectType.defaultMetadataFilename)));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    try {
+      T obj = (T) wr.get(objectType.clazz);
+      return obj;
+    } catch (UniformInterfaceException e) {
+      if (e.getResponse().getStatus() == 404) {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public void deleteObject(ObjectType objectType, String objectKey) {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o/{arg3}")
+            .build(region, namespace, bucketName, buildOSSKey(objectType.group, objectKey, objectType.defaultMetadataFilename)));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    try {
+      wr.delete();
+    } catch (UniformInterfaceException e) {
+      if (e.getResponse().getStatus() == 404) {
+        return;
+      }
+      throw e;
+    }
+
+    updateLastModified(objectType);
+  }
+
+  @Override
+  public <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T item) {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o/{arg3}")
+            .build(region, namespace, bucketName, buildOSSKey(objectType.group, objectKey, objectType.defaultMetadataFilename)));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    wr.put(item);
+
+    updateLastModified(objectType);
+  }
+
+  @Override
+  public Map<String, Long> listObjectKeys(ObjectType objectType) {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o")
+            .queryParam("prefix", objectType.group)
+            .queryParam("fields", "name,timeCreated")
+            .build(region, namespace, bucketName));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    ListObjects listObjects = wr.get(ListObjects.class);
+    Map<String, Long> results = new HashMap<>();
+    for (ObjectSummary summary : listObjects.getObjects()) {
+      if (summary.getName().endsWith(objectType.defaultMetadataFilename)) {
+        results.put(buildObjectKey(objectType, summary.getName()), summary.getTimeCreated().getTime());
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public <T extends Timestamped> Collection<T> listObjectVersions(ObjectType objectType, String objectKey, int maxResults) throws NotFoundException {
+    throw new RuntimeException("OracleBMCS Storage Service does not support versioning");
+  }
+
+  @Override
+  public long getLastModified(ObjectType objectType) {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o/{arg3}")
+            .build(region, namespace, bucketName, objectType.group + "/last-modified.json"));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    try {
+      LastModified lastModified = wr.get(LastModified.class);
+      return lastModified.getLastModified();
+    } catch (Exception e) {
+      return 0L;
+    }
+  }
+
+  private void updateLastModified(ObjectType objectType) {
+    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o/{arg3}")
+            .build(region, namespace, bucketName, objectType.group + "/last-modified.json"));
+    wr.accept(MediaType.APPLICATION_JSON_TYPE);
+    wr.put(new LastModified());
+  }
+
+  private String buildOSSKey(String group, String objectKey, String metadataFilename) {
+    if (objectKey.endsWith(metadataFilename)) {
+      return objectKey;
+    }
+
+    return (group + "/" + objectKey.toLowerCase() + "/" + metadataFilename).replace("//", "/");
+  }
+
+  private String buildObjectKey(ObjectType objectType, String ossKey) {
+    return ossKey
+            .replaceAll(objectType.group + "/", "")
+            .replaceAll("/" + objectType.defaultMetadataFilename, "");
+  }
+
+}

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -40,6 +40,7 @@ dependencies {
   compile project(":front50-pipelines")
   compile project(":front50-migrations")
   compile project(":front50-azure")
+  compile project(":front50-oracle-bmcs")
 
   spinnaker.group "bootWeb"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name = "front50"
 
-include 'front50-web', 'front50-core', 'front50-cassandra', 'front50-gcs', 'front50-pipelines', 'front50-redis', 'front50-s3', 'front50-test', 'front50-migrations', 'front50-azure', 'front50-swift'
+include 'front50-web', 'front50-core', 'front50-cassandra', 'front50-gcs', 'front50-pipelines', 'front50-redis', 'front50-s3', 'front50-test', 'front50-migrations', 'front50-azure', 'front50-swift', 'front50-oracle-bmcs'
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"
@@ -28,3 +28,4 @@ def setBuildFile(project) {
 rootProject.children.each {
   setBuildFile(it)
 }
+


### PR DESCRIPTION
Note that we manually download our SDK and add to classpath in our gradle build script. We did this in clouddriver too. This will be fixed once
our SDK is available on Maven central - soon(ish).

Also note that due to the Front50 classpath containing Jersey 1 (brought in by kork IIRC?) we've had to not use our SDK's Jersey 2 based storage
client and instead create a minimal Jersey 1 implementation. Hopefully this can be improved upon in the future either by bumping kork to use
Jersey 2?