### PR TITLE
fix(service-accounts): Fiat role sync requires a list of roles not users

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
 import groovy.util.logging.Slf4j
-import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.web.bind.annotation.PathVariable
@@ -75,10 +74,10 @@ public class ServiceAccountsController {
       return
     }
 
-    def roles = [StringUtils.substringBefore(serviceAccount.name.replaceAll('%40', "@"), "@")]
     try {
-      fiatService.sync(roles)
-      log.debug("Synced users with roles $roles")
+      // Empty body to keep OkHttp happy: https://github.com/square/retrofit/issues/854
+      fiatService.sync(new ArrayList<String>())
+      log.debug("Synced users with roles")
     } catch (RetrofitError re) {
       log.warn("Error syncing users", re)
     }


### PR DESCRIPTION
We should be sending a list of service account roles for Fiat to refresh, not the serviceAccount names.

See https://github.com/spinnaker/fiat/blob/master/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java#L99

@stewchen @danielpeach 