### PR TITLE
fix(application): fix tests

### DIFF
--- a/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/RedisApplicationDAOSpec.groovy
+++ b/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/RedisApplicationDAOSpec.groovy
@@ -46,7 +46,7 @@ class RedisApplicationDAOSpec extends Specification {
   @Shared
   Map<String, String> newApplicationAttrs = [
       name: "new-application", email: "email@netflix.com", description: "My application", pdApiKey: "pdApiKey",
-      accounts: "prod,test", repoProjectKey: "project-key", repoSlug: "repo", repoType: "github"
+      accounts: "prod,test", repoProjectKey: "project-key", repoSlug: "repo", repoType: "github", trafficGuards: []
   ]
 
   void setupSpec() {
@@ -191,7 +191,10 @@ class RedisApplicationDAOSpec extends Specification {
     given:
     def application = new Application([
         name       : "app1",
-        description: "My description"
+        description: "My description",
+        details: [
+            trafficGuards: []
+        ]
     ])
     redisApplicationDAO.create("app1", application)
 


### PR DESCRIPTION
Locally front50 tests were failing due to a missing traffic guard object in the created application. This fixes the tests, can you verify that this is correct?