### PR TITLE
feat(pipeline_template): delete template

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/Pipeline.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/Pipeline.groovy
@@ -66,4 +66,24 @@ class Pipeline extends HashMap<String, Object> implements Timestamped {
   void setLastModifiedBy(String lastModifiedBy) {
     super.put("lastModifiedBy", lastModifiedBy)
   }
+
+  @JsonIgnore
+  Object getConfig() {
+    return super.get("config")
+  }
+
+  @JsonIgnore
+  void setConfig(Object config) {
+    super.put("config", config)
+  }
+
+  @JsonIgnore
+  String getType() {
+    return super.get("type")
+  }
+
+  @JsonIgnore
+  void setType(String type) {
+    super.put("type", type)
+  }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineTemplate.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineTemplate.java
@@ -45,6 +45,8 @@ public class PipelineTemplate extends HashMap<String, Object> implements Timesta
     return (String) super.get("id");
   }
 
+  public void setId(String id) { super.put("id", id); }
+
   @Override
   public Long getLastModified() {
     String updateTs = (String) super.get("updateTs");
@@ -84,4 +86,8 @@ public class PipelineTemplate extends HashMap<String, Object> implements Timesta
     }
     return false;
   }
+
+  public String getSource() { return (String) super.get("source"); }
+
+  public void setSource(String source) { super.put("source", source); }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/TemplateConfiguration.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/TemplateConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.pipeline;
+
+public class TemplateConfiguration {
+
+  private PipelineDefinition pipeline;
+
+  public PipelineDefinition getPipeline() { return pipeline; }
+
+  public void setPipeline(PipelineDefinition pipeline) { this.pipeline = pipeline; }
+
+  public static class PipelineDefinition {
+
+    private TemplateSource template;
+
+    public TemplateSource getTemplate() { return template; }
+
+    public void setTemplate(TemplateSource template) { this.template = template; }
+  }
+
+  public static class TemplateSource {
+
+    private String source;
+
+    public String getSource() { return source; }
+
+    public void setSource(String source) { this.source = source; }
+  }
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateControllerSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.exceptions.InvalidRequestException
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate
+import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PipelineTemplateControllerSpec extends Specification {
+  def pipelineDAO = Mock(PipelineDAO)
+  def pipelineTemplateDAO = Mock(PipelineTemplateDAO)
+
+  @Subject
+  def controller = new PipelineTemplateController(
+    pipelineDAO: pipelineDAO,
+    pipelineTemplateDAO: pipelineTemplateDAO,
+    objectMapper: new ObjectMapper(),
+  )
+
+  def "should reject delete request if template has dependent configs"() {
+    given:
+    def templateId = "myTemplate"
+    def pipeline = new Pipeline(
+      type: "templatedPipeline",
+      config: [
+        pipeline: [
+          template: [
+            source: "spinnaker://myTemplate"
+          ]
+        ]
+      ]
+    )
+
+    when:
+    pipelineDAO.all() >> { [pipeline] }
+    controller.checkForDependentConfigs(templateId)
+
+    then:
+    thrown(InvalidRequestException)
+  }
+
+  def "should reject delete request if template has dependent templates"() {
+    given:
+    def templateId = "myTemplate"
+    def pipelineTemplate = new PipelineTemplate(
+      id: "myDependentTemplate",
+      source: "spinnaker://myTemplate"
+    )
+
+    when:
+    pipelineTemplateDAO.all() >> { [pipelineTemplate] }
+    controller.checkForDependentTemplates(templateId)
+
+    then:
+    thrown(InvalidRequestException)
+  }
+}


### PR DESCRIPTION
@robzienert I was going to put the check for dependent pipeline configs in Orca, but realized that wouldn't work for anyone using Fiat without read access to all applications.
