### PR TITLE
fix(serviceAccounts): Sync new service accounts with Fiat explicitly

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -75,9 +75,8 @@ public class ServiceAccountsController {
     }
 
     try {
-      // Empty body to keep OkHttp happy: https://github.com/square/retrofit/issues/854
-      fiatService.sync(new ArrayList<String>())
-      log.debug("Synced users with roles")
+      fiatService.loginWithRoles(serviceAccount.name, serviceAccount.memberOf)
+      log.debug("Synced serviceAccount {} with roles {}", serviceAccount.name, serviceAccount.memberOf)
     } catch (RetrofitError re) {
       log.warn("Error syncing users", re)
     }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -77,6 +77,9 @@ public class ServiceAccountsController {
     try {
       fiatService.loginWithRoles(serviceAccount.name, serviceAccount.memberOf)
       log.debug("Synced serviceAccount {} with roles {}", serviceAccount.name, serviceAccount.memberOf)
+      // Empty body to keep OkHttp happy: https://github.com/square/retrofit/issues/854
+      fiatService.sync(new ArrayList<String>())
+      log.debug("Synced users with roles")
     } catch (RetrofitError re) {
       log.warn("Error syncing users", re)
     }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatService
+import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount
+import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ServiceAccountsControllerSpec extends Specification {
+  def serviceAccountDAO = Mock(ServiceAccountDAO)
+  def fiatService = Mock(FiatService)
+  def fiatClientConfigurationProperties = Mock(FiatClientConfigurationProperties)
+
+
+  @Subject
+  def controller = new ServiceAccountsController(
+    serviceAccountDAO: serviceAccountDAO,
+    fiatService: fiatService,
+    fiatClientConfigurationProperties: fiatClientConfigurationProperties
+  )
+
+  def "should sync with fiat on creating a serviceAccount"() {
+    given:
+    def serviceAccount = new ServiceAccount(
+      name: "test-svc-acct",
+      memberOf: [
+        "test-role"
+      ]
+    )
+    when:
+    serviceAccountDAO.create(serviceAccount.id, serviceAccount) >> serviceAccount
+    fiatClientConfigurationProperties.isEnabled() >> true
+    controller.createServiceAccount(serviceAccount)
+    then:
+    1 * fiatService.loginWithRoles(serviceAccount.name, serviceAccount.memberOf)
+  }
+
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
@@ -50,6 +50,7 @@ class ServiceAccountsControllerSpec extends Specification {
     controller.createServiceAccount(serviceAccount)
     then:
     1 * fiatService.loginWithRoles(serviceAccount.name, serviceAccount.memberOf)
+    1 * fiatService.sync([])
   }
 
 }


### PR DESCRIPTION
We use managed service accounts and immediately after we create them, we need to save the pipeline that uses it. This causes that sometimes the Fiat cache is not fresh enough to know about the new service account and we get 404 in Orca while creating the pipelines with the new roles.
We found that using `loginWithRoles` instead of `sync`, makes Fiat aware of the new service account.