### PR TITLE
feat(app/permission): endpoint for single app permissions

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
@@ -72,6 +72,11 @@ public class PermissionsController {
     return actualPermissions.values()
   }
 
+  @RequestMapping(method = RequestMethod.GET, value = "/applications/{appName:.+}")
+  Application.Permission getApplicationPermission(@PathVariable String appName) {
+      return applicationPermissionDAO.findById(appName)
+  }
+
   @ApiOperation(value = "", notes = "Create an application permission.")
   @RequestMapping(method = RequestMethod.POST, value = "/applications")
   Application.Permission createApplicationPermission(


### PR DESCRIPTION
This endpoint is a building block for making it possible to push new
applications into the fiat application cache when they are created.

Currently FIAT updates its application cache every 20th second and this
will help us being able to trigger updates to the cache when an
application is created.

It will follow a PR to fiat that leverages this endpoint. When both of
these are merged there will come a new front50 PR that triggers the fiat
endpoint for adding a new app so that applications will be available to
users immediately after an application is created
