### PR TITLE
fix(application): do not blow away cloudProviders when updating appli…

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -125,6 +125,7 @@ class Application implements Timestamped {
     updatedApplication.createTs = this.createTs
     updatedApplication.description = updatedApplication.description ?: this.description
     updatedApplication.email = updatedApplication.email ?: this.email
+    updatedApplication.cloudProviders = updatedApplication.cloudProviders ?: this.cloudProviders
     mergeDetails(updatedApplication, this)
     validate(updatedApplication)
 


### PR DESCRIPTION
…cation

This has been a sneaky bug since forever. If you submit a partial update to an application, but don't include the `cloudProviders` field, it's gone. We happen to do this internally sometimes.
