### PR TITLE
fix(oraclebmcs): Throw NotFoundException instead of return null

### DIFF
--- a/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/OracleBMCSStorageService.java
+++ b/front50-oracle-bmcs/src/main/java/com/netflix/spinnaker/front50/model/OracleBMCSStorageService.java
@@ -124,7 +124,7 @@ public class OracleBMCSStorageService implements StorageService {
       return obj;
     } catch (UniformInterfaceException e) {
       if (e.getResponse().getStatus() == 404) {
-        return null;
+        throw new NotFoundException("Object not found (key: " + objectKey + ")");
       }
       throw e;
     }


### PR DESCRIPTION
Fixes the spinnaker/spinnaker#2648 bug where the user sees "Could not create application: Cannot get property 'name' on null object".

Tested locally running deck, redis, gate, orca, front50 - you can now successfully create applications with front50 backed by oracelbmcs storage service.