### PR TITLE
feat(s3): add regionOverride property

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
@@ -19,6 +19,9 @@ package com.netflix.spinnaker.front50.config;
 public class S3BucketProperties {
   private String bucket;
   private String region;
+  // regionOverride allows the aws client to override the region in s3 request signatures
+  // some s3 compatible solutions allow non-aws region identifiers to be used
+  private String regionOverride;
   private String endpoint;
   private String proxyHost;
   private String proxyPort;
@@ -39,6 +42,14 @@ public class S3BucketProperties {
 
   public void setRegion(String region) {
     this.region = region;
+  }
+
+  public String getRegionOverride() {
+    return regionOverride;
+  }
+
+  public void setRegionOverride(String regionOverride) {
+    this.regionOverride = regionOverride;
   }
 
   public String getEndpoint() {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -66,6 +66,11 @@ public class S3Config extends CommonStorageServiceDAOConfig {
 
     if (!StringUtils.isEmpty(s3Properties.getEndpoint())) {
       client.setEndpoint(s3Properties.getEndpoint());
+
+      if (!StringUtils.isEmpty(s3Properties.getRegionOverride())) {
+        client.setSignerRegionOverride(s3Properties.getRegionOverride());
+      }
+
       client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build());
     } else {
       Optional.ofNullable(s3Properties.getRegion())

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -74,6 +74,15 @@ public class S3Properties extends S3BucketProperties {
   }
 
   @Override
+  public String getRegionOverride() {
+    if (isFailoverEnabled()) {
+      return failover.getRegionOverride();
+    }
+
+    return super.getRegionOverride();
+  }
+
+  @Override
   public String getEndpoint() {
     if (isFailoverEnabled()) {
       return failover.getEndpoint();


### PR DESCRIPTION
some s3 compatible storage solutions (minio, for example) take the region into account when validating incoming requests but allow you to set non-aws region identifiers. this change allows you to explicitly set the region identifier as an override via `regionOverride`. it also allows you to set the region for configurations using the `endpoint` setting.
