### PR TITLE
fix(redis): Fix embedded redis leak

### DIFF
--- a/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/config/EmbeddedRedisConfig.java
+++ b/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/config/EmbeddedRedisConfig.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Primary;
 
 @TestConfiguration
 public class EmbeddedRedisConfig {
-  @Bean
+  @Bean(destroyMethod = "destroy")
   EmbeddedRedis embeddedRedis() {
     return EmbeddedRedis.embed();
   }


### PR DESCRIPTION
The refactor of the tests added a redis leak; destroy the bean when it goes out of scope so we don't have a redis outlive the test.