### PR TITLE
perf(core): Debounce concurrent cache refreshes

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -168,6 +168,7 @@ public class S3StorageService implements StorageService {
 
   @Override
   public Map<String, Long> listObjectKeys(ObjectType objectType) {
+    long startTime = System.currentTimeMillis();
     ObjectListing bucketListing = amazonS3.listObjects(
       new ListObjectsRequest(bucket, buildTypedFolder(rootFolder, objectType.group), null, null, 10000)
     );
@@ -177,6 +178,8 @@ public class S3StorageService implements StorageService {
       bucketListing = amazonS3.listNextBatchOfObjects(bucketListing);
       summaries.addAll(bucketListing.getObjectSummaries());
     }
+
+    log.debug("Took {}ms to fetch {} object keys for {}", (System.currentTimeMillis() - startTime), summaries.size(), objectType);
 
     return summaries
       .stream()


### PR DESCRIPTION
This is a step towards reducing the number of times that `listObjectKeys()`
is called in response to a stale cache being detected.

A loading cache as been added in front `listObjectKeys()`.

As such, loads are restricted to a single thread with all others
blocking and autocompleting after the load completes (provided the last
modified time of the object type remains constant).

This is low hanging fruit that should provide some benefit to anyone
with larger buckets (10k+ pipelines, applications, etc.) and reasonably
high request rates.
