### PR TITLE
fix(permissions): Make permission retrieval consistent

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -134,6 +134,8 @@ public class ApplicationsController {
       def perm = applicationPermissionDAO?.findById(app.name)
       if (perm?.permissions?.isRestricted()) {
         app.details().put("permissions", perm.permissions)
+      } else {
+        application.details().remove("permissions")
       }
     } catch (NotFoundException nfe) {
       // ignored.


### PR DESCRIPTION
In the cases where the application metadata has the permissions block
(for whatever reason - it should never have it) but the actual permissions are
empty, querying the application (via `/v2/applications/{appname}`) will return
the erroneous permissions object. Instead, make the single app getter EP
symmetric with all application getter EP (`/v2/applications`) and strip out
the permissions object when the permissions aren't there

see https://github.com/spinnaker/front50/pull/505 for change to the all
applications endpoint
