### PR TITLE
fix(test/redis): cloudProviders is promoted to its own field now

### DIFF
--- a/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/RedisApplicationDAOSpec.groovy
+++ b/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/RedisApplicationDAOSpec.groovy
@@ -158,6 +158,7 @@ class RedisApplicationDAOSpec extends Specification {
     attribute                        | value
     "email"                          | "updated@netflix.com"
     "description"                    | null
+    "cloudProviders"                 | "aws,titan"
   }
 
   @Unroll
@@ -180,7 +181,6 @@ class RedisApplicationDAOSpec extends Specification {
     "repoProjectKey"                 | "project-key"
     "repoSlug"                       | "repo"
     "repoType"                       | "github"
-    "cloudProviders"                 | "aws,titan"
     "platformHealthOnly"             | "true"
     "platformHealthOnlyShowOverride" | "false"
     "adHocField"                     | "postHocValidation"


### PR DESCRIPTION
Broke in https://github.com/spinnaker/front50/pull/427

FYI @ezimanyi 