### PR TITLE
fix(google): Fix caching of permissions

### DIFF
--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -116,10 +116,11 @@ public class GcsConfig extends CommonStorageServiceDAOConfig {
                                                            ObjectKeyLoader objectKeyLoader,
                                                            Registry registry) {
     GcsStorageService service = googleCloudStorageService(ApplicationPermissionDAO.DEFAULT_DATA_FILENAME, gcsProperties);
+    ObjectKeyLoader keyLoader = new DefaultObjectKeyLoader(service);
     return new DefaultApplicationPermissionDAO(
       service,
       Schedulers.from(Executors.newFixedThreadPool(storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
-      objectKeyLoader,
+      keyLoader,
       storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
       storageServiceConfigurationProperties.getApplicationPermission().getShouldWarmCache(),
       registry


### PR DESCRIPTION
The GCS ApplicationPermissionDAO is using the modification time of
'specification.json' to determine cache expiration but is actually
reading 'permission.json', leading to incorrect caching.