### PR TITLE
fix(web): savePipeline() should return the newly created pipeline

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -96,7 +96,7 @@ class PipelineController {
 
   @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission() and hasPermission(#pipeline.application, 'APPLICATION', 'WRITE') and @authorizationSupport.hasRunAsUserPermission(#pipeline)")
   @RequestMapping(value = '', method = RequestMethod.POST)
-  void save(@RequestBody Pipeline pipeline) {
+  Pipeline save(@RequestBody Pipeline pipeline) {
 
     validatePipeline(pipeline)
 
@@ -111,7 +111,7 @@ class PipelineController {
       }
     }
 
-    pipelineDAO.create(pipeline.id as String, pipeline)
+    return pipelineDAO.create(pipeline.id as String, pipeline)
   }
 
   @PreAuthorize("@fiatPermissionEvaluator.isAdmin()")


### PR DESCRIPTION
This allows the `SavePipelineTask` in `orca` to correctly capture the
pipeline identifier.
