### PR TITLE
fix(core): Fix auth propagation for `bulkImport` calls

### DIFF
--- a/front50-core/front50-core.gradle
+++ b/front50-core/front50-core.gradle
@@ -20,4 +20,5 @@ dependencies {
 
   compile spinnaker.dependency('kork')
   compile spinnaker.dependency('korkHystrix')
+  compile spinnaker.dependency('korkSecurity')
 }


### PR DESCRIPTION
Correctly propagate the authenticated username across thread boundaries
in `bulkImport`.
