### PR TITLE
feat(fiat): Adds migrator to add execute permissions to applications.

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/ApplicationExecutePermissionMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/ApplicationExecutePermissionMigration.java
@@ -1,0 +1,68 @@
+package com.netflix.spinnaker.front50.migrations;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+
+@Component
+@Slf4j
+public class ApplicationExecutePermissionMigration implements Migration {
+
+  // Only valid until May 1st, 2020
+  private static final LocalDate VALID_UNTIL = LocalDate.of(2020, Month.APRIL, 1);
+
+  private ApplicationPermissionDAO applicationPermissionDAO;
+
+  @Setter
+  private Clock clock = Clock.systemDefaultZone();
+
+  @Autowired
+  public ApplicationExecutePermissionMigration(
+      ApplicationPermissionDAO applicationPermissionDAO) {
+    this.applicationPermissionDAO = applicationPermissionDAO;
+  }
+
+  @Override
+  public boolean isValid() {
+    return LocalDate.now(clock).isBefore(VALID_UNTIL);
+  }
+
+  @Override
+  public void run() {
+    log.info("Starting migration of applications to include execute permissions ({})", this.getClass().getSimpleName());
+
+    applicationPermissionDAO.all().stream()
+        .filter(ap -> ap.getPermissions()!= null && ap.getPermissions().isRestricted()) // Ignore unrestricted applications
+        .filter(this::executeNotPresent) // Ignore applications that already have EXECUTE set
+        .forEach(app -> migrate(applicationPermissionDAO, app));
+  }
+
+  private boolean executeNotPresent(Application.Permission app) {
+    return CollectionUtils.isEmpty(app.getPermissions().get(Authorization.EXECUTE));
+  }
+
+  private void migrate(ApplicationPermissionDAO applicationPermissionDAO, Application.Permission app) {
+    log.info("Adding execute permissions to application: {} for users in groups: {}", app.getId(), app.getPermissions().allGroups());
+    Permissions permissions = app.getPermissions();
+    Permissions.Builder builder = new Permissions.Builder();
+    builder.add(Authorization.READ, permissions.get(Authorization.READ));
+    builder.add(Authorization.WRITE, permissions.get(Authorization.WRITE));
+
+    // Currently, anyone with READ permission can execute a pipeline and WRITE implies a READ.
+    // So, we'll give EXECUTE permissions to all groups that have READ or WRITE on an application.
+    builder.add(Authorization.EXECUTE, new ArrayList<>(permissions.allGroups()));
+    app.setPermissions(builder.build());
+    applicationPermissionDAO.update(app.getId(), app);
+  }
+}

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/ApplicationExecutePermissionMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/ApplicationExecutePermissionMigrationSpec.groovy
@@ -1,0 +1,111 @@
+package com.netflix.spinnaker.front50.migrations
+
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class ApplicationExecutePermissionMigrationSpec extends Specification {
+
+  def applicationPermissionDao = Mock(ApplicationPermissionDAO)
+
+  @Subject
+  def migration = new ApplicationExecutePermissionMigration(applicationPermissionDao)
+
+  def setup() {
+    migration.setClock(Clock.fixed(Instant.parse("2019-04-01T10:15:30.00Z"), ZoneId.of("Z")))
+  }
+
+  @Unroll
+  def "should #shouldRun migration if time is #date"() {
+    given:
+    migration.setClock(Clock.fixed(Instant.parse(date), ZoneId.of("Z")))
+
+    when:
+    def valid = migration.isValid()
+
+    then:
+    valid == expectedValid
+
+    where:
+    date                      || expectedValid
+    "2019-04-01T10:15:30.00Z" || true
+    "2020-03-31T23:59:59.99Z" || true
+    "2020-04-01T00:00:00.00Z" || false
+    "2020-04-02T10:15:30.00Z" || false
+    shouldRun = "${expectedValid ? '' : 'not '}run"
+
+  }
+
+  def "should not migrate unrestricted applications"() {
+    given:
+    def applicationPermission = new Application.Permission(name: "foo", permissions: givenPermissions)
+
+    when:
+    migration.run()
+
+    then:
+    1 * applicationPermissionDao.all() >> [applicationPermission]
+    0 * applicationPermissionDao.update("foo", applicationPermission)
+
+    applicationPermission.permissions == expectedPermissions
+
+    where:
+    givenPermissions       || expectedPermissions
+    null                   || null
+    Permissions.EMPTY      || Permissions.EMPTY
+
+  }
+
+  def "should not migrate an application if it already contains an EXECUTE permission"() {
+    given:
+    def builder = new Permissions.Builder()
+    builder.add(Authorization.READ, "readers")
+    builder.add(Authorization.WRITE, "writers")
+    builder.add(Authorization.EXECUTE, "executors")
+    def permissions = builder.build()
+
+    def applicationPermission = new Application.Permission(name: "foo", permissions: permissions)
+
+    when:
+    migration.run()
+
+    then:
+    1 * applicationPermissionDao.all() >> [applicationPermission]
+    0 * applicationPermissionDao.update("foo", applicationPermission)
+    applicationPermission.permissions == permissions
+  }
+
+  def "should add EXECUTE permissions to all groups with READ or WRITE permission"() {
+    given:
+    def builder = new Permissions.Builder()
+    builder.add(Authorization.READ, "readers")
+    builder.add(Authorization.WRITE, "writers")
+
+    def initialPermissions = builder.build()
+
+    builder.add(Authorization.EXECUTE, ["readers", "writers"])
+    def expectedPermissions = builder.build()
+
+    def applicationPermission = new Application.Permission(
+        name: "foo",
+        permissions: initialPermissions
+    )
+
+    when:
+    migration.run()
+
+    then:
+    1 * applicationPermissionDao.all() >> [applicationPermission]
+    1 * applicationPermissionDao.update("foo", applicationPermission)
+
+    applicationPermission.permissions == expectedPermissions
+  }
+}


### PR DESCRIPTION
Execute is added to all groups that currently have READ or WRITE permissions on an application. This is because currently anyone with READ permission can execute a pipeline.

Checks enforcing that users need EXECUTE to trigger a pipeline is coming in a follow up PR. 

Part of spinnaker/spinnaker#3554