### PR TITLE
feat(graphql): Additional trigger filtering

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/Pipeline.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/Pipeline.groovy
@@ -18,9 +18,12 @@
 package com.netflix.spinnaker.front50.model.pipeline
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.front50.model.Timestamped
 
 class Pipeline extends HashMap<String, Object> implements Timestamped {
+
+  private static ObjectMapper mapper = new ObjectMapper()
 
   public static final String TYPE_TEMPLATED = "templatedPipeline"
 
@@ -88,5 +91,14 @@ class Pipeline extends HashMap<String, Object> implements Timestamped {
   @JsonIgnore
   void setType(String type) {
     super.put("type", type)
+  }
+
+  @JsonIgnore
+  Collection<Trigger> getTriggers() {
+    return mapper.convertValue(super.getOrDefault("triggers", new ArrayList<>()), Trigger.COLLECTION_TYPE)
+  }
+
+  void setTriggers(Collection<Trigger> triggers) {
+    this.put("triggers", triggers);
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/Trigger.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/Trigger.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pipeline;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ForwardingMap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Trigger extends ForwardingMap<String, Object> {
+
+  public final static TypeReference<Collection<Trigger>> COLLECTION_TYPE = new TypeReference<Collection<Trigger>>() {};
+
+  private final Map<String, Object> backing = new HashMap<>();
+
+  public String getType() {
+    return (String) backing.get("type");
+  }
+
+  public void setType(String type) {
+    backing.put("type", type);
+  }
+
+  @Override
+  protected Map<String, Object> delegate() {
+    return backing;
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/GraphQLSchemaConfiguration.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/GraphQLSchemaConfiguration.java
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.front50.config;
 
 import com.netflix.spinnaker.front50.graphql.JsonScalarType;
 import com.netflix.spinnaker.front50.graphql.datafetcher.PipelinesDataFetcher;
+import com.netflix.spinnaker.front50.graphql.datafetcher.TriggersDataFetcher;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.StaticDataFetcher;
@@ -27,7 +28,6 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
@@ -44,6 +44,9 @@ public class GraphQLSchemaConfiguration {
         .dataFetcher("version", new StaticDataFetcher("0.1"))
         .dataFetcher("pipelines", pipelinesDataFetcher)
         .defaultDataFetcher(new StaticDataFetcher("TODO"))
+      )
+      .type("Pipeline", builder -> builder
+        .dataFetcher("triggers", new TriggersDataFetcher())
       )
       .type(newTypeWiring("Trigger").typeResolver(env -> (GraphQLObjectType) env.getSchema().getType("CronTrigger")))
       .build();

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/DataFetchingEnvironmentPredicate.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/DataFetchingEnvironmentPredicate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.graphql.datafetcher;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.function.Predicate;
+
+abstract class DataFetchingEnvironmentPredicate<T> implements Predicate<T> {
+
+  protected DataFetchingEnvironment environment;
+
+  public DataFetchingEnvironmentPredicate(DataFetchingEnvironment environment) {
+    this.environment = environment;
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/TriggersDataFetcher.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/TriggersDataFetcher.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.graphql.datafetcher;
+
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.Trigger;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class TriggersDataFetcher implements DataFetcher<Collection<Trigger>> {
+  @Override
+  public Collection<Trigger> get(DataFetchingEnvironment environment) {
+    Pipeline pipeline = environment.getSource();
+    Collection<Trigger> triggers = pipeline.getTriggers();
+
+    if (environment.containsArgument("types")) {
+      Collection<String> types = environment.getArgument("types");
+      return triggers.stream()
+        .filter(t -> types.contains(t.getType()))
+        .collect(Collectors.toList());
+    }
+
+    return triggers;
+  }
+}

--- a/front50-web/src/main/resources/graphql/pipelineConfig.graphqls
+++ b/front50-web/src/main/resources/graphql/pipelineConfig.graphqls
@@ -6,7 +6,7 @@ schema {
 
 type Query {
   version: String!
-  pipelines(havingTriggerType: String): [Pipeline]!
+  pipelines(havingTriggerType: String, disabled: Boolean): [Pipeline]!
 }
 
 type Pipeline {
@@ -24,7 +24,7 @@ type Pipeline {
   spelEvaluator: String!
   stageCounter: Int
   stages: [Stage]!
-  triggers: [Trigger]!
+  triggers(types: [String!]): [Trigger]!
   updateTs: String!
   extra: JSON
 }
@@ -69,16 +69,15 @@ type Stage {
 }
 
 interface Trigger {
-  id: ID!
   type: String!
-  enabled: Boolean!
+  enabled: Boolean
   extra: JSON
 }
 
 type CronTrigger implements Trigger {
-  id: ID!
+  id: ID
   type: String!
-  enabled: Boolean!
-  cronExpression: String!
+  enabled: Boolean
   extra: JSON
+  cronExpression: String!
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/DisabledPredicateSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/DisabledPredicateSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.graphql.datafetcher
+
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import graphql.schema.DataFetchingEnvironment
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DisabledPredicateSpec extends Specification {
+
+  @Unroll
+  def "filters pipelines by disabled status"() {
+    given:
+    DataFetchingEnvironment env = Mock() {
+      containsArgument(_) >> { disabled != null }
+      getArgument(_) >> disabled
+    }
+
+    expect:
+    passes == new PipelinesDataFetcher.DisabledPredicate(env).test(pipeline)
+
+    where:
+    passes || disabled | pipeline
+    true   || null     | new Pipeline(id: "1")
+    true   || null     | new Pipeline(id: "2", disabled: true)
+    true   || null     | new Pipeline(id: "3", disabled: false)
+    true   || true     | new Pipeline(id: "4")
+    true   || true     | new Pipeline(id: "5", disabled: true)
+    false  || true     | new Pipeline(id: "6", disabled: false)
+    false  || false    | new Pipeline(id: "7")
+    false  || false    | new Pipeline(id: "8", disabled: true)
+    true   || false    | new Pipeline(id: "9", disabled: false)
+  }
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/HavingTriggerTypePredicateSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/HavingTriggerTypePredicateSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.graphql.datafetcher
+
+import com.netflix.spinnaker.front50.graphql.datafetcher.PipelinesDataFetcher
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.model.pipeline.Trigger
+import graphql.schema.DataFetchingEnvironment
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class HavingTriggerTypePredicateSpec extends Specification {
+
+  @Unroll
+  def "passes pipelines with more than one trigger"() {
+    given:
+    DataFetchingEnvironment env = Mock() {
+      getArgument(_) >> type
+    }
+
+    expect:
+    passes == new PipelinesDataFetcher.HavingTriggerTypePredicate(env).test(pipeline)
+
+    where:
+    passes || type    | pipeline
+    true   || "cron"  | new Pipeline(id: "1", triggers: [new Trigger([type: "cron"])])
+    false  || "cron"  | new Pipeline(id: "2")
+    false  || "cron"  | new Pipeline(id: "3", triggers: [])
+    true   || "cron"  | new Pipeline(id: "4").with { put("triggers", [[type: "cron"]]); it }
+    true   || null    | new Pipeline(id: "5", triggers: [])
+  }
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/TriggersDataFetcherSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/graphql/datafetcher/TriggersDataFetcherSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.graphql.datafetcher
+
+import com.netflix.spinnaker.front50.graphql.datafetcher.TriggersDataFetcher
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.model.pipeline.Trigger
+import graphql.schema.DataFetchingEnvironment
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TriggersDataFetcherSpec extends Specification {
+
+  @Subject
+  TriggersDataFetcher subject = new TriggersDataFetcher()
+
+  def "fetches a list of triggers"() {
+    given:
+    Pipeline pipeline = new Pipeline()
+    pipeline.triggers = triggers
+
+    and:
+    DataFetchingEnvironment environment = Mock() {
+      getSource() >> pipeline
+      getArguments() >> []
+    }
+
+    when:
+    def result = subject.get(environment)
+
+    then:
+    result == triggers
+
+    where:
+    triggers = [
+      new Trigger([type: "jenkins"]),
+      new Trigger([type: "cron"])
+    ]
+  }
+
+  def "fetches triggers by type"() {
+    given:
+    Pipeline pipeline = new Pipeline()
+    pipeline.triggers = triggers
+
+    and:
+    DataFetchingEnvironment environment = Mock() {
+      getSource() >> pipeline
+      getArguments() >> [types: ["cron"]]
+    }
+
+    when:
+    def result = subject.get(environment)
+
+    then:
+    result == triggers
+
+    where:
+    triggers = [
+      new Trigger([type: "cron"]),
+      new Trigger([type: "jenkins"])
+    ]
+  }
+}


### PR DESCRIPTION
Here's some more stuffs for our POC. Starting to find my feet from a server perspective; the client side of things is still quite dodgy.

```graphql
query {
  pipelines(havingTriggerType: "cron", disabled: false) {
    id
    name
    application
    triggers(types: ["cron"]) {
      ... on CronTrigger {
        id
        enabled
        cronExpression
      }
    }
  }
}
```