### PR TITLE
feat(aws): Support for incremental cache updates based on s3 events

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
@@ -104,31 +104,6 @@ public class AzureStorageService implements StorageService {
   }
 
   @Override
-  public <T extends Timestamped> Collection<T> loadObjectsWithPrefix(ObjectType objectType, String prefix, int maxResults) {
-    Set<T> blobs = new HashSet<>();
-    String key = buildKeyPath(objectType.group, prefix, "");
-    try {
-      ResultContinuation token = null;
-      EnumSet<BlobListingDetails> listDetails = EnumSet.of(BlobListingDetails.METADATA);
-      do {
-        ResultSegment<ListBlobItem> result = blobContainer.listBlobsSegmented(key, true, listDetails, maxResults, token, null, null);
-        token = result.getContinuationToken();
-
-        for (ListBlobItem item : result.getResults()) {
-          blobs.add(deserialize((CloudBlockBlob)item, (Class<T>) objectType.clazz));
-        }
-      } while (token != null);
-    } catch (IOException e) {
-      throw new IllegalStateException("Unable to deserialize object(s) (key: " + key + ")", e);
-    } catch (StorageException se) {
-      logStorageException(se, key);
-    } catch (Exception e) {
-      log.error("Failed to retrieve objects with prefix {}: {}", key, e.getMessage());
-    }
-    return blobs;
-  }
-
-  @Override
   public void deleteObject(ObjectType objectType, String objectKey) {
     String key = buildKeyPath(objectType.group, objectKey, objectType.defaultMetadataFilename);
     try {

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectKeyLoader.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectKeyLoader.java
@@ -24,4 +24,8 @@ public interface ObjectKeyLoader {
    * @return Key: Last Modified Timestamp for all keys of type {@code ObjectType}
    */
   Map<String, Long> listObjectKeys(ObjectType objectType);
+
+  default void shutdown() {
+    // do nothing
+  }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
@@ -34,8 +34,6 @@ public interface StorageService {
    */
   boolean supportsVersioning();
 
-  <T extends Timestamped> Collection<T> loadObjectsWithPrefix(ObjectType objectType, String prefix, int maxResults);
-
   <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) throws NotFoundException;
 
   void deleteObject(ObjectType objectType, String objectKey);

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -281,11 +281,6 @@ public class GcsStorageService implements StorageService {
   }
 
   @Override
-  public <T extends Timestamped> Collection<T> loadObjectsWithPrefix(ObjectType objectType, String prefix, int maxResults) {
-    throw new UnsupportedOperationException("loadObjectsWithPrefix is not yet supported!");
-  }
-
-  @Override
   public <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) throws NotFoundException {
     String path = keyToPath(objectKey, objectType.group);
     try {

--- a/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/OracleBMCSStorageService.java
+++ b/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/OracleBMCSStorageService.java
@@ -115,23 +115,6 @@ public class OracleBMCSStorageService implements StorageService {
   }
 
   @Override
-  public <T extends Timestamped> Collection<T> loadObjectsWithPrefix(ObjectType objectType, String prefix, int maxResults) {
-    WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o")
-            .queryParam("prefix", prefix)
-            .build(region, namespace, bucketName));
-    wr.accept(MediaType.APPLICATION_JSON_TYPE);
-    ListObjects listObjects = wr.get(ListObjects.class);
-
-    Collection<T> objects = new ArrayList<>(listObjects.getObjects().size());
-    for (ObjectSummary summary : listObjects.getObjects()) {
-      if (summary.getName().endsWith(objectType.defaultMetadataFilename)) {
-        objects.add(loadObject(objectType, summary.getName()));
-      }
-    }
-    return objects;
-  }
-
-  @Override
   public <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) throws NotFoundException {
     WebResource wr = client.resource(UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o/{arg3}")
             .build(region, namespace, bucketName, buildOSSKey(objectType.group, objectKey, objectType.defaultMetadataFilename)));

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -8,19 +8,30 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
 import com.netflix.spinnaker.clouddriver.aws.bastion.BastionConfig;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.front50.model.EventingS3ObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.S3StorageService;
+import com.netflix.spinnaker.front50.model.TemporarySQSQueue;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Optional;
 
 @Configuration
@@ -65,20 +76,96 @@ public class S3Config extends CommonStorageServiceDAOConfig {
   }
 
   @Bean
+  public AmazonSQS awsSQSClient(AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
+    return AmazonSQSClientBuilder
+      .standard()
+      .withCredentials(awsCredentialsProvider)
+      .withClientConfiguration(new ClientConfiguration())
+      .withRegion(s3Properties.getRegion())
+      .build();
+  }
+
+  @Bean
+  public AmazonSNS awsSNSClient(AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
+    return AmazonSNSClientBuilder
+      .standard()
+      .withCredentials(awsCredentialsProvider)
+      .withClientConfiguration(new ClientConfiguration())
+      .withRegion(s3Properties.getRegion())
+      .build();
+  }
+
+  @Bean
   @ConditionalOnMissingBean(RestTemplate.class)
   public RestTemplate restTemplate() {
     return new RestTemplate();
   }
 
   @Bean
-  public S3StorageService s3StorageService(AmazonS3 amazonS3, S3Properties s3Properties) {
+  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
+  public TemporarySQSQueue temporaryQueueSupport(Optional<ApplicationInfoManager> applicationInfoManager,
+                                                 AmazonSQS amazonSQS,
+                                                 AmazonSNS amazonSNS,
+                                                 S3Properties s3Properties) {
+    return new TemporarySQSQueue(
+      amazonSQS,
+      amazonSNS,
+      s3Properties.eventing.getSnsTopicName(),
+      getInstanceId(applicationInfoManager)
+    );
+  }
+
+  @Bean
+  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
+  public ObjectKeyLoader eventingS3ObjectKeyLoader(TaskScheduler taskScheduler,
+                                                   ObjectMapper objectMapper,
+                                                   S3Properties s3Properties,
+                                                   S3StorageService s3StorageService,
+                                                   TemporarySQSQueue temporaryQueueSupport) {
+    return new EventingS3ObjectKeyLoader(
+      taskScheduler,
+      objectMapper,
+      s3Properties,
+      temporaryQueueSupport,
+      s3StorageService,
+      true
+    );
+  }
+
+  @Bean
+  public S3StorageService s3StorageService(AmazonS3 amazonS3,
+                                           S3Properties s3Properties) {
     ObjectMapper awsObjectMapper = new ObjectMapper();
     AmazonObjectMapperConfigurer.configure(awsObjectMapper);
 
-    S3StorageService service = new S3StorageService(awsObjectMapper, amazonS3, s3Properties.getBucket(),
-                                                    s3Properties.getRootFolder(), s3Properties.isFailoverEnabled(),
-                                                    s3Properties.getRegion(), s3Properties.getVersioning());
+    S3StorageService service = new S3StorageService(
+      awsObjectMapper,
+      amazonS3,
+      s3Properties.getBucket(),
+      s3Properties.getRootFolder(),
+      s3Properties.isFailoverEnabled(),
+      s3Properties.getRegion(),
+      s3Properties.getVersioning()
+    );
     service.ensureBucketExists();
+
     return service;
+  }
+
+  /**
+   * This will likely need improvement should it ever need to run in a non-eureka environment.
+   *
+   * @return instance identifier that will be used to create a uniquely named sqs queue
+   */
+  private static String getInstanceId(Optional<ApplicationInfoManager> applicationInfoManager) {
+    if (applicationInfoManager.isPresent()) {
+      return applicationInfoManager.get().getInfo().getInstanceId();
+    }
+
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3EventingProperties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3EventingProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+public class S3EventingProperties {
+  boolean enabled = false;
+
+  String snsTopicName;
+
+  long refreshIntervalMs = 120000;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getSnsTopicName() {
+    return snsTopicName;
+  }
+
+  public void setSnsTopicName(String snsTopicName) {
+    this.snsTopicName = snsTopicName;
+  }
+
+  public long getRefreshIntervalMs() {
+    return refreshIntervalMs;
+  }
+
+  public void setRefreshIntervalMs(long refreshIntervalMs) {
+    this.refreshIntervalMs = refreshIntervalMs;
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -26,6 +26,9 @@ public class S3Properties extends S3BucketProperties {
   @NestedConfigurationProperty
   S3FailoverProperties failover = new S3FailoverProperties();
 
+  @NestedConfigurationProperty
+  S3EventingProperties eventing = new S3EventingProperties();
+
   public String getRootFolder() {
     return rootFolder;
   }
@@ -44,6 +47,14 @@ public class S3Properties extends S3BucketProperties {
 
   public boolean isFailoverEnabled() {
     return failover != null && failover.enabled;
+  }
+
+  public S3EventingProperties getEventing() {
+    return eventing;
+  }
+
+  public void setEventing(S3EventingProperties eventing) {
+    this.eventing = eventing;
   }
 
   @Override

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/EventingS3ObjectKeyLoader.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/EventingS3ObjectKeyLoader.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.amazonaws.services.sqs.model.Message;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.netflix.spinnaker.front50.config.S3Properties;
+import com.netflix.spinnaker.front50.model.events.S3Event;
+import com.netflix.spinnaker.front50.model.events.S3EventWrapper;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.TaskScheduler;
+
+import javax.annotation.PreDestroy;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An ObjectKeyLoader is responsible for returning a last modified timestamp for all objects of a particular type.
+ *
+ * This implementation listens to an S3 event stream and applies incremental updates whenever an event is received
+ * indicating that an object has been modified (add/update/delete).
+ *
+ * It is significantly faster than delegating to `s3StorageService.listObjectKeys()` with some slight latency attributed
+ * to the time taken for an event to be received and processed.
+ *
+ * Expected latency is < 1s (Amazon
+ */
+public class EventingS3ObjectKeyLoader implements ObjectKeyLoader, Runnable {
+  private static final Logger log = LoggerFactory.getLogger(EventingS3ObjectKeyLoader.class);
+  private static final Executor executor = Executors.newFixedThreadPool(5);
+
+  private final ObjectMapper objectMapper;
+  private final S3StorageService s3StorageService;
+  private final TemporarySQSQueue temporarySQSQueue;
+
+  private final Cache<KeyWithObjectType, Long> objectKeysByLastModifiedCache;
+  private final LoadingCache<ObjectType, Map<String, Long>> objectKeysByObjectTypeCache;
+
+  private final String rootFolder;
+
+  private boolean pollForMessages = true;
+
+  public EventingS3ObjectKeyLoader(TaskScheduler taskScheduler,
+                                   ObjectMapper objectMapper,
+                                   S3Properties s3Properties,
+                                   TemporarySQSQueue temporarySQSQueue,
+                                   S3StorageService s3StorageService,
+                                   boolean scheduleImmediately) {
+    this.objectMapper = objectMapper;
+    this.temporarySQSQueue = temporarySQSQueue;
+    this.s3StorageService = s3StorageService;
+
+    this.objectKeysByLastModifiedCache = CacheBuilder
+      .newBuilder()
+      // ensure that these keys only expire _after_ their object type has been refreshed
+      .expireAfterWrite(s3Properties.getEventing().getRefreshIntervalMs() + 60000, TimeUnit.MILLISECONDS)
+      .recordStats()
+      .build();
+
+
+    this.objectKeysByObjectTypeCache = CacheBuilder
+      .newBuilder()
+      .refreshAfterWrite(s3Properties.getEventing().getRefreshIntervalMs(), TimeUnit.MILLISECONDS)
+      .recordStats()
+      .build(
+        new CacheLoader<ObjectType, Map<String, Long>>() {
+          @Override
+          public Map<String, Long> load(ObjectType objectType) throws Exception {
+            log.debug("Loading object keys for {}", objectType);
+            return s3StorageService.listObjectKeys(objectType);
+          }
+
+          @Override
+          public ListenableFuture<Map<String, Long>> reload(ObjectType objectType, Map<String, Long> previous) throws Exception {
+            ListenableFutureTask<Map<String, Long>> task = ListenableFutureTask.create(
+              () -> {
+                log.debug("Refreshing object keys for {} (asynchronous)", objectType);
+                return s3StorageService.listObjectKeys(objectType);
+              }
+            );
+            executor.execute(task);
+            return task;
+          }
+        }
+      );
+
+    this.rootFolder = s3Properties.getRootFolder();
+
+    if (scheduleImmediately) {
+      taskScheduler.schedule(this, new Date());
+    }
+  }
+
+  @Override
+  @PreDestroy
+  public void shutdown() {
+    log.debug("Stopping ...");
+    pollForMessages = false;
+    log.debug("Stopped");
+  }
+
+  @Override
+  public Map<String, Long> listObjectKeys(ObjectType objectType) {
+    try {
+      Map<String, Long> objectKeys = objectKeysByObjectTypeCache.get(objectType);
+      objectKeysByLastModifiedCache.asMap().entrySet()
+        .stream()
+        .filter(e -> e.getKey().objectType == objectType)
+        .forEach(e -> {
+          String key = e.getKey().key;
+          if (objectKeys.containsKey(key)) {
+            Long currentLastModifiedTime = e.getValue();
+            Long previousLastModifiedTime = objectKeys.get(key);
+            if (currentLastModifiedTime > previousLastModifiedTime) {
+              log.info(
+                "Detected Recent Modification (type: {}, key: {}, previous: {}, current: {})",
+                objectType,
+                key,
+                new Date(previousLastModifiedTime),
+                new Date(e.getValue())
+              );
+              objectKeys.put(key, currentLastModifiedTime);
+            }
+          } else {
+            log.info(
+              "Detected Recent Modification (type: {}, key: {}, current: {})",
+              objectType,
+              key,
+              new Date(e.getValue())
+            );
+            objectKeys.put(key, e.getValue());
+          }
+        });
+      return objectKeys;
+    } catch (ExecutionException e) {
+      log.error("Unable to fetch keys from cache", e);
+      return s3StorageService.listObjectKeys(objectType);
+    }
+  }
+
+  @Override
+  public void run() {
+    while (pollForMessages) {
+      List<Message> messages = temporarySQSQueue.fetchMessages();
+
+      if (messages.isEmpty()) {
+        continue;
+      }
+
+      messages.forEach(message -> {
+        S3Event s3Event = unmarshall(objectMapper, message.getBody());
+        if (s3Event != null) {
+          tick(s3Event);
+        }
+        temporarySQSQueue.markMessageAsHandled(message.getReceiptHandle());
+      });
+    }
+  }
+
+  private void tick(S3Event s3Event) {
+    s3Event.records.forEach(record -> {
+      if (record.s3.object.key.endsWith("last-modified.json")) {
+        return;
+      }
+
+      String eventType = record.eventName;
+      KeyWithObjectType keyWithObjectType = buildObjectKey(rootFolder, record.s3.object.key);
+      DateTime eventTime = new DateTime(record.eventTime);
+
+      log.debug(
+        "Received Event (objectType: {}, type: {}, key: {}, delta: {})",
+        keyWithObjectType.objectType,
+        eventType,
+        keyWithObjectType.key,
+        System.currentTimeMillis() - eventTime.getMillis()
+      );
+
+      objectKeysByLastModifiedCache.put(keyWithObjectType, eventTime.getMillis());
+    });
+  }
+
+  private static KeyWithObjectType buildObjectKey(String rootFolder, String s3ObjectKey) {
+    if (!rootFolder.endsWith("/")) {
+      rootFolder = rootFolder + "/";
+    }
+
+    s3ObjectKey = s3ObjectKey.replace(rootFolder, "");
+    s3ObjectKey = s3ObjectKey.substring(s3ObjectKey.indexOf("/") + 1);
+
+    String metadataFilename = s3ObjectKey.substring(s3ObjectKey.lastIndexOf("/") + 1);
+    s3ObjectKey = s3ObjectKey.substring(0, s3ObjectKey.lastIndexOf("/"));
+
+    try {
+      s3ObjectKey = URLDecoder.decode(s3ObjectKey, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalArgumentException("Invalid key '" + s3ObjectKey + "' (non utf-8)");
+    }
+
+    ObjectType objectType = Arrays.stream(ObjectType.values())
+      .filter(o -> o.defaultMetadataFilename.equalsIgnoreCase(metadataFilename))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("No ObjectType found (defaultMetadataFileName: " + metadataFilename + ")"));
+
+    return new KeyWithObjectType(objectType, s3ObjectKey);
+  }
+
+  private static S3Event unmarshall(ObjectMapper objectMapper, String messageBody) {
+    S3EventWrapper s3EventWrapper;
+    try {
+      s3EventWrapper = objectMapper.readValue(messageBody, S3EventWrapper.class);
+    } catch (IOException e) {
+      log.debug("Unable unmarshal S3EventWrapper (body: {})", messageBody, e);
+      return null;
+    }
+
+    try {
+      return objectMapper.readValue(s3EventWrapper.message, S3Event.class);
+    } catch (IOException e) {
+      log.debug("Unable unmarshal S3Event (body: {})", s3EventWrapper.message, e);
+      return null;
+    }
+  }
+
+  private static class KeyWithObjectType {
+    final ObjectType objectType;
+    final String key;
+
+    KeyWithObjectType(ObjectType objectType, String key) {
+      this.objectType = objectType;
+      this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      KeyWithObjectType that = (KeyWithObjectType) o;
+
+      if (objectType != that.objectType) return false;
+      return key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = objectType.hashCode();
+      result = 31 * result + key.hashCode();
+      return result;
+    }
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/TemporarySQSQueue.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/TemporarySQSQueue.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.amazonaws.auth.policy.Condition;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.SQSActions;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.ListTopicsResult;
+import com.amazonaws.services.sns.model.Topic;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiptHandleIsInvalidException;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Encapsulates the lifecycle of a temporary queue.
+ *
+ * Upon construction, an SQS queue will be created and subscribed to the specified SNS topic.
+ * Upon destruction, both the SQS queue and SNS subscription will be removed.
+ */
+public class TemporarySQSQueue {
+  private final Logger log = LoggerFactory.getLogger(TemporarySQSQueue.class);
+
+  private final AmazonSQS amazonSQS;
+  private final AmazonSNS amazonSNS;
+
+  private final TemporaryQueue temporaryQueue;
+
+  public TemporarySQSQueue(AmazonSQS amazonSQS, AmazonSNS amazonSNS, String snsTopicName, String instanceId) {
+    this.amazonSQS = amazonSQS;
+    this.amazonSNS = amazonSNS;
+
+    String snsTopicArn = getSnsTopicArn(amazonSNS, snsTopicName);
+    String sqsQueueName = snsTopicName + "__" + instanceId;
+    String sqsQueueArn = snsTopicArn.substring(0, snsTopicArn.lastIndexOf(":") + 1).replace("sns", "sqs") + sqsQueueName;
+
+    this.temporaryQueue = createQueue(snsTopicArn, sqsQueueArn, sqsQueueName);
+  }
+
+  List<Message> fetchMessages() {
+    ReceiveMessageResult receiveMessageResult = amazonSQS.receiveMessage(
+      new ReceiveMessageRequest(temporaryQueue.sqsQueueUrl)
+        .withMaxNumberOfMessages(10)
+        .withWaitTimeSeconds(1)
+    );
+
+    return receiveMessageResult.getMessages();
+  }
+
+  void markMessageAsHandled(String receiptHandle) {
+    try {
+      amazonSQS.deleteMessage(temporaryQueue.sqsQueueUrl, receiptHandle);
+    } catch (ReceiptHandleIsInvalidException e) {
+      log.warn("Error deleting message, reason: {} (receiptHandle: {})", e.getMessage(), receiptHandle);
+    }
+  }
+
+  @PreDestroy
+  void shutdown() {
+    try {
+      log.debug("Removing Temporary S3 Notification Queue: {}", temporaryQueue.sqsQueueUrl);
+      amazonSQS.deleteQueue(temporaryQueue.sqsQueueUrl);
+      log.debug("Removed Temporary S3 Notification Queue: {}", temporaryQueue.sqsQueueUrl);
+    } catch (Exception e) {
+      log.error("Unable to remove queue: {} (reason: {})", temporaryQueue.sqsQueueUrl, e.getMessage(), e);
+    }
+
+    try {
+      log.debug("Removing S3 Notification Subscription: {}", temporaryQueue.snsTopicSubscriptionArn);
+      amazonSNS.unsubscribe(temporaryQueue.snsTopicSubscriptionArn);
+      log.debug("Removed S3 Notification Subscription: {}", temporaryQueue.snsTopicSubscriptionArn);
+    } catch (Exception e) {
+      log.error("Unable to unsubscribe queue from topic: {} (reason: {})", temporaryQueue.snsTopicSubscriptionArn, e.getMessage(), e);
+    }
+  }
+
+  private String getSnsTopicArn(AmazonSNS amazonSNS, String topicName) {
+    ListTopicsResult listTopicsResult = amazonSNS.listTopics();
+    String nextToken = listTopicsResult.getNextToken();
+    List<Topic> topics = listTopicsResult.getTopics();
+
+    while (nextToken != null) {
+      listTopicsResult = amazonSNS.listTopics(nextToken);
+      nextToken = listTopicsResult.getNextToken();
+      topics.addAll(listTopicsResult.getTopics());
+    }
+
+    return topics
+      .stream()
+      .filter(t -> t.getTopicArn().toLowerCase().endsWith(":" + topicName.toLowerCase()))
+      .map(Topic::getTopicArn)
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("No SNS topic found (topicName: " + topicName + ")"));
+  }
+
+  private TemporaryQueue createQueue(String snsTopicArn, String sqsQueueArn, String sqsQueueName) {
+    String sqsQueueUrl = amazonSQS.createQueue(
+      new CreateQueueRequest()
+        .withQueueName(sqsQueueName)
+        .withAttributes(Collections.singletonMap("MessageRetentionPeriod", "60")) // 60s message retention
+    ).getQueueUrl();
+    log.info("Created Temporary S3 Notification Queue: {}", sqsQueueUrl);
+
+    String snsTopicSubscriptionArn = amazonSNS.subscribe(snsTopicArn, "sqs", sqsQueueArn).getSubscriptionArn();
+
+    Statement snsStatement = new Statement(Statement.Effect.Allow).withActions(SQSActions.SendMessage);
+    snsStatement.setPrincipals(Principal.All);
+    snsStatement.setResources(Collections.singletonList(new Resource(sqsQueueArn)));
+    snsStatement.setConditions(Collections.singletonList(
+      new Condition().withType("ArnEquals").withConditionKey("aws:SourceArn").withValues(snsTopicArn)
+    ));
+
+    Policy allowSnsPolicy = new Policy("allow-sns", Collections.singletonList(snsStatement));
+
+    HashMap<String, String> attributes = new HashMap<>();
+    attributes.put("Policy", allowSnsPolicy.toJson());
+    amazonSQS.setQueueAttributes(
+      sqsQueueUrl,
+      attributes
+    );
+
+    return new TemporaryQueue(snsTopicArn, sqsQueueArn, sqsQueueUrl, snsTopicSubscriptionArn);
+  }
+
+  protected static class TemporaryQueue {
+    final String snsTopicArn;
+    final String sqsQueueArn;
+    final String sqsQueueUrl;
+    final String snsTopicSubscriptionArn;
+
+    TemporaryQueue(String snsTopicArn, String sqsQueueArn, String sqsQueueUrl, String snsTopicSubscriptionArn) {
+      this.snsTopicArn = snsTopicArn;
+      this.sqsQueueArn = sqsQueueArn;
+      this.sqsQueueUrl = sqsQueueUrl;
+      this.snsTopicSubscriptionArn = snsTopicSubscriptionArn;
+    }
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/events/S3Event.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/events/S3Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,27 @@
  * limitations under the License.
  */
 
+package com.netflix.spinnaker.front50.model.events;
 
-package com.netflix.spinnaker.front50.model.tag
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.netflix.spinnaker.front50.model.ItemDAO
+import java.util.List;
 
-interface EntityTagsDAO extends ItemDAO<EntityTags> {
+public class S3Event {
+  @JsonProperty("Records")
+  public List<S3EventRecord> records;
+
+  public static class S3EventRecord {
+    public String eventName;
+    public String eventTime;
+    public S3Meta s3;
+  }
+
+  public static class S3Meta {
+    public S3Object object;
+  }
+
+  public static class S3Object {
+    public String key;
+  }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/events/S3EventWrapper.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/events/S3EventWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+package com.netflix.spinnaker.front50.model.events;
 
-package com.netflix.spinnaker.front50.model.tag
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.netflix.spinnaker.front50.model.ItemDAO
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class S3EventWrapper {
+  @JsonProperty("Subject")
+  public String subject;
 
-interface EntityTagsDAO extends ItemDAO<EntityTags> {
+  @JsonProperty("Message")
+  public String message;
 }

--- a/front50-s3/src/test/groovy/com/netflix/spinnaker/front50/model/EventingS3ObjectKeyLoaderSpec.groovy
+++ b/front50-s3/src/test/groovy/com/netflix/spinnaker/front50/model/EventingS3ObjectKeyLoaderSpec.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.config.S3Properties
+import com.netflix.spinnaker.front50.model.events.S3Event
+import org.springframework.scheduling.TaskScheduler
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class EventingS3ObjectKeyLoaderSpec extends Specification {
+  def taskScheduler = Mock(TaskScheduler)
+  def objectMapper = new ObjectMapper()
+  def s3Properties = new S3Properties(
+    rootFolder: "root"
+  )
+  def temporarySQSQueue = Mock(TemporarySQSQueue)
+  def s3StorageService = Mock(S3StorageService)
+
+  @Subject
+  def objectKeyLoader = new EventingS3ObjectKeyLoader(
+    taskScheduler,
+    objectMapper,
+    s3Properties,
+    temporarySQSQueue,
+    s3StorageService,
+    false
+  )
+
+  @Unroll
+  def "should build object key"() {
+    when:
+    def keyWithObjectType = EventingS3ObjectKeyLoader.buildObjectKey(rootFolder, s3ObjectKey)
+
+    then:
+    keyWithObjectType == new EventingS3ObjectKeyLoader.KeyWithObjectType(expectedObjectType, expectedKey)
+
+    where:
+    rootFolder | s3ObjectKey                                                              || expectedKey                   || expectedObjectType
+    "my/root/" | "my/root/tags/aws%3Aservergroup%3Amy_asg-v720/entity-tags-metadata.json" || "aws:servergroup:my_asg-v720" || ObjectType.ENTITY_TAGS // should decode s3ObjectKey
+    "my/root"  | "my/root/tags/aws%3Aservergroup%3Amy_asg-v720/entity-tags-metadata.json" || "aws:servergroup:my_asg-v720" || ObjectType.ENTITY_TAGS // trailing slash is optional
+    "my/root/" | "my/root/applications/my_application/application-metadata.json"          || "my_application"              || ObjectType.APPLICATION
+  }
+
+  def "should apply recent modifications when listing object keys"() {
+    given:
+    objectKeyLoader.objectKeysByLastModifiedCache.putAll([
+      (new EventingS3ObjectKeyLoader.KeyWithObjectType(ObjectType.APPLICATION, "key1")): 95L,
+      (new EventingS3ObjectKeyLoader.KeyWithObjectType(ObjectType.PIPELINE, "key2"))   : 205L,
+      (new EventingS3ObjectKeyLoader.KeyWithObjectType(ObjectType.APPLICATION, "key3")): 210L,
+    ])
+
+    when:
+    def objectKeys = objectKeyLoader.listObjectKeys(ObjectType.APPLICATION)
+
+    then:
+    1 * s3StorageService.listObjectKeys(ObjectType.APPLICATION) >> {
+      return [
+        "key1": 100L,
+        "key2": 105L,
+        "key3": 110L
+      ]
+    }
+
+    objectKeys == [
+      "key1": 100L,    // recent modification isn't actually newer
+      "key2": 105L,    // pipeline:key2 != application:key2
+      "key3": 210L     // recent modification should override
+    ]
+  }
+
+  def "should record all modifications contained within an S3Event"() {
+    given:
+    def s3Event = new S3Event(
+      records: [
+        new S3Event.S3EventRecord(
+          eventName: "PUT",
+          eventTime: new Date(9999).format("yyyy-MM-dd'T'HH:mm:ssZ"),
+          s3: new S3Event.S3Meta(object: new S3Event.S3Object(key: "root/applications/last-modified.json")) // last-modified.json keys should be skipped
+        ),
+        new S3Event.S3EventRecord(
+          eventName: "PUT",
+          eventTime: new Date(5000).format("yyyy-MM-dd'T'HH:mm:ssZ"),
+          s3: new S3Event.S3Meta(object: new S3Event.S3Object(key: "root/applications/key1/application-metadata.json"))
+        ),
+        new S3Event.S3EventRecord(
+          eventName: "PUT",
+          eventTime: new Date(25000).format("yyyy-MM-dd'T'HH:mm:ssZ"),
+          s3: new S3Event.S3Meta(object: new S3Event.S3Object(key: "root/pipelines/key2/pipeline-metadata.json"))
+        )
+      ]
+    )
+
+    when:
+    objectKeyLoader.tick(s3Event)
+
+    then:
+    objectKeyLoader.objectKeysByLastModifiedCache.asMap() == [
+      (new EventingS3ObjectKeyLoader.KeyWithObjectType(ObjectType.APPLICATION, "key1")): 5000L,
+      (new EventingS3ObjectKeyLoader.KeyWithObjectType(ObjectType.PIPELINE, "key2"))   : 25000L
+    ]
+  }
+}

--- a/front50-s3/src/test/groovy/com/netflix/spinnaker/front50/model/TemporarySQSQueueSpec.groovy
+++ b/front50-s3/src/test/groovy/com/netflix/spinnaker/front50/model/TemporarySQSQueueSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.ListTopicsResult
+import com.amazonaws.services.sns.model.SubscribeResult
+import com.amazonaws.services.sns.model.Topic
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.CreateQueueResult
+import spock.lang.Specification;
+
+class TemporarySQSQueueSpec extends Specification {
+  def "should create and teardown temporary sqs queue"() {
+    given:
+    def amazonSQS = Mock(AmazonSQS)
+    def amazonSNS = Mock(AmazonSNS)
+
+    when:
+    def temporarySQSQueue = new TemporarySQSQueue(amazonSQS, amazonSNS, "my_topic", "my_id")
+
+    then:
+    1 * amazonSNS.listTopics() >> {
+      return new ListTopicsResult().withTopics(
+        new Topic().withTopicArn("arn:aws:sns:us-west-2:123:not_my_topic"),
+        new Topic().withTopicArn("arn:aws:sns:us-west-2:123:my_topic")
+      )
+    }
+    1 * amazonSQS.createQueue({ CreateQueueRequest cqr ->
+      cqr.attributes["MessageRetentionPeriod"] == "60" && cqr.queueName == "my_topic__my_id"
+    }) >> {
+      new CreateQueueResult().withQueueUrl("http://my/queue_url")
+    }
+    1 * amazonSNS.subscribe("arn:aws:sns:us-west-2:123:my_topic", "sqs", "arn:aws:sqs:us-west-2:123:my_topic__my_id") >> {
+      new SubscribeResult().withSubscriptionArn("arn:subscription")
+    }
+    1 * amazonSQS.setQueueAttributes("http://my/queue_url", _)
+    0 * _
+
+    temporarySQSQueue.temporaryQueue.with {
+      snsTopicArn == "arn:aws:sns:us-west-2:1234:my_topic"
+      sqsQueueArn == "arn:aws:sqs:us-west-2:1234:my_topic__my_id"
+      sqsQueueUrl == "http://my/queue_url"
+      snsTopicSubscriptionArn == "arn:subscription"
+    }
+
+    when:
+    temporarySQSQueue.shutdown()
+
+    then:
+    1 * amazonSQS.deleteQueue("http://my/queue_url")
+    1 * amazonSNS.unsubscribe("arn:subscription")
+    0 * _
+  }
+}

--- a/front50-swift/src/main/java/com/netflix/spinnaker/front50/model/SwiftStorageService.java
+++ b/front50-swift/src/main/java/com/netflix/spinnaker/front50/model/SwiftStorageService.java
@@ -124,17 +124,6 @@ public class SwiftStorageService implements StorageService {
   }
 
   @Override
-  public <T extends Timestamped> Collection<T> loadObjectsWithPrefix(ObjectType objectType, String prefix, int maxResults) {
-    List<? extends SwiftObject> objects = getSwift().objects().list(containerName, ObjectListOptions.create().path(objectType.group).startsWith(prefix).limit(maxResults));
-    return objects.stream()
-      .map(obj -> {
-        T item = deserialize(obj, (Class<T>) objectType.clazz);
-        item.setLastModified(obj.getLastModified().getTime());
-        return item;
-      }).collect(Collectors.toSet());
-  }
-
-  @Override
   public <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) throws NotFoundException {
     SwiftObject o = getSwift().objects().get(containerName, objectKey);
     return deserialize(o, (Class<T>) objectType.clazz);


### PR DESCRIPTION
Adds a new `ObjectKeyLoader` implementation that subscribes to an sqs
queue and receives events generated in response to s3 modifications.

These events should be received no more than 1s after the modification.

This PR also removes the unused `loadObjectsWithPrefix` StorageService
method.