### PR TITLE
fix(front50/log): Append to log instead of overwrite

### DIFF
--- a/front50-web/etc/init/front50.conf
+++ b/front50-web/etc/init/front50.conf
@@ -9,4 +9,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec /opt/front50/bin/front50 2>&1 > /var/log/spinnaker/front50/front50.log &
+exec /opt/front50/bin/front50 2>&1 >> /var/log/spinnaker/front50/front50.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.