### PR TITLE
[DNMY] feat(authz): More robust handling of managed service accounts

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -108,14 +108,11 @@ class PipelineController {
     pipeline.name = pipeline.getName().trim()
     pipeline = ensureCronTriggersHaveIdentifier(pipeline)
 
-    if (!pipeline.id || pipeline.regenerateCronTriggerIds) {
+    if (!pipeline.id) {
       // ensure that cron triggers are assigned a unique identifier for new pipelines
       def triggers = (pipeline.triggers ?: []) as List<Map>
       triggers.findAll { it.type == "cron" }.each { Map trigger ->
         trigger.id = UUID.randomUUID().toString()
-      }
-      if (pipeline.regenerateCronTriggerIds) {
-        pipeline.remove("regenerateCronTriggerIds")
       }
     }
 

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsController.groovy
@@ -60,6 +60,18 @@ public class ServiceAccountsController {
     serviceAccountDAO.all();
   }
 
+  @RequestMapping(method = RequestMethod.GET, value = "/{serviceAccountId:.+}")
+  ServiceAccount getServiceAccount(@PathVariable String serviceAccountId) {
+    serviceAccountDAO.findById(serviceAccountId)
+  }
+
+  @RequestMapping(method = RequestMethod.POST, value = "/{serviceAccountId:.+}/invalidateCache")
+  void invalidateCache(@PathVariable String serviceAccountId) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication()
+    fiatPermissionEvaluator.invalidatePermission((String) auth?.principal)
+    fiatPermissionEvaluator.invalidatePermission(serviceAccountId)
+  }
+
   @RequestMapping(method = RequestMethod.POST)
   ServiceAccount createServiceAccount(@RequestBody ServiceAccount serviceAccount) {
     def acct = serviceAccountDAO.create(serviceAccount.id, serviceAccount)


### PR DESCRIPTION
Reverts #488, as it is no longer needed. Adds two new endpoints to the `/serviceAccounts` endpoint: one to request a single service account and one to invalidate local fiat caches.
Prerequisite for https://github.com/spinnaker/orca/pull/3092