### PR TITLE
chore(syncroles): Sync only the service account roles

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -81,7 +81,7 @@ public class ServiceAccountsController {
     }
     try {
       // Empty body to keep OkHttp happy: https://github.com/square/retrofit/issues/854
-      fiatService.sync(new ArrayList<String>())
+      fiatService.sync(serviceAccount.memberOf)
       log.debug("Synced users with roles")
       // Invalidate the current user's permissions in the local cache
       Authentication auth = SecurityContextHolder.getContext().getAuthentication()

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -80,7 +80,6 @@ public class ServiceAccountsController {
       return
     }
     try {
-      // Empty body to keep OkHttp happy: https://github.com/square/retrofit/issues/854
       fiatService.sync(serviceAccount.memberOf)
       log.debug("Synced users with roles")
       // Invalidate the current user's permissions in the local cache

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
@@ -53,7 +53,7 @@ class ServiceAccountsControllerSpec extends Specification {
 
     then:
     1 * fiatPermissionsEvaluator.invalidatePermission(_)
-    1 * fiatService.sync([])
+    1 * fiatService.sync(["test-role"])
   }
 
 }


### PR DESCRIPTION
Doing a full sync implies querying all the service accounts back to
front50 when doing the sync. However, we only need to pass the roles of
the service user being created. This helps on sync time when the amount
of service accounts is huge.