### PR TITLE
chore(google): Clean up front50-gcs dependencies

### DIFF
--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -16,11 +16,16 @@
 
 dependencies {
   compile project(":front50-core")
-  compile 'io.reactivex:rxjava:1.0.10'
 
-  spinnaker.group('google')
+  compile spinnaker.dependency('bootAutoConfigure')
   compile spinnaker.dependency('clouddriverGoogleCommon')
-  compile spinnaker.dependency("korkSecurity")
+  compile spinnaker.dependency('commonsLang')
+  compile spinnaker.dependency('googleStorage')
+  compile spinnaker.dependency('korkHystrix')
+  compile spinnaker.dependency('korkSecurity')
+  compile spinnaker.dependency('logstashEncoder')
+  compile spinnaker.dependency('rxJava')
+  compile spinnaker.dependency('spectatorApi')
 
   testCompile project(":front50-test")
 }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -64,7 +64,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;


### PR DESCRIPTION
front50-gcs currently depends on all google libraries whereas it only needs to depend on googleStorage; remove the extra dependencies.  Also, add in explicit dependencies that were transitively included.