### PR TITLE
refactor(S3): checks for non empty string before using it as an endpoint

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.front50.model.EventingS3ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.S3StorageService;
 import com.netflix.spinnaker.front50.model.TemporarySQSQueue;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -63,7 +64,7 @@ public class S3Config extends CommonStorageServiceDAOConfig {
 
     AmazonS3Client client = new AmazonS3Client(awsCredentialsProvider, clientConfiguration);
 
-    if (s3Properties.getEndpoint() != null) {
+    if (!StringUtils.isEmpty(s3Properties.getEndpoint())) {
       client.setEndpoint(s3Properties.getEndpoint());
       client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build());
     } else {


### PR DESCRIPTION
Checks for an non empty string before using it as an endpoint for the S3.  This comes up in cases when a user leaves optionally leaves the field empty in a properties file if the env var doesn't exist.  For example, the following configuration would result in an empty string if `services.front50.endpoint` doesn't exist.

```
spinnaker:
  s3:
    enabled: true
    bucket: ${services.front50.storage_bucket:}
    rootFolder: ${services.front50.rootFolder:front50}
    endpoint: ${services.front50.endpoint:}
```
