### PR TITLE
perf(s3): Short circuit when asking for object history w/ maxResults = 1

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -182,6 +182,10 @@ public class S3StorageService implements StorageService {
   public <T extends Timestamped> Collection<T> listObjectVersions(ObjectType objectType,
                                                                   String objectKey,
                                                                   int maxResults) throws NotFoundException {
+    if (maxResults == 1) {
+      return loadObject(objectType, objectKey);
+    }
+
     try {
       VersionListing versionListing = amazonS3.listVersions(
         new ListVersionsRequest(


### PR DESCRIPTION
In such cases, it is more efficient to just `loadObject(type, key)`.
