### PR TITLE
refactor(pipelineTemplates): Use shared strings

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateController.java
@@ -40,6 +40,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.netflix.spinnaker.front50.model.pipeline.Pipeline.TYPE_TEMPLATED;
+import static com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration.TemplateSource.SPINNAKER_PREFIX;
+
 @RestController
 @RequestMapping("pipelineTemplates")
 public class PipelineTemplateController {
@@ -110,7 +113,7 @@ public class PipelineTemplateController {
 
     pipelineDAO.all()
       .stream()
-      .filter(pipeline -> pipeline.getType() != null && pipeline.getType().equals("templatedPipeline"))
+      .filter(pipeline -> pipeline.getType() != null && pipeline.getType().equals(TYPE_TEMPLATED))
       .forEach(templatedPipeline -> {
         String source;
         try {
@@ -131,10 +134,10 @@ public class PipelineTemplateController {
 
   private List<String> convertAllTemplateIdsToSources(String rootTemplateId, boolean recursive) {
     List<String> templateIds = new ArrayList<>();
-    templateIds.add("spinnaker://" + rootTemplateId);
+    templateIds.add(SPINNAKER_PREFIX + rootTemplateId);
     if (recursive) {
       for (String id : getDependentTemplates(rootTemplateId, Optional.empty())) {
-        templateIds.add("spinnaker://" + id);
+        templateIds.add(SPINNAKER_PREFIX + id);
       }
     }
     return templateIds;
@@ -165,7 +168,7 @@ public class PipelineTemplateController {
     final Collection<PipelineTemplate> pipelineTemplates = templates.orElse(getPipelineTemplateDAO().all());
     pipelineTemplates.forEach(template -> {
         if (template.getSource() != null
-          && template.getSource().equalsIgnoreCase("spinnaker://" + templateId)) {
+          && template.getSource().equalsIgnoreCase(SPINNAKER_PREFIX + templateId)) {
           dependentTemplateIds.add(template.getId());
           dependentTemplateIds.addAll(getDependentTemplates(template.getId(), Optional.of(pipelineTemplates)));
         }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineTemplateControllerSpec.groovy
@@ -25,6 +25,9 @@ import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
 import spock.lang.Specification
 import spock.lang.Subject
 
+import static com.netflix.spinnaker.front50.model.pipeline.Pipeline.TYPE_TEMPLATED;
+import static com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration.TemplateSource.SPINNAKER_PREFIX;
+
 class PipelineTemplateControllerSpec extends Specification {
   def pipelineDAO = Mock(PipelineDAO)
   def pipelineTemplateDAO = Mock(PipelineTemplateDAO)
@@ -42,11 +45,11 @@ class PipelineTemplateControllerSpec extends Specification {
       id: "myTemplate"
     )
     def pipeline = new Pipeline(
-      type: "templatedPipeline",
+      type: TYPE_TEMPLATED,
       config: [
         pipeline: [
           template: [
-            source: "spinnaker://myTemplate"
+            source: SPINNAKER_PREFIX + "myTemplate"
           ]
         ]
       ]
@@ -66,7 +69,7 @@ class PipelineTemplateControllerSpec extends Specification {
     def templateId = "myTemplate"
     def pipelineTemplate = new PipelineTemplate(
       id: "myDependentTemplate",
-      source: "spinnaker://myTemplate"
+      source: SPINNAKER_PREFIX + "myTemplate"
     )
 
     when:
@@ -84,11 +87,11 @@ class PipelineTemplateControllerSpec extends Specification {
     )
     def childTemplate = new PipelineTemplate(
       id: 'childTemplate',
-      source: 'spinnaker://rootTemplate'
+      source: SPINNAKER_PREFIX + 'rootTemplate'
     )
     def grandchildTemplate = new PipelineTemplate(
       id: 'grandchildTemplate',
-      source: 'spinnaker://childTemplate'
+      source: SPINNAKER_PREFIX + 'childTemplate'
     )
     def unrelatedTemplate = new PipelineTemplate(
       id: 'unrelatedTemplate'


### PR DESCRIPTION
For template type and source prefix used shared strins.