### PR TITLE
fix(core): Fix merge conflict on cherry-pick

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -53,8 +53,6 @@ class Application implements Timestamped {
   String updateTs
   String createTs
   String lastModifiedBy
-  public List<TrafficGuard> trafficGuards = []
-  Object cloudProviders // might be persisted as a List or a String
 
   private Map<String, Object> details = new HashMap<String, Object>()
 


### PR DESCRIPTION
The last commit incorrectly resolved a merge conflict; cloudProviders was never in the 1.12 branch and should not have been added.  Instead, trafficGuards should have been removed.