### PR TITLE
feat(keel): adding basic storage of intents

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -24,6 +24,8 @@ import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
 import com.netflix.spinnaker.front50.model.application.DefaultApplicationDAO;
 import com.netflix.spinnaker.front50.model.application.DefaultApplicationPermissionDAO;
+import com.netflix.spinnaker.front50.model.intent.DefaultIntentDAO;
+import com.netflix.spinnaker.front50.model.intent.IntentDAO;
 import com.netflix.spinnaker.front50.model.notification.DefaultNotificationDAO;
 import com.netflix.spinnaker.front50.model.notification.NotificationDAO;
 import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineDAO;
@@ -199,6 +201,21 @@ public class CommonStorageServiceDAOConfig {
       objectKeyLoader,
       storageServiceConfigurationProperties.getEntityTags().getRefreshMs(),
       storageServiceConfigurationProperties.getEntityTags().getShouldWarmCache(),
+      registry
+    );
+  }
+
+  @Bean
+  IntentDAO intentDAO(StorageService storageService,
+                      StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+                      ObjectKeyLoader objectKeyLoader,
+                      Registry registry) {
+    return new DefaultIntentDAO(
+      storageService,
+      Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getEntityTags().getThreadPool())),
+      objectKeyLoader,
+      storageServiceConfigurationProperties.getIntent().getRefreshMs(),
+      storageServiceConfigurationProperties.getIntent().getShouldWarmCache(),
       registry
     );
   }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.groovy
@@ -31,6 +31,7 @@ class StorageServiceConfigurationProperties {
   PerObjectType pipeline = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
   PerObjectType pipelineTemplate = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
   PerObjectType snapshot = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1))
+  PerObjectType intent = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
 
   // not commonly used outside of Netflix
   PerObjectType entityTags = new PerObjectType(2, TimeUnit.MINUTES.toMillis(5), false)

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.front50.model.application.Application;
 import com.netflix.spinnaker.front50.model.notification.Notification;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
+import com.netflix.spinnaker.front50.model.intent.Intent;
 import com.netflix.spinnaker.front50.model.project.Project;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
 import com.netflix.spinnaker.front50.model.snapshot.Snapshot;
@@ -30,6 +31,7 @@ public enum ObjectType {
   PIPELINE(Pipeline.class, "pipelines", "pipeline-metadata.json"),
   STRATEGY(Pipeline.class, "pipeline-strategies", "pipeline-strategy-metadata.json"),
   PIPELINE_TEMPLATE(PipelineTemplate.class, "pipeline-templates", "pipeline-template-metadata.json"),
+  INTENT(Intent.class, "intents", "intent-metadata.json"),
   NOTIFICATION(Notification.class, "notifications", "notification-metadata.json"),
   SERVICE_ACCOUNT(ServiceAccount.class, "serviceAccounts", "serviceAccount-metadata.json"),
   APPLICATION(Application.class, "applications", "application-metadata.json"),

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/intent/DefaultIntentDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/intent/DefaultIntentDAO.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.intent;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.ObjectType;
+import com.netflix.spinnaker.front50.model.StorageService;
+import com.netflix.spinnaker.front50.model.StorageServiceSupport;
+import org.springframework.util.Assert;
+import rx.Scheduler;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DefaultIntentDAO extends StorageServiceSupport<Intent> implements IntentDAO {
+
+  public DefaultIntentDAO(StorageService service,
+                                    Scheduler scheduler,
+                                    ObjectKeyLoader objectKeyLoader,
+                                    long refreshIntervalMs,
+                                    boolean shouldWarmCache,
+                                    Registry registry) {
+    super(ObjectType.INTENT, service, scheduler, objectKeyLoader, refreshIntervalMs, shouldWarmCache, registry);
+  }
+
+  @Override
+  public Collection<Intent> getIntentsByKind(List<String> kind) {
+    return all()
+      .stream()
+      .filter(i -> kind.contains(i.getKind()))
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<Intent> getIntentsByStatus(List<String> status) {
+    if (status == null || status.isEmpty()) {
+      return all();
+    }
+
+    return all()
+      .stream()
+      .filter(i -> status.contains(i.getStatus()))
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public Intent create(String id, Intent item) {
+    Assert.notNull(item.getId(), "id field must NOT to be null!");
+    Assert.notNull(item.getSchema(), "schema field must NOT to be null!");
+    Assert.notNull(item.getSpec(), "spec field must NOT to be null!");
+    Assert.notNull(item.getKind(), "kind field must NOT to be null!");
+    if (item.getStatus() == null) {
+      item.setStatus("ACTIVE");
+    }
+
+    update(id, item);
+    return findById(id);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/intent/Intent.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/intent/Intent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.intent;
+
+import com.netflix.spinnaker.front50.model.Timestamped;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+public class Intent extends HashMap<String, Object> implements Timestamped {
+
+  private static final Logger log = LoggerFactory.getLogger(PipelineTemplate.class);
+
+  @Override
+  public String getId() {
+    return (String) super.get("id");
+  }
+
+  public void setId(String id) {
+    super.put("id", id);
+  }
+
+  @Override
+  public Long getLastModified() {
+    String updateTs = (String) super.get("updateTs");
+    return (updateTs != null) ? Long.valueOf(updateTs) : null;
+  }
+
+  @Override
+  public void setLastModified(Long lastModified) {
+    super.put("updateTs", lastModified.toString());
+  }
+
+  @Override
+  public String getLastModifiedBy() {
+    return (String) super.get("lastModifiedBy");
+  }
+
+  @Override
+  public void setLastModifiedBy(String lastModifiedBy) {
+    super.put("lastModifiedBy", lastModifiedBy);
+  }
+
+  public String getKind() {
+    return (String) super.get("kind");
+  }
+
+  public void setKind(String kind) {
+    super.put("kind", kind);
+  }
+
+  public String getSchema() {
+    return (String) super.get("schema");
+  }
+
+  public void setSchema(String schema) {
+    super.put("schema", schema);
+  }
+
+  public Object getSpec() {
+    return super.get("spec");
+  }
+
+  public void setSpec(Object spec) {
+    super.put("spec", spec);
+  }
+
+  public String getStatus() {
+    return (String) super.get("status");
+  }
+
+  public void setStatus(String status) {
+    super.put("status", status);
+  }
+
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/intent/IntentDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/intent/IntentDAO.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.intent;
+
+import com.netflix.spinnaker.front50.model.ItemDAO;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface IntentDAO extends ItemDAO<Intent> {
+
+  Collection<Intent> getIntentsByKind(List<String> kind);
+
+  Collection<Intent> getIntentsByStatus(List<String> status);
+}

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisConfig.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisConfig.groovy
@@ -17,10 +17,12 @@
 package com.netflix.spinnaker.front50.redis
 
 import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.intent.Intent
 import com.netflix.spinnaker.front50.model.notification.Notification
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate
 import com.netflix.spinnaker.front50.model.project.Project
+import jdk.nashorn.internal.ir.BreakableNode
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -58,6 +60,11 @@ class RedisConfig {
   @Bean
   RedisPipelineTemplateDAO redisPipelineTemplateDAO(RedisTemplate<String, PipelineTemplate> template) {
     new RedisPipelineTemplateDAO(redisTemplate: template)
+  }
+
+  @Bean
+  RedisIntentDAO redisIntentDAO(RedisTemplate<String, Intent> template) {
+    new RedisIntentDAO(redisTemplate: template)
   }
 
   @Bean
@@ -135,6 +142,18 @@ class RedisConfig {
     template.keySerializer = stringRedisSerializer
     template.hashKeySerializer = stringRedisSerializer
     template.hashValueSerializer = new Jackson2JsonRedisSerializer<>(Notification)
+
+    template
+  }
+
+  @Bean
+  RedisTemplate<String, Intent> intentRedisTemplate(RedisConnectionFactory connectionFactory,
+                                                    StringRedisSerializer stringRedisSerializer) {
+    RedisTemplate<String, Intent> template = new RedisTemplate<>()
+    template.connectionFactory = connectionFactory
+    template.keySerializer = stringRedisSerializer
+    template.hashKeySerializer = stringRedisSerializer
+    template.hashValueSerializer = new Jackson2JsonRedisSerializer<>(Intent)
 
     template
   }

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisIntentDAO.java
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisIntentDAO.java
@@ -1,0 +1,108 @@
+package com.netflix.spinnaker.front50.redis;
+
+import com.google.common.collect.Lists;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.intent.Intent;
+import com.netflix.spinnaker.front50.model.intent.IntentDAO;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
+import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.util.Assert;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RedisIntentDAO implements IntentDAO {
+
+  static final String BOOK_KEEPING_KEY = "com.netflix.spinnaker:front50:intents";
+
+  RedisTemplate<String, Intent> redisTemplate;
+
+  @Override
+  public Collection<Intent> getIntentsByKind(List<String> kind) {
+    return all()
+      .stream()
+      .filter(it -> kind.contains(it.getKind()))
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<Intent> getIntentsByStatus(List<String> status) {
+    return all()
+      .stream()
+      .filter(it -> status.contains(it.getKind()))
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public Intent findById(final String id) throws NotFoundException {
+    Object results = redisTemplate.opsForHash().get(BOOK_KEEPING_KEY, id);
+    if (!DefaultGroovyMethods.asBoolean(results)) {
+      throw new NotFoundException("No intent found with id \'" + id + "\'");
+    }
+
+    return ((Intent) (results));
+  }
+
+  @Override
+  public Collection<Intent> all() {
+    return all(true);
+  }
+
+  @Override
+  public Collection<Intent> all(boolean refresh) {
+    return Lists.newArrayList(redisTemplate.opsForHash().scan(BOOK_KEEPING_KEY, ScanOptions.scanOptions().match("*").build()))
+      .stream()
+      .map(e -> (Intent) e.getValue())
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<Intent> history(String id, int maxResults) {
+    return Lists.newArrayList(findById(id));
+  }
+
+  @Override
+  public Intent create(String id, Intent item) {
+    Assert.notNull(item.getId(), "id field must NOT to be null!");
+    Assert.notNull(item.getKind(), "kind field must NOT to be null!");
+    Assert.notNull(item.getSpec(), "spec field must NOT to be null!");
+    Assert.notNull(item.getSchema(), "schema field must NOT to be null!");
+    if (item.getStatus() == null) {
+      item.setStatus("ACTIVE");
+    }
+
+    redisTemplate.opsForHash().put(BOOK_KEEPING_KEY, item.getId(), item);
+
+    return item;
+  }
+
+  @Override
+  public void update(String id, Intent item) {
+    item.setLastModified(System.currentTimeMillis());
+    create(id, item);
+  }
+
+  @Override
+  public void delete(String id) {
+    redisTemplate.opsForHash().delete(BOOK_KEEPING_KEY, id);
+  }
+
+  @Override
+  public void bulkImport(Collection<Intent> items) {
+    items.forEach(it -> create(it.getId(), it));
+  }
+
+  @Override
+  public boolean isHealthy() {
+    try {
+      redisTemplate.opsForHash().get("", "");
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.front50.exceptions.AccessDeniedExceptionHandler
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO
+import com.netflix.spinnaker.front50.model.intent.IntentDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
@@ -35,6 +36,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
 import org.springframework.http.HttpStatus
@@ -118,6 +120,12 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
   @ConditionalOnBean(ServiceAccountDAO)
   ItemDAOHealthIndicator serviceAccountDAOHealthIndicator(ServiceAccountDAO serviceAccountDAO, TaskScheduler taskScheduler) {
     return new ItemDAOHealthIndicator(serviceAccountDAO, taskScheduler)
+  }
+
+  @Bean
+  @ConditionalOnBean(IntentDAO)
+  ItemDAOHealthIndicator intentDAOHealthIndicator(IntentDAO intentDAO, TaskScheduler taskScheduler) {
+    return new ItemDAOHealthIndicator(intentDAO, taskScheduler)
   }
 
   @Bean

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/IntentController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/IntentController.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.exceptions.DuplicateEntityException;
+import com.netflix.spinnaker.front50.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.front50.model.intent.Intent;
+import com.netflix.spinnaker.front50.model.intent.IntentDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("intents")
+public class IntentController {
+
+  @Autowired
+  IntentDAO intentDAO;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @RequestMapping(value = "", method = RequestMethod.GET)
+  List<Intent> list(@RequestParam(required = false, value = "status") List<String> status) {
+    return (List<Intent>) intentDAO.getIntentsByStatus(status);
+  }
+
+  @RequestMapping(value = "{id}", method = RequestMethod.GET)
+  Intent get(@PathVariable String id) {
+    return intentDAO.findById(id);
+  }
+
+  @RequestMapping(value = "", method = RequestMethod.POST)
+  void save(@RequestBody Intent intent) {
+    checkForDuplicateIntents(intent.getId());
+    intentDAO.create(intent.getId(), intent);
+  }
+
+  @RequestMapping(value = "{id}", method = RequestMethod.PUT)
+  Intent update(@PathVariable String id, @RequestBody Intent intent) {
+    Intent existingIntent = intentDAO.findById(id);
+    if (!intent.getId().equals(existingIntent.getId())) {
+      throw new InvalidRequestException("The provided id " + id + " doesn't match the intent id " + intent.getId());
+    }
+
+    intent.setLastModified(System.currentTimeMillis());
+    intentDAO.update(id, intent);
+
+    return intent;
+  }
+
+  @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
+  void delete(@PathVariable String id) {
+    intentDAO.delete(id);
+  }
+
+  private void checkForDuplicateIntents(String id) {
+    try {
+      intentDAO.findById(id);
+    } catch (NotFoundException e) {
+      return;
+    }
+    throw new DuplicateEntityException("An intent with the id " + id + " already exists");
+  }
+
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/IntentControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/IntentControllerSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.exceptions.DuplicateEntityException
+import com.netflix.spinnaker.front50.exceptions.InvalidRequestException
+import com.netflix.spinnaker.front50.model.intent.Intent
+import com.netflix.spinnaker.front50.model.intent.IntentDAO
+import spock.lang.Specification
+import spock.lang.Subject
+
+
+class IntentControllerSpec extends Specification {
+  def intentDAO = Mock(IntentDAO)
+
+  @Subject
+  def controller = new IntentController(
+    intentDAO: intentDAO,
+    objectMapper:  new ObjectMapper(),
+  )
+
+  def "should reject creation of intent with the same id"() {
+    given:
+    def intent = new Intent(
+      id: "ahoymatey",
+      kind: "Parrot",
+      schema: "1",
+      spec: [
+          application: "keel",
+          deescription: "hello"
+      ],
+      status: "ACTIVE"
+    )
+    def oldIntent = new Intent(
+      id: "ahoymatey",
+      kind: "Parrot",
+      schema: "1",
+      spec: [
+        application: "keel",
+        deescription: "ahoy"
+      ],
+      status: "ACTIVE"
+    )
+
+    when:
+    intentDAO.all() >> { [oldIntent] }
+    controller.save(intent)
+
+    then:
+    thrown(DuplicateEntityException)
+  }
+
+  def "should reject update of intent where id is different"() {
+    given:
+    def id = "ahoymatey"
+    def intent = new Intent(
+      id: "arr arr",
+      kind: "Parrot",
+      schema: "1",
+      spec: [
+        application: "keel",
+        deescription: "hello"
+      ],
+      status: "ACTIVE"
+    )
+    def oldIntent = new Intent(
+      id: "ahoymatey",
+      kind: "Parrot",
+      schema: "1",
+      spec: [
+        application: "keel",
+        deescription: "ahoy"
+      ],
+      status: "ACTIVE"
+    )
+
+    when:
+    intentDAO.findById(id) >> { [oldIntent] }
+    controller.update(id, intent)
+
+    then:
+    thrown(InvalidRequestException)
+  }
+}


### PR DESCRIPTION
Basics of intent storage for keel. Object looks like https://github.com/spinnaker/keel/blob/master/README.md.

@ajordens @robzienert PTAL