### PR TITLE
feat(authz): Migrate manual service users to managed service users

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
@@ -93,7 +93,9 @@ public class RunAsUserToPermissionsMigration implements Migration {
       if (runAsUser != null && !runAsUser.endsWith(SERVICE_ACCOUNT_SUFFIX)) {
         ServiceAccount manualServiceAccount = serviceAccounts.get(runAsUser);
         if (manualServiceAccount != null && !manualServiceAccount.getMemberOf().isEmpty()) {
-          List<String> oldRoles = manualServiceAccount.getMemberOf();
+          List<String> oldRoles = manualServiceAccount.getMemberOf().stream()
+              .map(String::toLowerCase) // Because roles in Spinnaker are always lowercase
+              .collect(Collectors.toList());
           newRoles.addAll(oldRoles);
         }
       }

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2019 Schibsted Media Group. All rights reserved
+ */
+
+package com.netflix.spinnaker.front50.migrations;
+
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
+import com.netflix.spinnaker.front50.model.pipeline.Trigger;
+import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
+import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
+
+@Component
+@ConditionalOnProperty("migrations.migrateToManagedServiceAccounts")
+public class RunAsUserToPermissionsMigration implements Migration {
+
+  // Only valid until April 1, 2020
+  private static final LocalDate VALID_UNTIL = LocalDate.of(2020, Month.APRIL, 1);
+
+  private static final Logger LOG = LoggerFactory.getLogger(RunAsUserToPermissionsMigration.class);
+  private static final String SERVICE_ACCOUNT_SUFFIX = "@managed-service-account";
+  private static final String RUN_AS_USER = "runAsUser";
+  private static final String ROLES = "roles";
+
+  private final PipelineDAO pipelineDAO;
+  private final ServiceAccountDAO serviceAccountDAO;
+  private Clock clock = Clock.systemDefaultZone();
+
+  @Autowired
+  public RunAsUserToPermissionsMigration(PipelineDAO pipelineDAO, ServiceAccountDAO serviceAccountDAO) {
+    this.pipelineDAO = pipelineDAO;
+    this.serviceAccountDAO = serviceAccountDAO;
+  }
+
+  @Override
+  public boolean isValid() {
+    return LocalDate.now(clock).isBefore(VALID_UNTIL);
+  }
+
+  @Override
+  public void run() {
+    LOG.info("Starting runAsUser to automatic service user migration ({})", this.getClass().getSimpleName());
+
+    Map<String, ServiceAccount> serviceAccounts = serviceAccountDAO.all().stream()
+        .collect(Collectors.toMap(ServiceAccount::getName, Function.identity()));
+
+    pipelineDAO.all().parallelStream()
+        .filter(p -> p.get(ROLES) == null || ((List) p.get(ROLES)).isEmpty())
+        .filter(p -> p.getTriggers().stream().anyMatch(this::hasManualServiceUser))
+        .forEach(pipeline -> migrate(pipeline, serviceAccounts));
+
+    LOG.info("Finished runAsUser to automatic service user migration");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void migrate(Pipeline pipeline, Map<String, ServiceAccount> serviceAccounts) {
+    LOG.info("Starting migration of pipeline '{}' (application: '{}', pipelineId: '{}')",
+        value("pipelineName", pipeline.getName()),
+        value("application", pipeline.getApplication()),
+        value("pipelineId", pipeline.getId())
+    );
+
+    Set<String> newRoles = new HashSet<>();
+
+    String serviceAccountName = generateSvcAcctName(pipeline);
+
+    ServiceAccount automaticServiceAccount = new ServiceAccount();
+    automaticServiceAccount.setName(serviceAccountName);
+
+    Collection<Trigger> triggers = pipeline.getTriggers();
+
+    triggers.forEach(trigger -> {
+      String runAsUser = (String) trigger.get(RUN_AS_USER);
+      if (runAsUser != null && !runAsUser.endsWith(SERVICE_ACCOUNT_SUFFIX)) {
+        ServiceAccount manualServiceAccount = serviceAccounts.get(runAsUser);
+        if (manualServiceAccount != null && !manualServiceAccount.getMemberOf().isEmpty()) {
+          List<String> oldRoles = manualServiceAccount.getMemberOf();
+          newRoles.addAll(oldRoles);
+        }
+      }
+      LOG.info("Replacing '{}' with automatic service user '{}' (application: '{}', pipelineName: '{}', "
+              + "pipelineId: '{}')",
+          value("oldServiceUser", runAsUser),
+          value("newServiceUser", serviceAccountName),
+          value("application", pipeline.getApplication()),
+          value("pipelineName", pipeline.getName()),
+          value("pipelineId", pipeline.getId())
+      );
+      trigger.put(RUN_AS_USER, serviceAccountName);
+    });
+
+    LOG.info("Creating service user '{}' with roles {}", serviceAccountName, newRoles);
+    automaticServiceAccount.getMemberOf().addAll(newRoles);
+    pipeline.put(ROLES, new ArrayList<>(newRoles));
+    pipeline.setTriggers(triggers);
+
+    serviceAccountDAO.create(automaticServiceAccount.getId(), automaticServiceAccount);
+    pipelineDAO.update(pipeline.getId(), pipeline);
+  }
+
+  private boolean hasManualServiceUser(Trigger trigger) {
+    String runAsUser = (String) trigger.get(RUN_AS_USER);
+    return runAsUser != null && !runAsUser.endsWith(SERVICE_ACCOUNT_SUFFIX);
+  }
+
+  private String generateSvcAcctName(Pipeline pipeline) {
+    if (pipeline.containsKey("serviceAccount")) {
+      return (String) pipeline.get("serviceAccount");
+    }
+    String pipelineName = pipeline.getId();
+    return pipelineName.toLowerCase() + SERVICE_ACCOUNT_SUFFIX;
+  }
+
+  void setClock(Clock clock) {
+    this.clock = clock;
+  }
+}

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
@@ -71,7 +71,6 @@ public class RunAsUserToPermissionsMigration implements Migration {
     LOG.info("Finished runAsUser to automatic service user migration");
   }
 
-  @SuppressWarnings("unchecked")
   private void migrate(Pipeline pipeline, Map<String, ServiceAccount> serviceAccounts) {
     LOG.info("Starting migration of pipeline '{}' (application: '{}', pipelineId: '{}')",
         value("pipelineName", pipeline.getName()),

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2019 Schibsted Media Group. All rights reserved
+ */
+
+package com.netflix.spinnaker.front50.migrations
+
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount
+import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class RunAsUserToPermissionsMigrationSpec extends Specification {
+  PipelineDAO pipelineDAO = Mock()
+  ServiceAccountDAO serviceAccountDAO = Mock()
+
+  @Subject
+  def migration = new RunAsUserToPermissionsMigration(pipelineDAO, serviceAccountDAO)
+
+  @Unroll
+  def "should #shouldRun migration if time is #date"() {
+    given:
+    migration.setClock(Clock.fixed(Instant.parse(date), ZoneId.of("Z")))
+
+    when:
+    def valid = migration.isValid()
+
+    then:
+    valid == expectedValid
+
+    where:
+    date                      || expectedValid
+    "2019-04-01T10:15:30.00Z" || true
+    "2020-03-31T23:59:59.99Z" || true
+    "2020-04-01T00:00:00.00Z" || false
+    "2020-04-02T10:15:30.00Z" || false
+    shouldRun = "${expectedValid ? '' : 'not '}run"
+
+  }
+
+  def "should not migrate a pipeline with roles set"() {
+    given:
+    def pipeline = new Pipeline([
+      application: "test",
+      id: "1337",
+      name: "My Pipeline",
+      roles: [
+        "my-role"
+      ],
+      triggers: [
+        [
+          enabled: true,
+          job: "org/repo/master",
+          master: "travis",
+          runAsUser: "my-existing-service-user@org.com",
+          type: "travis"
+        ]
+      ]
+    ])
+
+    when:
+    migration.run()
+
+    then:
+    1 * serviceAccountDAO.all() >> []
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update(_, _)
+    0 * serviceAccountDAO.create(_, _)
+  }
+
+  def "should not migrate a pipeline with an automatic service user already set"() {
+    given:
+    def pipeline = new Pipeline([
+      application: "test",
+      id: "1337",
+      name: "My Pipeline",
+      roles: [
+      ],
+      triggers: [
+        [
+          enabled: true,
+          job: "org/repo/master",
+          master: "travis",
+          runAsUser: "1337@managed-service-account",
+          type: "travis"
+        ]
+      ]
+    ])
+
+    when:
+    migration.run()
+
+    then:
+    1 * serviceAccountDAO.all() >> []
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update(_, _)
+    0 * serviceAccountDAO.create(_, _)
+  }
+
+  def "should not migrate a pipeline with neither roles or runAsUser set"() {
+    given:
+    def pipeline = new Pipeline([
+      application: "test",
+      id: "1337",
+      name: "My Pipeline",
+      roles: [
+      ],
+      triggers: [
+        [
+          enabled: true,
+          job: "org/repo/master",
+          master: "travis",
+          type: "travis"
+        ]
+      ]
+    ])
+
+    when:
+    migration.run()
+
+    then:
+    1 * serviceAccountDAO.all() >> []
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update(_, _)
+    0 * serviceAccountDAO.create(_, _)
+  }
+
+  def "should migrate pipeline with a simple trigger"() {
+    given:
+    def pipeline = new Pipeline([
+      application: "test",
+      id: "1337",
+      name: "My Pipeline",
+      roles: [
+      ],
+      triggers: [
+        [
+          enabled: true,
+          job: "org/repo/master",
+          master: "travis",
+          runAsUser: "my-existing-service-user@org.com",
+          type: "travis"
+        ]
+      ]
+    ])
+    def serviceAccount = new ServiceAccount(
+      name: "my-existing-service-user@org.com",
+      memberOf: ["my-role", "another-role"]
+    )
+
+    when:
+    migration.run()
+
+    then:
+    1 * serviceAccountDAO.all() >> [serviceAccount]
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    1 * pipelineDAO.update("1337", pipeline)
+    1 * serviceAccountDAO.create("1337@managed-service-account", _)
+
+    pipeline.roles == ["my-role", "another-role"]
+    pipeline.getTriggers()*.get("runAsUser") == ["1337@managed-service-account"]
+  }
+
+  def "should migrate pipeline with multiple triggers"() {
+    given:
+    def pipeline = new Pipeline([
+      application: "test",
+      id: "1337",
+      name: "My Pipeline",
+      roles: [],
+      triggers: [
+        [
+          enabled: true,
+          job: "org/repo/master",
+          master: "travis",
+          runAsUser: "my-existing-service-user@org.com",
+          type: "travis"
+        ], [
+          enabled: true,
+          job: "org/repo/master",
+          master: "jenkins",
+          type: "jenkins"
+        ]
+      ]
+    ])
+    def serviceAccount = new ServiceAccount(
+      name: "my-existing-service-user@org.com",
+      memberOf: ["my-role", "another-role"]
+    )
+
+    when:
+    migration.run()
+
+    then:
+    1 * serviceAccountDAO.all() >> [serviceAccount]
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    1 * pipelineDAO.update("1337", pipeline)
+    1 * serviceAccountDAO.create("1337@managed-service-account", _)
+
+    pipeline.roles == ["my-role", "another-role"]
+    pipeline.getTriggers()*.get("runAsUser") == ["1337@managed-service-account", "1337@managed-service-account"]
+  }
+
+  def "should migrate pipeline with multiple triggers with different service accounts"() {
+    given:
+    def pipeline = new Pipeline([
+      application: "test",
+      id: "1337",
+      name: "My Pipeline",
+      roles: [],
+      triggers: [
+        [
+          enabled: true,
+          job: "org/repo/master",
+          master: "travis",
+          runAsUser: "my-existing-service-user@org.com",
+          type: "travis"
+        ], [
+        enabled: true,
+        job: "org/repo/master",
+        master: "jenkins",
+        runAsUser: "another-existing-service-user@org.com",
+        type: "jenkins"
+      ]
+      ]
+    ])
+    def travisServiceAccount = new ServiceAccount(
+      name: "my-existing-service-user@org.com",
+      memberOf: ["my-role", "another-role"]
+    )
+    def jenkinsServiceAccount = new ServiceAccount(
+      name: "another-existing-service-user@org.com",
+      memberOf: ["foo", "bar"]
+    )
+
+    when:
+    migration.run()
+
+    then:
+    1 * serviceAccountDAO.all() >> [travisServiceAccount, jenkinsServiceAccount]
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    1 * pipelineDAO.update("1337", pipeline)
+    1 * serviceAccountDAO.create("1337@managed-service-account", _)
+
+    pipeline.roles.sort() == ["my-role", "another-role", "foo", "bar"].sort()
+    pipeline.getTriggers()*.get("runAsUser") == ["1337@managed-service-account", "1337@managed-service-account"]
+  }
+
+}


### PR DESCRIPTION
This migration will migrate pipelines that have manual service users to use the new permissions format. It will only run on pipelines where `roles` are not present and `runAsUser` is set to a non-managed service account.
The migration job will automatically create the new managed service users, and the new service user will get the same permissions as the manual service user that it replaces.

The migration must be manually enabled by setting the property `migrations.migrateToManagedServiceAccounts` to `true`.

*Note:* If a pipeline has multiple triggers with _different_ `runAsUser`'s set, the new managed service user will get all of the roles of the different manual service users (as you can only have one managed service user per pipeline). This can potentially remove some users ability to edit or execute affected pipelines. However, I do not think this is a very common scenario.