### PR TITLE
feat(web): New `/admin/recover` endpoint

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/AdminOperations.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/AdminOperations.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import lombok.Data;
+
+public interface AdminOperations {
+  void recover(Recover operation);
+
+  @Data
+  class Recover {
+    String objectType;
+    String objectId;
+  }
+}

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -103,6 +103,17 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
         expectThrows<NotFoundException> {
           sqlStorageService.loadObject<Application>(ObjectType.APPLICATION, "application001")
         }
+
+        // recover the application
+        sqlStorageService.recover(
+          AdminOperations.Recover().apply {
+            objectType = "application"
+            objectId = "application001"
+          }
+        )
+
+        application = sqlStorageService.loadObject(ObjectType.APPLICATION, "application001")
+        expectThat(application.description).isEqualTo("my updated application!")
       }
     }
 

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/AdminController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/AdminController.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers;
+
+import com.netflix.spinnaker.front50.model.AdminOperations;
+import groovy.util.logging.Slf4j;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import java.util.Collection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin")
+@Api(value = "admin", description = "Various administrative operations")
+public class AdminController {
+  private final Collection<AdminOperations> adminOperations;
+
+  @Autowired
+  public AdminController(Collection<AdminOperations> adminOperations) {
+    this.adminOperations = adminOperations;
+  }
+
+  @ApiOperation(value = "", notes = "Recover a previously deleted object")
+  @RequestMapping(value = "/recover", method = RequestMethod.POST)
+  void recover(@RequestBody AdminOperations.Recover operation) {
+    adminOperations.forEach(o -> o.recover(operation));
+  }
+}


### PR DESCRIPTION
This endpoint supports the recovery of arbitrary objects that have
previously been deleted.

Currently supports `SQL` but any versioned storage service can implement
the `AdminOperations` interface.
