### PR TITLE
refactor(applications): migrate cloudProviders to comma-separated string

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/CloudProvidersStringMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/CloudProvidersStringMigration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.migrations;
+
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+@Component
+public class CloudProvidersStringMigration implements Migration {
+  private static final Logger log = LoggerFactory.getLogger(CloudProvidersStringMigration.class);
+
+  // Only valid until June 1st, 2020
+  private static final Date VALID_UNTIL = new GregorianCalendar(2020, 6, 1).getTime();
+
+  @Autowired
+  private ApplicationDAO applicationDAO;
+
+  private Clock clock = Clock.systemDefaultZone();
+
+  @Override
+  public boolean isValid() {
+    return clock.instant().toEpochMilli() < VALID_UNTIL.getTime();
+  }
+
+  @Override
+  public void run() {
+    log.info("Starting cloud provider string migration");
+    for (Application a : applicationDAO.all()) {
+      if (a.details().get("cloudProviders") instanceof List) {
+        migrate(a);
+      }
+    }
+  }
+
+  private void migrate(Application application) {
+    log.info("Converting cloudProviders ({}) for application {} from a List to a String for {}",
+      application.details().get("cloudProviders").toString(),
+      application.getName());
+    application.set("cloudProviders", String.join(",", (List<String>) application.details().get("cloudProviders")));
+    application.update(application);
+  }
+}

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/CloudProvidersStringMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/CloudProvidersStringMigrationSpec.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.migrations
+
+import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.time.Instant
+
+class CloudProvidersStringMigrationSpec extends Specification {
+
+  ApplicationDAO applicationDAO = Mock(ApplicationDAO)
+  Clock clock = Mock(Clock)
+
+  @Subject
+  CloudProvidersStringMigration migration = new CloudProvidersStringMigration(clock: clock, applicationDAO: applicationDAO)
+
+  @Unroll
+  def "should set cloudProviders to a comma-separated string if it is a list"() {
+    given:
+    Application application = new Application(name: "foo", details: [cloudProviders: original], dao: applicationDAO)
+
+    when:
+    migration.run()
+
+    then:
+    _ * applicationDAO.all() >> [application]
+    1 * applicationDAO.update('FOO', { it.details().cloudProviders == expected })
+    _ * clock.instant() >> { Instant.ofEpochMilli(Date.parse("yyyy-MM-dd", "2019-01-24").getTime()) }
+
+    where:
+    original  || expected
+    ["a"]     || "a"
+    ["a","b"] || "a,b"
+  }
+
+  @Unroll
+  def "should not try to update cloudProviders if not a list"() {
+    given:
+    Application application = new Application(name: "foo", details: [cloudProviders: original], dao: applicationDAO)
+
+    when:
+    migration.run()
+
+    then:
+    _ * applicationDAO.all() >> [application]
+    0 * applicationDAO.update(_, _)
+    _ * clock.instant() >> { Instant.ofEpochMilli(Date.parse("yyyy-MM-dd", "2019-01-24").getTime()) }
+
+    where:
+    original << ["a", "a,b", null]
+  }
+
+  @Unroll
+  def "should only be valid until 01 June 2019"() {
+    when:
+    migration.isValid() == isValid
+
+    then:
+    clock.instant() >> { Instant.ofEpochMilli(Date.parse("yyyy-MM-dd", date).getTime()) }
+    0 * _
+
+    where:
+    date         || isValid
+    "2019-06-02" || false
+    "2019-06-01" || true
+    "2019-02-02" || true
+  }
+}


### PR DESCRIPTION
Cleans up data to ensure `cloudProviders` is a string