### PR TITLE
fix(trafficguards): default to empty list of traffic guards

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -53,7 +53,7 @@ class Application implements Timestamped {
   String updateTs
   String createTs
   String lastModifiedBy
-  public List<TrafficGuard> trafficGuards
+  public List<TrafficGuard> trafficGuards = []
 
   private Map<String, Object> details = new HashMap<String, Object>()
 


### PR DESCRIPTION
Turns out Front50 serializes null values, surprise