### PR TITLE
feat(core): Introduce ObjectKeyLoader interface

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.front50.config;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
@@ -38,6 +40,7 @@ import com.netflix.spinnaker.front50.model.snapshot.DefaultSnapshotDAO;
 import com.netflix.spinnaker.front50.model.snapshot.SnapshotDAO;
 import com.netflix.spinnaker.front50.model.tag.DefaultEntityTagsDAO;
 import com.netflix.spinnaker.front50.model.tag.EntityTagsDAO;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import rx.schedulers.Schedulers;
 
@@ -45,12 +48,20 @@ import java.util.concurrent.Executors;
 
 public class CommonStorageServiceDAOConfig {
   @Bean
+  @ConditionalOnMissingBean(ObjectKeyLoader.class)
+  ObjectKeyLoader defaultObjectKeyLoader(StorageService storageService) {
+    return new DefaultObjectKeyLoader(storageService);
+  }
+
+  @Bean
   ApplicationDAO applicationDAO(StorageService storageService,
                                 StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                ObjectKeyLoader objectKeyLoader,
                                 Registry registry) {
     return new DefaultApplicationDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getApplication().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getApplication().getRefreshMs(),
       storageServiceConfigurationProperties.getApplication().getShouldWarmCache(),
       registry
@@ -60,10 +71,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   ApplicationPermissionDAO applicationPermissionDAO(StorageService storageService,
                                                     StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                                    ObjectKeyLoader objectKeyLoader,
                                                     Registry registry) {
     return new DefaultApplicationPermissionDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
       storageServiceConfigurationProperties.getApplicationPermission().getShouldWarmCache(),
       registry
@@ -73,10 +86,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   ServiceAccountDAO serviceAccountDAO(StorageService storageService,
                                       StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                      ObjectKeyLoader objectKeyLoader,
                                       Registry registry) {
     return new DefaultServiceAccountDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getServiceAccount().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getServiceAccount().getRefreshMs(),
       storageServiceConfigurationProperties.getServiceAccount().getShouldWarmCache(),
       registry
@@ -86,10 +101,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   ProjectDAO projectDAO(StorageService storageService,
                         StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                        ObjectKeyLoader objectKeyLoader,
                         Registry registry) {
     return new DefaultProjectDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getProject().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getProject().getRefreshMs(),
       storageServiceConfigurationProperties.getProject().getShouldWarmCache(),
       registry
@@ -99,10 +116,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   NotificationDAO notificationDAO(StorageService storageService,
                                   StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                  ObjectKeyLoader objectKeyLoader,
                                   Registry registry) {
     return new DefaultNotificationDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getNotification().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getNotification().getRefreshMs(),
       storageServiceConfigurationProperties.getNotification().getShouldWarmCache(),
       registry
@@ -112,10 +131,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   PipelineStrategyDAO pipelineStrategyDAO(StorageService storageService,
                                           StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                          ObjectKeyLoader objectKeyLoader,
                                           Registry registry) {
     return new DefaultPipelineStrategyDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getPipelineStrategy().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getPipelineStrategy().getRefreshMs(),
       storageServiceConfigurationProperties.getPipelineStrategy().getShouldWarmCache(),
       registry
@@ -125,10 +146,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   PipelineDAO pipelineDAO(StorageService storageService,
                           StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                          ObjectKeyLoader objectKeyLoader,
                           Registry registry) {
     return new DefaultPipelineDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getPipeline().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getPipeline().getRefreshMs(),
       storageServiceConfigurationProperties.getPipeline().getShouldWarmCache(),
       registry
@@ -138,10 +161,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   PipelineTemplateDAO pipelineTemplateDAO(StorageService storageService,
                                           StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                          ObjectKeyLoader objectKeyLoader,
                                           Registry registry) {
     return new DefaultPipelineTemplateDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getPipelineTemplate().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getPipelineTemplate().getRefreshMs(),
       storageServiceConfigurationProperties.getPipelineTemplate().getShouldWarmCache(),
       registry
@@ -151,10 +176,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   SnapshotDAO snapshotDAO(StorageService storageService,
                           StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                          ObjectKeyLoader objectKeyLoader,
                           Registry registry) {
     return new DefaultSnapshotDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getSnapshot().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getSnapshot().getRefreshMs(),
       storageServiceConfigurationProperties.getSnapshot().getShouldWarmCache(),
       registry
@@ -164,10 +191,12 @@ public class CommonStorageServiceDAOConfig {
   @Bean
   EntityTagsDAO entityTagsDAO(StorageService storageService,
                               StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                              ObjectKeyLoader objectKeyLoader,
                               Registry registry) {
     return new DefaultEntityTagsDAO(
       storageService,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getEntityTags().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getEntityTags().getRefreshMs(),
       storageServiceConfigurationProperties.getEntityTags().getShouldWarmCache(),
       registry

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/DefaultObjectKeyLoader.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/DefaultObjectKeyLoader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import java.util.Map;
+
+public class DefaultObjectKeyLoader implements ObjectKeyLoader {
+  private final StorageService storageService;
+
+  public DefaultObjectKeyLoader(StorageService storageService) {
+    this.storageService = storageService;
+  }
+
+  @Override
+  public Map<String, Long> listObjectKeys(ObjectType objectType) {
+    return storageService.listObjectKeys(objectType);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectKeyLoader.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectKeyLoader.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import java.util.Map;
+
+public interface ObjectKeyLoader {
+  /**
+   * @param objectType ObjectType
+   * @return Key -> Last Modified Timestamp for all keys of type {@code ObjectType}
+   */
+  Map<String, Long> listObjectKeys(ObjectType objectType);
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.application;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -29,10 +30,11 @@ import java.util.Map;
 public class DefaultApplicationDAO extends StorageServiceSupport<Application> implements ApplicationDAO {
   public DefaultApplicationDAO(StorageService service,
                                Scheduler scheduler,
+                               ObjectKeyLoader objectKeyLoader,
                                long refreshIntervalMs,
                                boolean shouldWarmCache,
                                Registry registry) {
-    super(ObjectType.APPLICATION, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.APPLICATION, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.application;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -25,10 +26,11 @@ import rx.Scheduler;
 public class DefaultApplicationPermissionDAO extends StorageServiceSupport<Application.Permission> implements ApplicationPermissionDAO {
   public DefaultApplicationPermissionDAO(StorageService service,
                                          Scheduler scheduler,
+                                         ObjectKeyLoader objectKeyLoader,
                                          long refreshIntervalMs,
                                          boolean shouldWarmCache,
                                          Registry registry) {
-    super(ObjectType.APPLICATION_PERMISSION, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.APPLICATION_PERMISSION, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/notification/DefaultNotificationDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/notification/DefaultNotificationDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.notification;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -26,10 +27,11 @@ import rx.Scheduler;
 public class DefaultNotificationDAO extends StorageServiceSupport<Notification> implements NotificationDAO {
   public DefaultNotificationDAO(StorageService service,
                                 Scheduler scheduler,
+                                ObjectKeyLoader objectKeyLoader,
                                 long refreshIntervalMs,
                                 boolean shouldWarmCache,
                                 Registry registry) {
-    super(ObjectType.NOTIFICATION, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.NOTIFICATION, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.pipeline;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -31,10 +32,11 @@ import java.util.stream.Collectors;
 public class DefaultPipelineDAO extends StorageServiceSupport<Pipeline> implements PipelineDAO {
   public DefaultPipelineDAO(StorageService service,
                             Scheduler scheduler,
+                            ObjectKeyLoader objectKeyLoader,
                             long refreshIntervalMs,
                             boolean shouldWarmCache,
                             Registry registry) {
-    super(ObjectType.PIPELINE, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.PIPELINE, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.pipeline;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -30,10 +31,11 @@ import java.util.stream.Collectors;
 public class DefaultPipelineStrategyDAO extends StorageServiceSupport<Pipeline> implements PipelineStrategyDAO {
   public DefaultPipelineStrategyDAO(StorageService service,
                                     Scheduler scheduler,
+                                    ObjectKeyLoader objectKeyLoader,
                                     long refreshIntervalMs,
                                     boolean shouldWarmCache,
                                     Registry registry) {
-    super(ObjectType.STRATEGY, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.STRATEGY, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineTemplateDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineTemplateDAO.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.front50.model.pipeline;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -30,10 +31,11 @@ public class DefaultPipelineTemplateDAO extends StorageServiceSupport<PipelineTe
 
   public DefaultPipelineTemplateDAO(StorageService service,
                                     Scheduler scheduler,
+                                    ObjectKeyLoader objectKeyLoader,
                                     long refreshIntervalMs,
                                     boolean shouldWarmCache,
                                     Registry registry) {
-    super(ObjectType.PIPELINE_TEMPLATE, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.PIPELINE_TEMPLATE, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.project;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -28,10 +29,11 @@ import java.util.UUID;
 public class DefaultProjectDAO extends StorageServiceSupport<Project> implements ProjectDAO {
   public DefaultProjectDAO(StorageService service,
                            Scheduler scheduler,
+                           ObjectKeyLoader objectKeyLoader,
                            long refreshIntervalMs,
                            boolean shouldWarmCache,
                            Registry registry) {
-    super(ObjectType.PROJECT, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.PROJECT, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.serviceaccount;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -25,10 +26,11 @@ import rx.Scheduler;
 public class DefaultServiceAccountDAO extends StorageServiceSupport<ServiceAccount> implements ServiceAccountDAO {
   public DefaultServiceAccountDAO(StorageService service,
                                   Scheduler scheduler,
+                                  ObjectKeyLoader objectKeyLoader,
                                   long refreshIntervalMs,
                                   boolean shouldWarmCache,
                                   Registry registry) {
-    super(ObjectType.SERVICE_ACCOUNT, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.SERVICE_ACCOUNT, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.snapshot;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -28,10 +29,11 @@ import java.util.Collection;
 public class DefaultSnapshotDAO extends StorageServiceSupport<Snapshot> implements SnapshotDAO {
   public DefaultSnapshotDAO(StorageService service,
                             Scheduler scheduler,
+                            ObjectKeyLoader objectKeyLoader,
                             long refreshIntervalMs,
                             boolean shouldWarmCache,
                             Registry registry) {
-    super(ObjectType.SNAPSHOT, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.SNAPSHOT, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.tag;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
 import com.netflix.spinnaker.front50.model.StorageServiceSupport;
@@ -28,10 +29,11 @@ import java.util.concurrent.TimeUnit;
 public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags> implements EntityTagsDAO {
   public DefaultEntityTagsDAO(StorageService service,
                               Scheduler scheduler,
+                              ObjectKeyLoader objectKeyLoader,
                               long refreshIntervalMs,
                               boolean shouldWarmCache,
                               Registry registry) {
-    super(ObjectType.ENTITY_TAGS, service, scheduler, refreshIntervalMs, shouldWarmCache, registry);
+    super(ObjectType.ENTITY_TAGS, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
   }
 
   @Override

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -110,11 +110,13 @@ public class GcsConfig extends CommonStorageServiceDAOConfig {
   @Override
   public ApplicationPermissionDAO applicationPermissionDAO(StorageService storageService,
                                                            StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                                                           ObjectKeyLoader objectKeyLoader,
                                                            Registry registry) {
     GcsStorageService service = googleCloudStorageService(ApplicationPermissionDAO.DEFAULT_DATA_FILENAME, gcsProperties);
     return new DefaultApplicationPermissionDAO(
       service,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
+      objectKeyLoader,
       storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
       storageServiceConfigurationProperties.getApplicationPermission().getShouldWarmCache(),
       registry


### PR DESCRIPTION
This will allow cloud providers / implementors to provide alternative
more optimized loads for object metadata (key -> last modified time).

The default implementation is to call `storageService.listObjectKeys()`
directly.
