### PR TITLE
fix(pipelines): More robust handling of missing cron trigger id's

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -108,19 +108,15 @@ class PipelineController {
     pipeline.name = pipeline.getName().trim()
     pipeline = ensureCronTriggersHaveIdentifier(pipeline)
 
-    if (!pipeline.id || extractCronTriggersWithoutId(pipeline)) {
+    if (!pipeline.id) {
       // ensure that cron triggers are assigned a unique identifier for new pipelines
-      extractCronTriggersWithoutId(pipeline).each { Map trigger ->
+      def triggers = (pipeline.triggers ?: []) as List<Map>
+      triggers.findAll { it.type == "cron" }.each { Map trigger ->
         trigger.id = UUID.randomUUID().toString()
       }
     }
 
     return pipelineDAO.create(pipeline.id as String, pipeline)
-  }
-
-  private static List<Map> extractCronTriggersWithoutId(Pipeline pipeline) {
-    def triggers = (pipeline.triggers ?: []) as List<Map>
-    triggers.findAll { it.type == "cron" && !it.id }
   }
 
   @PreAuthorize("@fiatPermissionEvaluator.isAdmin()")

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -108,11 +108,14 @@ class PipelineController {
     pipeline.name = pipeline.getName().trim()
     pipeline = ensureCronTriggersHaveIdentifier(pipeline)
 
-    if (!pipeline.id) {
+    if (!pipeline.id || pipeline.regenerateCronTriggerIds) {
       // ensure that cron triggers are assigned a unique identifier for new pipelines
       def triggers = (pipeline.triggers ?: []) as List<Map>
       triggers.findAll { it.type == "cron" }.each { Map trigger ->
         trigger.id = UUID.randomUUID().toString()
+      }
+      if (pipeline.regenerateCronTriggerIds) {
+        pipeline.remove("regenerateCronTriggerIds")
       }
     }
 


### PR DESCRIPTION
Needed because we sometimes generate the pipeline id outside Front50 (e.g. https://github.com/spinnaker/orca/pull/2754)