### PR TITLE
fix(s3): don't create sqs and sns topics when eventing is disabled

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -77,6 +77,7 @@ public class S3Config extends CommonStorageServiceDAOConfig {
   }
 
   @Bean
+  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
   public AmazonSQS awsSQSClient(AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
     return AmazonSQSClientBuilder
       .standard()
@@ -87,6 +88,7 @@ public class S3Config extends CommonStorageServiceDAOConfig {
   }
 
   @Bean
+  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
   public AmazonSNS awsSNSClient(AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
     return AmazonSNSClientBuilder
       .standard()


### PR DESCRIPTION
This leads to an exception when using s3 compatible systems like minio. Error creating bean with name 'awsSQSClient' defined in class path resource [com/netflix/spinnaker/front50/config/S3Config.class]