### PR TITLE
fix(authz): Automatic Service Account migration missing some pipelines

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
@@ -97,10 +97,9 @@ public class RunAsUserToPermissionsMigration implements Migration {
       if (runAsUser != null && !runAsUser.endsWith(SERVICE_ACCOUNT_SUFFIX)) {
         ServiceAccount manualServiceAccount = serviceAccounts.get(runAsUser);
         if (manualServiceAccount != null && !manualServiceAccount.getMemberOf().isEmpty()) {
-          List<String> oldRoles = manualServiceAccount.getMemberOf().stream()
+          manualServiceAccount.getMemberOf().stream()
               .map(String::toLowerCase) // Because roles in Spinnaker are always lowercase
-              .collect(Collectors.toList());
-          newRoles.addAll(oldRoles);
+              .forEach(newRoles::add);
         }
       }
       log.info("Replacing '{}' with automatic service user '{}' (application: '{}', pipelineName: '{}', "

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
@@ -10,8 +10,6 @@ import com.netflix.spinnaker.front50.model.pipeline.Trigger;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -65,13 +63,13 @@ public class RunAsUserToPermissionsMigration implements Migration {
         .collect(Collectors.toMap(ServiceAccount::getName, Function.identity()));
 
     pipelineDAO.all().parallelStream()
-        .filter(p -> p.get(ROLES) == null || ((List) p.get(ROLES)).isEmpty())
         .filter(p -> p.getTriggers().stream().anyMatch(this::hasManualServiceUser))
         .forEach(pipeline -> migrate(pipeline, serviceAccounts));
 
     log.info("Finished runAsUser to automatic service user migration");
   }
 
+  @SuppressWarnings("unchecked")
   private void migrate(Pipeline pipeline, Map<String, ServiceAccount> serviceAccounts) {
     log.info("Starting migration of pipeline '{}' (application: '{}', pipelineId: '{}')",
         value("pipelineName", pipeline.getName()),
@@ -80,6 +78,12 @@ public class RunAsUserToPermissionsMigration implements Migration {
     );
 
     Set<String> newRoles = new HashSet<>();
+    List<String> existingRoles = (List) pipeline.get(ROLES);
+    if (existingRoles != null) {
+      existingRoles.stream()
+        .map(String::toLowerCase)
+        .forEach(newRoles::add);
+    }
 
     String serviceAccountName = generateSvcAcctName(pipeline);
 

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
@@ -16,12 +16,16 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-class RunAsUserToPermissionsMigrationSpec extends Specification {
+class   RunAsUserToPermissionsMigrationSpec extends Specification {
   PipelineDAO pipelineDAO = Mock()
   ServiceAccountDAO serviceAccountDAO = Mock()
 
   @Subject
   def migration = new RunAsUserToPermissionsMigration(pipelineDAO, serviceAccountDAO)
+
+  def setup() {
+    migration.setClock(Clock.fixed(Instant.parse("2019-04-01T10:15:30.00Z"), ZoneId.of("Z")))
+  }
 
   @Unroll
   def "should #shouldRun migration if time is #date"() {
@@ -44,14 +48,14 @@ class RunAsUserToPermissionsMigrationSpec extends Specification {
 
   }
 
-  def "should not migrate a pipeline with roles set"() {
+  def "should migrate pipeline if one trigger is missing automatic service user"() {
     given:
     def pipeline = new Pipeline([
       application: "test",
       id: "1337",
       name: "My Pipeline",
       roles: [
-        "my-role"
+        "My-Role"
       ],
       triggers: [
         [
@@ -60,18 +64,32 @@ class RunAsUserToPermissionsMigrationSpec extends Specification {
           master: "travis",
           runAsUser: "my-existing-service-user@org.com",
           type: "travis"
+        ], [
+          enabled: true,
+          job: "org/repo2/master",
+          master: "jenkins",
+          runAsUser: "1337@managed-service-account",
+          type: "jenkins"
         ]
       ]
     ])
+
+    def serviceAccount = new ServiceAccount(
+      name: "my-existing-service-user@org.com",
+      memberOf: ["Another-Role"]
+    )
 
     when:
     migration.run()
 
     then:
-    1 * serviceAccountDAO.all() >> []
+    1 * serviceAccountDAO.all() >> [serviceAccount]
     1 * pipelineDAO.all() >> { return [pipeline] }
-    0 * pipelineDAO.update(_, _)
-    0 * serviceAccountDAO.create(_, _)
+    1 * pipelineDAO.update("1337", pipeline)
+    1 * serviceAccountDAO.create("1337@managed-service-account", _)
+
+    pipeline.roles == ["my-role", "another-role"]
+    pipeline.getTriggers()*.get("runAsUser") == ["1337@managed-service-account", "1337@managed-service-account"]
   }
 
   def "should not migrate a pipeline with an automatic service user already set"() {
@@ -80,8 +98,6 @@ class RunAsUserToPermissionsMigrationSpec extends Specification {
       application: "test",
       id: "1337",
       name: "My Pipeline",
-      roles: [
-      ],
       triggers: [
         [
           enabled: true,

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
@@ -16,7 +16,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-class   RunAsUserToPermissionsMigrationSpec extends Specification {
+class RunAsUserToPermissionsMigrationSpec extends Specification {
   PipelineDAO pipelineDAO = Mock()
   ServiceAccountDAO serviceAccountDAO = Mock()
 


### PR DESCRIPTION
If a pipeline has two or more triggers, but not all are updated to automatic service accounts, the pipeline would still be skipped in the migration because `roles` would already be present. This PR fixes so that existing roles will be handled and triggers with manual service users are always migrated.