### PR TITLE
fix(s3): Favor the persisted `lastModified` time over the s3 timestamp

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -112,7 +112,11 @@ public class S3StorageService implements StorageService {
     try {
       S3Object s3Object = amazonS3.getObject(bucket, buildS3Key(objectType.group, objectKey, objectType.defaultMetadataFilename));
       T item = deserialize(s3Object, (Class<T>) objectType.clazz);
-      item.setLastModified(s3Object.getObjectMetadata().getLastModified().getTime());
+
+      if (item.getLastModified() == null) {
+        item.setLastModified(s3Object.getObjectMetadata().getLastModified().getTime());
+      }
+
       return item;
     } catch (AmazonS3Exception e) {
       if (e.getStatusCode() == 404) {
@@ -230,7 +234,11 @@ public class S3StorageService implements StorageService {
             new GetObjectRequest(bucket, buildS3Key(objectType.group, objectKey, objectType.defaultMetadataFilename), s3VersionSummary.getVersionId())
           );
           T item = deserialize(s3Object, (Class<T>) objectType.clazz);
-          item.setLastModified(s3Object.getObjectMetadata().getLastModified().getTime());
+
+          if (item.getLastModified() == null) {
+            item.setLastModified(s3Object.getObjectMetadata().getLastModified().getTime());
+          }
+
           return item;
         } catch (IOException e) {
           throw new IllegalStateException(e);


### PR DESCRIPTION
This preserves last modified timestamps when keys are migrated across
buckets.
