### PR TITLE
fix(core): do not overwrite traffic guard configurations

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -118,6 +118,7 @@ class Application implements Timestamped {
     updatedApplication.createTs = this.createTs
     updatedApplication.description = updatedApplication.description ?: this.description
     updatedApplication.email = updatedApplication.email ?: this.email
+    updatedApplication.trafficGuards = updatedApplication.trafficGuards ?: this.trafficGuards
     mergeDetails(updatedApplication, this)
     validate(updatedApplication)
 


### PR DESCRIPTION
Defaulting this to an empty list also means we will always have an empty list when performing an update, which is not great.