### PR TITLE
fix(core): Better handle case-insensitive identifiers.

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -296,10 +296,11 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
     Map<String, T> resultMap = new HashMap<>();
     for (T item : existingItems) {
       if (keyUpdateTime.containsKey(buildObjectKey(item))) {
-        if (resultMap.containsKey(item.getId())) {
-          log.error("Duplicate item id found, last-write wins: (id: {})", value("id", item.getId()));
+        String itemId = buildObjectKey(item.getId());
+        if (resultMap.containsKey(itemId)) {
+          log.error("Duplicate item id found, last-write wins: (id: {})", value("id", itemId));
         }
-        resultMap.put(item.getId(), item);
+        resultMap.put(itemId, item);
       }
     }
 


### PR DESCRIPTION
We encountered a situation where one of our pipelines had an uppercase
`id` that resulted in two copies returned from `/pipelines/{app}`.

This PR calls `buildObjectKey()` in one more spot and should be more
consistent.
