### PR TITLE
fix(core): Ensure lastModified and lastModifiedBy is set on item

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -219,6 +219,8 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
   }
 
   public void update(String id, T item) {
+    item.setLastModifiedBy(AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
+    item.setLastModified(System.currentTimeMillis());
     service.storeObject(objectType, buildObjectKey(id), item);
   }
 

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/model/GcsStorageService.java
@@ -43,7 +43,6 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.retry.GcsSafeRetry;
-import com.netflix.spinnaker.security.AuthenticatedRequest;
 import groovy.lang.Closure;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
@@ -390,8 +389,6 @@ public class GcsStorageService implements StorageService {
 
   @Override
   public <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T obj) {
-    obj.setLastModifiedBy(AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
-
     byte[] bytes;
     String path = keyToPath(objectKey, objectType.group);
     try {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.netflix.spinnaker.front50.exception.NotFoundException;
-import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Duration;
@@ -165,7 +164,6 @@ public class S3StorageService implements StorageService {
       throw new ReadOnlyModeException();
     }
     try {
-      item.setLastModifiedBy(AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
       byte[] bytes = objectMapper.writeValueAsBytes(item);
 
       ObjectMetadata objectMetadata = new ObjectMetadata();


### PR DESCRIPTION
Currently we're relying on the underlying `StorageService` implementations
to set and track lastModified and lastModifiedBy.

Pulling it up to the `StorageServiceSupport` ensures consistent behavior
across all current and future `StorageService` implementations.
