### PR TITLE
fix(application): Persist cloud providers.

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -84,6 +84,7 @@ class Application implements Timestamped {
         name: this.name,
         description: this.description,
         email: this.email,
+        cloudProviders: this.cloudProviders,
         updateTs: this.updateTs,
         createTs: this.createTs,
         details: this.details


### PR DESCRIPTION
Broke in commit 23090d5a32a7e254f65279d1f1555a958fc0f138

@anotherchrisberry 
I dont understand why the earlier PR broke our integration test, but this fixes it.
The earlier PR had started persisting cloudProviders as "null" rather than the comma-delimited string.