### PR TITLE
chore(oracle/dependency): upgrade oracle oci sdk version to 1.2.44

### DIFF
--- a/front50-oracle/front50-oracle.gradle
+++ b/front50-oracle/front50-oracle.gradle
@@ -1,3 +1,4 @@
+
 class DownloadTask extends DefaultTask {
   @Input
   String sourceUrl
@@ -12,11 +13,12 @@ class DownloadTask extends DefaultTask {
 }
 
 final File sdkDownloadLocation = project.file('build/sdkdownload')
-final File sdkLocation = project.file('build/bmcs-sdk')
+final File sdkLocation = project.file('build/oci-java-sdk')
 
-// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile deps
+// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
+// https://github.com/oracle/oci-java-sdk/issues/25
 task fetchSdk(type: DownloadTask) {
-  sourceUrl = 'https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.5/oracle-bmcs-java-sdk.zip'
+  sourceUrl = 'https://github.com/oracle/oci-java-sdk/releases/download/v1.2.44/oci-java-sdk.zip'
   target = sdkDownloadLocation
 }
 
@@ -29,6 +31,9 @@ task unpackSdk(type: Sync) {
   exclude "**/*-javadoc.jar"
   exclude "apidocs/**"
   exclude "examples/**"
+
+  // Scary but works. I think clouddriver deps in general need cleaning at some point
+  // Even without the oracle bmc sdk 3rd party deps there's still multiple javax.inject and commons-X JARs
   exclude "**/*jackson*.jar"
   exclude "**/*jersey*.jar"
   exclude "**/hk2*.jar"
@@ -40,6 +45,8 @@ task unpackSdk(type: Sync) {
   exclude "**/osgi*.jar"
   exclude "**/validation*.jar"
   exclude "**/jsr305*.jar"
+  exclude "**/json-smart*.jar"
+  exclude "**/oci-java-sdk-full-shaded-*.jar"
 }
 
 task cleanSdk(type: Delete) {


### PR DESCRIPTION
Upgrade the Oracle OCI SDK dependency in front50-oracle to 1.2.44.  The similar change had been done in clouddriver which uses the same Oracle OCI SDK dependency.  https://github.com/spinnaker/clouddriver/blob/master/clouddriver-oracle/clouddriver-oracle.gradle 