### PR TITLE
fix(pipelines): sort and apply unique index on application pipelines

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -54,7 +54,21 @@ class PipelineController {
   @RequestMapping(value = '{application:.+}', method = RequestMethod.GET)
   List<Pipeline> listByApplication(@PathVariable(value = 'application') String application,
                                    @RequestParam(required = false, value = 'refresh', defaultValue = 'true') boolean refresh) {
-    pipelineDAO.getPipelinesByApplication(application, refresh)
+    List<Pipeline> pipelines = pipelineDAO.getPipelinesByApplication(application, refresh)
+    pipelines.sort { p1, p2 ->
+      if (p1.index != null && p2.index == null) {
+        return -1
+      }
+      if (p1.index == null && p2.index != null) {
+        return 1
+      }
+      if (p1.index != p2.index) {
+        return p1.index - p2.index
+      }
+      return (p1.getName() ?: p1.getId()).compareToIgnoreCase(p2.getName() ?: p2.getId())
+    }
+    pipelines.eachWithIndex{ Pipeline entry, int i -> entry.index = i }
+    return pipelines
   }
 
   @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")


### PR DESCRIPTION
@ajordens PTAL

There's nothing enforcing unique index fields on pipeline configs, which can cause problems when Deck retrieves the configs and finds them missing, as it'll try to correct the issue by adding a unique index and re-saving the pipeline config.

This should still return the pipeline configs in a stable order, with ones that have an explicit index before others, sorting by name and id as fallbacks.