### PR TITLE
feat(s3): Allow to disable versioning via config

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Lists;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
@@ -180,7 +181,11 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
   }
 
   public Collection<T> history(String id, int maxResults) {
-    return service.listObjectVersions(objectType, id, maxResults);
+    if (service.supportsVersioning()) {
+      return service.listObjectVersions(objectType, id, maxResults);
+    } else {
+      return Lists.newArrayList(findById(id));
+    }
   }
 
   /**

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
@@ -23,6 +23,7 @@ public class S3BucketProperties {
   private String proxyHost;
   private String proxyPort;
   private String proxyProtocol;
+  private Boolean versioning = true; // enabled by default
 
   public String getBucket() {
     return bucket;
@@ -71,4 +72,8 @@ public class S3BucketProperties {
   public void setProxyProtocol(String proxyProtocol) {
     this.proxyProtocol = proxyProtocol;
   }
+
+  public Boolean getVersioning() { return versioning; }
+
+  public void setVersioning(Boolean versioning) { this.versioning = versioning; }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -75,7 +75,9 @@ public class S3Config extends CommonStorageServiceDAOConfig {
     ObjectMapper awsObjectMapper = new ObjectMapper();
     AmazonObjectMapperConfigurer.configure(awsObjectMapper);
 
-    S3StorageService service = new S3StorageService(awsObjectMapper, amazonS3, s3Properties.getBucket(), s3Properties.getRootFolder(), s3Properties.isFailoverEnabled(), s3Properties.getRegion());
+    S3StorageService service = new S3StorageService(awsObjectMapper, amazonS3, s3Properties.getBucket(),
+                                                    s3Properties.getRootFolder(), s3Properties.isFailoverEnabled(),
+                                                    s3Properties.getRegion(), s3Properties.getVersioning());
     service.ensureBucketExists();
     return service;
   }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -93,4 +93,13 @@ public class S3Properties extends S3BucketProperties {
     }
     return super.getProxyProtocol();
   }
+
+  @Override
+  public Boolean getVersioning() {
+    if (isFailoverEnabled()) {
+      return failover.getVersioning();
+    }
+
+    return super.getVersioning();
+  }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -43,19 +43,22 @@ public class S3StorageService implements StorageService {
   private final String rootFolder;
   private final Boolean readOnlyMode;
   private final String region;
+  private final Boolean versioning;
 
   public S3StorageService(ObjectMapper objectMapper,
                           AmazonS3 amazonS3,
                           String bucket,
                           String rootFolder,
                           Boolean readOnlyMode,
-                          String region) {
+                          String region,
+                          Boolean versioning) {
     this.objectMapper = objectMapper;
     this.amazonS3 = amazonS3;
     this.bucket = bucket;
     this.rootFolder = rootFolder;
     this.readOnlyMode = readOnlyMode;
     this.region = region;
+    this.versioning = versioning;
   }
 
   @Override
@@ -73,14 +76,16 @@ public class S3StorageService implements StorageService {
           amazonS3.createBucket(bucket, region);
         }
 
-        log.info("Enabling versioning of the S3 bucket " + bucket);
-        BucketVersioningConfiguration configuration =
+        if (versioning) {
+          log.info("Enabling versioning of the S3 bucket " + bucket);
+          BucketVersioningConfiguration configuration =
             new BucketVersioningConfiguration().withStatus("Enabled");
 
-        SetBucketVersioningConfigurationRequest setBucketVersioningConfigurationRequest =
+          SetBucketVersioningConfigurationRequest setBucketVersioningConfigurationRequest =
             new SetBucketVersioningConfigurationRequest(bucket, configuration);
 
-        amazonS3.setBucketVersioningConfiguration(setBucketVersioningConfigurationRequest);
+          amazonS3.setBucketVersioningConfiguration(setBucketVersioningConfigurationRequest);
+        }
 
       } else {
         throw e;
@@ -90,7 +95,7 @@ public class S3StorageService implements StorageService {
 
   @Override
   public boolean supportsVersioning() {
-    return true;
+    return versioning;
   }
 
   @Override


### PR DESCRIPTION
[Minio s3](https://github.com/minio/minio) compatible storage [isn't supporting versioning](https://github.com/minio/minio/issues/2111) and this causes some issues when using it as storage backend for front50. So, I think it's nice idea to make versioning configurable in configuration file, so if someone is using s3 compatible storage that isn't supporting this, it would be easy to disable it.

As an alternative option, will be autodetection of versioning support on storage, but this might not work well on many different s3 compatible storages.