### PR TITLE
fix(application): Fix persistence of cloudProviders

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -86,7 +86,8 @@ class Application implements Timestamped {
         email: this.email,
         updateTs: this.updateTs,
         createTs: this.createTs,
-        details: this.details
+        details: this.details,
+        cloudProviders: this.cloudProviders,
     ]
   }
 

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
@@ -237,6 +237,17 @@ class ApplicationModelSpec extends Specification {
     normalApp.cloudProviders == 'a,b,c'
   }
 
+  void 'should properly initialize cloudProviders from either a String or a list'() {
+    def listApp = new Application(cloudProviders: ['a','b'])
+    def normalApp = new Application(cloudProviders: 'a,b,c')
+
+    def newApp = new Application()
+
+    expect:
+    newApp.initialize(listApp).cloudProviders == 'a,b'
+    newApp.initialize(normalApp).cloudProviders == 'a,b,c'
+  }
+
   void 'should return empty collection if no apps exist'() {
     def dao = Mock(ApplicationDAO) {
       1 * all() >> { throw new NotFoundException("no apps found") }


### PR DESCRIPTION
The cloudProviders field on applications is not being persisted; it was promoted from 'details' to its own field, but 'getPersistedProperties' was not updated so it is not being set when initializing a new application from the JSON that is posted to front50.  Update getPersistedProperties so it is properly persisted and add a test case.

Fixes a bug from #427 which was caught by our integration tests.