### PR TITLE
refactor(application): ensure cloudProviders is a comma-separated string

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -53,9 +53,15 @@ class Application implements Timestamped {
   String updateTs
   String createTs
   String lastModifiedBy
+  Object cloudProviders // might be persisted as a List or a String
   public List<TrafficGuard> trafficGuards = []
 
   private Map<String, Object> details = new HashMap<String, Object>()
+
+  String getCloudProviders() {
+    // Orca expects a String
+    return cloudProviders instanceof List ? cloudProviders.join(',') : cloudProviders
+  }
 
   String getName() {
     // there is an expectation that application names are uppercased (historical)

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
@@ -228,6 +228,15 @@ class ApplicationModelSpec extends Specification {
     apps.size() == 2
   }
 
+  void 'should convert cloudProviders to a String if it is a list'() {
+    def listApp = new Application(cloudProviders: ['a','b'])
+    def normalApp = new Application(cloudProviders: 'a,b,c')
+
+    expect:
+    listApp.cloudProviders == 'a,b'
+    normalApp.cloudProviders == 'a,b,c'
+  }
+
   void 'should return empty collection if no apps exist'() {
     def dao = Mock(ApplicationDAO) {
       1 * all() >> { throw new NotFoundException("no apps found") }


### PR DESCRIPTION
https://github.com/spinnaker/orca/pull/2604 assumes `cloudProviders` is a string, so let's make sure it is