### PR TITLE
fix(core): A better case insensitive comparison when bulk loading objects

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -362,7 +362,7 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
 
       Map<String, T> objectsById =
           objects.stream()
-              .collect(Collectors.toMap(Timestamped::getId, Function.identity(), (o1, o2) -> o1));
+              .collect(Collectors.toMap(this::buildObjectKey, Function.identity(), (o1, o2) -> o1));
 
       for (String objectKey : objectKeys) {
         if (objectsById.containsKey(objectKey)) {
@@ -371,6 +371,8 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
           // equivalent to the NotFoundException handling in the exceptional case below
           resultMap.remove(keyToId.get(objectKey));
           numRemoved.getAndIncrement();
+
+          log.warn("Unable to find result for {}:{} (filtering!)", objectType, objectKey);
         }
       }
     } catch (UnsupportedOperationException e) {


### PR DESCRIPTION
Previously was using `Timestamped::getId` which may not always return
_expected_ lower case `id`.
