### PR TITLE
feat(entitytags): Support for bulk delete of entity tags

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ItemDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ItemDAO.java
@@ -27,6 +27,12 @@ public interface ItemDAO<T> {
 
   void bulkImport(Collection<T> items);
 
+  default void bulkDelete(Collection<String> ids) {
+    for (String id : ids) {
+      delete(id);
+    }
+  }
+
   boolean isHealthy();
 
   default long getHealthIntervalMillis() {

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
@@ -38,6 +38,12 @@ public interface StorageService {
 
   void deleteObject(ObjectType objectType, String objectKey);
 
+  default void bulkDeleteObjects(ObjectType objectType, Collection<String> objectKeys) {
+    for (String objectKey : objectKeys) {
+      deleteObject(objectType, objectKey);
+    }
+  }
+
   <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T item);
 
   Map<String, Long> listObjectKeys(ObjectType objectType);

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -236,6 +236,10 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
         .single();
   }
 
+  public void bulkDelete(Collection<String> ids) {
+    service.bulkDeleteObjects(objectType, ids);
+  }
+
   /**
    * Update local cache with any recently modified items.
    */

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/EnsureCronTriggerHasIdentifierMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/EnsureCronTriggerHasIdentifierMigration.java
@@ -55,7 +55,7 @@ public class EnsureCronTriggerHasIdentifierMigration implements Migration {
 
   @Override
   public void run() {
-    log.info("Starting cron trigger identifer migration");
+    log.info("Starting cron trigger identifier migration");
     Predicate<Pipeline> hasCronTrigger = p -> {
       List<Map> triggers = (List<Map>) p.get("triggers");
       return triggers != null && triggers.stream().anyMatch(t -> {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
@@ -26,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.util.AntPathMatcher
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
@@ -89,6 +88,15 @@ class EntityTagsController {
 
     taggedEntityDAO.bulkImport(tags)
     return findAllByIds(tags.findResults { it.id })
+  }
+
+  @RequestMapping(value = "/batchDelete", method = RequestMethod.POST)
+  void batchDelete(@RequestBody final Collection<String> ids) {
+    if (!taggedEntityDAO) {
+      throw new BadRequestException("Tagging is not supported")
+    }
+
+    taggedEntityDAO.bulkDelete(ids)
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/**")


### PR DESCRIPTION
Ultimately delegates to the `deleteObjects` available for S3, other
providers will continue to use their respective per-object delete
functions.

```
curl -X "POST" "https://localhost:8081/v2/tags/batchDelete" \
     -H 'Content-Type: application/json' \
     -d $'[
  "aws:servergroup:app-v023:111111111111:us-west-2",
  "aws:servergroup:app-v000:111111111111:us-east-1"
]'
'
```
