### PR TITLE
fix(applications): add dao to application before updating

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -99,7 +99,7 @@ class Application implements Timestamped {
   }
 
   @JsonIgnore
-  ApplicationDAO dao
+  public ApplicationDAO dao
 
   @JsonIgnore
   ProjectDAO projectDao

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/CloudProvidersStringMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/CloudProvidersStringMigration.java
@@ -60,6 +60,7 @@ public class CloudProvidersStringMigration implements Migration {
       application.details().get("cloudProviders").toString(),
       application.getName());
     application.set("cloudProviders", String.join(",", (List<String>) application.details().get("cloudProviders")));
+    application.dao = applicationDAO;
     application.update(application);
   }
 }

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RemoveApplicationAccountsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RemoveApplicationAccountsMigration.java
@@ -61,10 +61,9 @@ public class RemoveApplicationAccountsMigration implements Migration {
   }
 
   private void migrate(Application application) {
-    log.info("Removing accounts field ({}) from application {}",
-      application.details().get("accounts").toString(),
-      application.getName());
-    application.details().put("accounts", null);
+    log.info("Removing accounts field from application {}", application.getName());
+    application.details().remove("accounts");
+    application.dao = applicationDAO;
     application.update(application);
   }
 }


### PR DESCRIPTION
The `Application` class is weird and doesn't have the `dao` set on it, even though it relies on it for updates (turns out it gets added in the controller). So our migrations are quickly and quietly failing on the first attempted update.