### PR TITLE
 fix(core): Warn when an object's key does not match its id

### DIFF
--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -410,7 +410,7 @@ GcsStorageService implements StorageService {
         if (items != null) {
           for (StorageObject item: items) {
             String name = item.getName();
-            if (name.endsWith(dataFilename)) {
+            if (name.endsWith('/' + dataFilename)) {
               result.put(name.substring(skipToOffset, name.length() - skipFromEnd), item.getUpdated().getValue());
             }
           }


### PR DESCRIPTION
If there are objects in the bucket that front50 is polling that weren't added by front50, some buggy behavior can occur:
* Specific to GCS, objects that match `(.*)[^/]specification.json` are returned by the listing operation, but the actual fetch operation looks for `$1/specification.json` causing a 404.
* For all back-ends, objects whose key does not match do not match their id are cached every cycle.  (Aside from this caching every cycle, looking up the objects by id does not work because the lookup logic assumes the key matches the id.)

The above situations should not occur for any object created by Spinnaker, but let's make the logic robust and/or warn if there are unexpected objects in the bucket.