### PR TITLE
feat(MPTv2): Updates latest tag on v2 MPT write.

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineTemplate.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineTemplate.java
@@ -89,6 +89,15 @@ public class PipelineTemplate extends HashMap<String, Object> implements Timesta
     return (updateTs != null) ? Long.valueOf(updateTs) : null;
   }
 
+  /**
+   * Removes and returns last modified time from the pipeline template.
+   * @return last modified time of the pipeline template.
+   */
+  public Long removeLastModified() {
+    String updateTs = (String) super.remove("updateTs");
+    return (updateTs != null) ? Long.valueOf(updateTs) : null;
+  }
+
   @Override
   public void setLastModified(Long lastModified) {
     super.put("updateTs", lastModified.toString());
@@ -97,6 +106,14 @@ public class PipelineTemplate extends HashMap<String, Object> implements Timesta
   @Override
   public String getLastModifiedBy() {
     return (String) super.get("lastModifiedBy");
+  }
+
+  /**
+   * Removes and returns user that last modified the pipeline template.
+   * @return user last modifying the pipeline template.
+   */
+  public String removeLastModifiedBy() {
+    return (String) super.remove("lastModifiedBy");
   }
 
   @Override


### PR DESCRIPTION
Also: 

* made some fixes to digest last updated time handling -- previously on each update we were calculating a different hash due to the update time rolling.

* fixed strange error handling in `/create` where we would no-op and succeed when trying to write a duplicate id + tag combo.