### PR TITLE
chore(dependencies): Bump spinnaker-dependencies to 0.101.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects { project ->
   group = "com.netflix.spinnaker.front50"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.91.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.101.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.front50.exception.BadRequestException
+import com.netflix.spinnaker.front50.exceptions.AccessDeniedExceptionHandler
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
@@ -114,6 +115,11 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
     return new HystrixRuntimeExceptionHandler()
   }
 
+  @Bean
+  AccessDeniedExceptionHandler accessDeniedExceptionHandler() {
+    return new AccessDeniedExceptionHandler()
+  }
+
   @ControllerAdvice
   static class HystrixRuntimeExceptionHandler {
     @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
@@ -129,16 +135,6 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
           status           : HttpStatus.TOO_MANY_REQUESTS.value(),
           timestamp        : System.currentTimeMillis()
       ]
-    }
-  }
-
-  @ControllerAdvice
-  static class BadRequestExceptionHandler {
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ResponseBody
-    @ExceptionHandler(BadRequestException)
-    void handleBadRequest(BadRequestException exception, HttpServletResponse response) {
-      response.sendError(HttpStatus.BAD_REQUEST.value(), exception.message)
     }
   }
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/NotificationController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/NotificationController.groovy
@@ -16,20 +16,17 @@
 
 package com.netflix.spinnaker.front50.controllers
 
+import com.netflix.spinnaker.front50.exception.NotFoundException
 import com.netflix.spinnaker.front50.model.notification.HierarchicalLevel
 import com.netflix.spinnaker.front50.model.notification.Notification
 import com.netflix.spinnaker.front50.model.notification.NotificationDAO
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
-import org.springframework.context.i18n.LocaleContextHolder
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -121,19 +118,8 @@ class NotificationController {
     private static HierarchicalLevel getLevel(String type) {
         HierarchicalLevel result = HierarchicalLevel.fromString(type)
         if (!result) {
-            throw new HierarchicalLevelNotFoundException(type: type)
+            throw new NotFoundException("No hierarchical level matches '${type}'")
         }
         result
-    }
-
-    static class HierarchicalLevelNotFoundException extends RuntimeException {
-        String type
-    }
-
-    @ExceptionHandler
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    Map hierarchicalLevelNotFoundExceptionHandler(HierarchicalLevelNotFoundException ex) {
-        def message = messageSource.getMessage("level.not.found", [ex.type] as String[], "No hierarchical level matches '${ex.type}'", LocaleContextHolder.locale)
-        [error: "level.not.found", message: message, status: HttpStatus.NOT_FOUND]
     }
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateController.java
@@ -17,22 +17,19 @@ package com.netflix.spinnaker.front50.controllers;
 
 import com.netflix.spinnaker.front50.exception.BadRequestException;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.exceptions.DuplicateEntityException;
+import com.netflix.spinnaker.front50.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("pipelineTemplates")
@@ -63,7 +60,7 @@ public class PipelineTemplateController {
   PipelineTemplate update(@PathVariable String id, @RequestBody PipelineTemplate pipelineTemplate) {
     PipelineTemplate existingPipelineTemplate = getPipelineTemplateDAO().findById(id);
     if (!pipelineTemplate.getId().equals(existingPipelineTemplate.getId())) {
-      throw new InvalidPipelineTemplateRequestException("The provided id " + id + " doesn't match the pipeline template id " + pipelineTemplate.getId());
+      throw new InvalidRequestException("The provided id " + id + " doesn't match the pipeline template id " + pipelineTemplate.getId());
     }
 
     pipelineTemplate.setLastModified(System.currentTimeMillis());
@@ -78,7 +75,7 @@ public class PipelineTemplateController {
     } catch (NotFoundException e) {
       return;
     }
-    throw new DuplicatePipelineTemplateIdException("A pipeline template with the id " + id + " already exists");
+    throw new DuplicateEntityException("A pipeline template with the id " + id + " already exists");
   }
 
   private PipelineTemplateDAO getPipelineTemplateDAO() {
@@ -87,35 +84,4 @@ public class PipelineTemplateController {
     }
     return pipelineTemplateDAO;
   }
-
-  @ExceptionHandler(InvalidPipelineTemplateRequestException.class)
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map handleInvalidPipelineTemplateRequestException(InvalidPipelineTemplateRequestException e) {
-    Map<String, Object> m = new HashMap<>();
-    m.put("error", e.getMessage());
-    m.put("status", HttpStatus.BAD_REQUEST);
-    return m;
-  }
-
-  @ExceptionHandler(DuplicatePipelineTemplateIdException.class)
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map handleDuplicatePipelineTemplateIdException(DuplicatePipelineTemplateIdException e) {
-    Map<String, Object> m = new HashMap<>();
-    m.put("error", e.getMessage());
-    m.put("status", HttpStatus.BAD_REQUEST);
-    return m;
-  }
-
-  static class InvalidPipelineTemplateRequestException extends RuntimeException {
-    InvalidPipelineTemplateRequestException(String message) {
-      super(message);
-    }
-  }
-
-  static class DuplicatePipelineTemplateIdException extends RuntimeException {
-    DuplicatePipelineTemplateIdException(String message) {
-      super(message);
-    }
-  }
-
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/SnapshotsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/SnapshotsController.groovy
@@ -16,25 +16,20 @@
 
 package com.netflix.spinnaker.front50.controllers
 
+import com.netflix.spinnaker.front50.exceptions.InvalidEntityException
 import com.netflix.spinnaker.front50.model.snapshot.Snapshot
 import com.netflix.spinnaker.front50.model.snapshot.SnapshotDAO
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
-import org.springframework.http.HttpStatus
-import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-
-import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 
 @RestController
 @RequestMapping("/snapshots")
@@ -73,23 +68,9 @@ class SnapshotsController {
     @RequestMapping(value = "", method = RequestMethod.POST)
     void save(@RequestBody Snapshot snapshot) {
         if (!snapshot.application || !snapshot.account) {
-            throw new InvalidSnapshotDefinition()
+            throw new InvalidEntityException("A snapshot requires application and account fields")
         }
         String id = "$snapshot.application-$snapshot.account"
         snapshotDAO.create(id, snapshot)
     }
-
-    @ExceptionHandler(InvalidSnapshotDefinition)
-    @ResponseStatus(UNPROCESSABLE_ENTITY)
-    Map handleInvalidSnapshotDefinition() {
-        return [error: "A snapshot requires application and account fields", status: UNPROCESSABLE_ENTITY]
-    }
-
-    @ExceptionHandler(AccessDeniedException)
-    @ResponseStatus(HttpStatus.FORBIDDEN)
-    Map handleAccessDeniedException(AccessDeniedException ade) {
-        return [error: "Access is denied", status: HttpStatus.FORBIDDEN.value()]
-    }
-
-    static class InvalidSnapshotDefinition extends Exception {}
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.HttpStatus
-import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
@@ -140,12 +139,6 @@ public class ApplicationsController {
       }
     }
     return [error: "Validation Failed.", errors: errorStrings, status: HttpStatus.BAD_REQUEST]
-  }
-
-  @ExceptionHandler(AccessDeniedException)
-  @ResponseStatus(HttpStatus.FORBIDDEN)
-  Map handleAccessDeniedException(AccessDeniedException ade) {
-    return [error: "Access is denied", status: HttpStatus.FORBIDDEN.value()]
   }
 
   private Application getApplication() {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/AccessDeniedExceptionHandler.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/AccessDeniedExceptionHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.exceptions;
+
+import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@ControllerAdvice
+public class AccessDeniedExceptionHandler {
+  private final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes();
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public void handleNotFoundException(Exception e, HttpServletResponse response, HttpServletRequest request) throws IOException {
+    storeException(request, response, e);
+    response.sendError(HttpStatus.FORBIDDEN.value(), "Access is denied");
+  }
+
+  private void storeException(HttpServletRequest request, HttpServletResponse response, Exception ex) {
+    // store exception as an attribute of HttpServletRequest such that it can be referenced by GenericErrorController
+    defaultErrorAttributes.resolveException(request, response, null, ex);
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/DuplicateEntityException.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/DuplicateEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+package com.netflix.spinnaker.front50.exceptions;
 
-package com.netflix.spinnaker.front50.controllers.exception
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import groovy.transform.InheritConstructors
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ResponseStatus
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
-@InheritConstructors
-@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "No applications found")
-class NoApplicationsFoundException extends RuntimeException {}
+@ResponseStatus(BAD_REQUEST)
+public class DuplicateEntityException extends RuntimeException {
+  public DuplicateEntityException(String message) {
+    super(message);
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/InvalidEntityException.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/InvalidEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+package com.netflix.spinnaker.front50.exceptions;
 
-package com.netflix.spinnaker.front50.controllers.exception
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import groovy.transform.InheritConstructors
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ResponseStatus
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
-@InheritConstructors
-@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Application not found")
-class ApplicationNotFoundException extends RuntimeException {}
+@ResponseStatus(UNPROCESSABLE_ENTITY)
+public class InvalidEntityException extends RuntimeException {
+  public InvalidEntityException(String message) {
+    super(message);
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/InvalidRequestException.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/exceptions/InvalidRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+package com.netflix.spinnaker.front50.exceptions;
 
-package com.netflix.spinnaker.front50.controllers.exception
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import groovy.transform.InheritConstructors
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ResponseStatus
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
-@InheritConstructors
-@ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE, reason = "Exception, baby")
-class ApplicationException extends RuntimeException {}
+@ResponseStatus(BAD_REQUEST)
+public class InvalidRequestException extends RuntimeException {
+  public InvalidRequestException(String message) {
+    super(message);
+  }
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/SimpleExceptionHandlerExceptionResolver.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/SimpleExceptionHandlerExceptionResolver.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver
+import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod
+
+import java.lang.reflect.Method;
+
+class SimpleExceptionHandlerExceptionResolver extends ExceptionHandlerExceptionResolver {
+  protected ServletInvocableHandlerMethod getExceptionHandlerMethod(HandlerMethod handlerMethod, Exception exception) {
+    Method method = new ExceptionHandlerMethodResolver(GenericExceptionHandlers.class).resolveMethod(exception);
+    return new ServletInvocableHandlerMethod(new GenericExceptionHandlers(), method);
+  }
+}


### PR DESCRIPTION
The generic exception handling from `kork-web` allows us to remove nearly
all examples of custom ``@ExceptionHandler` in front50.

Custom handling for `Application.ValidationException` remains and requires
further work in `kork` to fully eliminate.