### PR TITLE
fix(s3): Add control over nb of objects retrieved per batch (maxKeys)

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -155,7 +155,8 @@ public class S3Config extends CommonStorageServiceDAOConfig {
       s3Properties.getRootFolder(),
       s3Properties.isFailoverEnabled(),
       s3Properties.getRegion(),
-      s3Properties.getVersioning()
+      s3Properties.getVersioning(),
+      s3Properties.getMaxKeys()
     );
     service.ensureBucketExists();
 

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -29,6 +30,11 @@ public class S3Properties extends S3BucketProperties {
   @NestedConfigurationProperty
   S3EventingProperties eventing = new S3EventingProperties();
 
+  // Front50 retrieves objects in batches of this size. Some S3 compatible store enforce a maximum number of keys
+  @Value("${spinnaker.s3.maxKeys:10000}")
+  private Integer maxKeys;
+
+
   public String getRootFolder() {
     return rootFolder;
   }
@@ -36,6 +42,10 @@ public class S3Properties extends S3BucketProperties {
   public void setRootFolder(String rootFolder) {
     this.rootFolder = rootFolder;
   }
+
+  public Integer getMaxKeys() { return maxKeys; }
+
+  public void setMaxKeys(Integer maxKeys) { this.maxKeys = maxKeys; }
 
   public S3FailoverProperties getFailover() {
     return failover;

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.front50.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -31,8 +30,7 @@ public class S3Properties extends S3BucketProperties {
   S3EventingProperties eventing = new S3EventingProperties();
 
   // Front50 retrieves objects in batches of this size. Some S3 compatible store enforce a maximum number of keys
-  @Value("${spinnaker.s3.maxKeys:10000}")
-  private Integer maxKeys;
+  private Integer maxKeys = 10000;
 
 
   public String getRootFolder() {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -43,9 +43,13 @@ public class S3Properties extends S3BucketProperties {
     this.rootFolder = rootFolder;
   }
 
-  public Integer getMaxKeys() { return maxKeys; }
+  public Integer getMaxKeys() {
+    return maxKeys;
+  }
 
-  public void setMaxKeys(Integer maxKeys) { this.maxKeys = maxKeys; }
+  public void setMaxKeys(Integer maxKeys) {
+    this.maxKeys = maxKeys;
+  }
 
   public S3FailoverProperties getFailover() {
     return failover;

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -47,6 +47,7 @@ public class S3StorageService implements StorageService {
   private final Boolean readOnlyMode;
   private final String region;
   private final Boolean versioning;
+  private final Integer maxKeys;
 
   public S3StorageService(ObjectMapper objectMapper,
                           AmazonS3 amazonS3,
@@ -54,7 +55,8 @@ public class S3StorageService implements StorageService {
                           String rootFolder,
                           Boolean readOnlyMode,
                           String region,
-                          Boolean versioning) {
+                          Boolean versioning,
+                          Integer maxKeys) {
     this.objectMapper = objectMapper;
     this.amazonS3 = amazonS3;
     this.bucket = bucket;
@@ -62,6 +64,7 @@ public class S3StorageService implements StorageService {
     this.readOnlyMode = readOnlyMode;
     this.region = region;
     this.versioning = versioning;
+    this.maxKeys = maxKeys;
   }
 
   @Override
@@ -180,7 +183,7 @@ public class S3StorageService implements StorageService {
   public Map<String, Long> listObjectKeys(ObjectType objectType) {
     long startTime = System.currentTimeMillis();
     ObjectListing bucketListing = amazonS3.listObjects(
-      new ListObjectsRequest(bucket, buildTypedFolder(rootFolder, objectType.group), null, null, 10000)
+      new ListObjectsRequest(bucket, buildTypedFolder(rootFolder, objectType.group), null, null, maxKeys)
     );
     List<S3ObjectSummary> summaries = bucketListing.getObjectSummaries();
 


### PR DESCRIPTION
This is the same PR as #364 for release 1.9 branch.

