### PR TITLE
chore(build): Add debug flag to front50 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Spinnaker Application & Project Metadata Repository
 [![Build Status](https://api.travis-ci.org/spinnaker/front50.svg?branch=master)](https://travis-ci.org/spinnaker/front50)
 This service fronts a Spinnaker datastore. By default it's Cassandra, however, it's intended that any datastore could work. Front50 written using [Spring Boot][0]. 
 
+### Debugging
 
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 8180.  The JVM will _not_ wait for
+the debugger to be attached before starting Front50; the relevant JVM arguments can be seen and
+modified as needed in `build.gradle`.
 
 [0]:http://projects.spring.io/spring-boot/

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,13 @@ allprojects { project ->
       }
     }
   }
+
+  tasks.withType(JavaExec) {
+    if (System.getProperty('DEBUG', 'false') == 'true') {
+      jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8180'
+    }
+  }
+
   dependencies {
     compile spinnaker.dependency("groovy")
     spinnaker.group("test")


### PR DESCRIPTION
Starting front50 with ./gradlew -DDEBUG=true now causes the JVM to listen on port 8180 for a remote debugger.