### PR TITLE
fix(web): Better handling when `ServiceAccountPermissionDAO` does not…

### DIFF
--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/ServiceAccountsControllerSpec.groovy
@@ -25,18 +25,18 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class ServiceAccountsControllerSpec extends Specification {
-  def serviceAccountDAO = Mock(ServiceAccountDAO)
-  def fiatService = Mock(FiatService)
-  def fiatClientConfigurationProperties = Mock(FiatClientConfigurationProperties)
-  def fiatPermissionsEvaluator = Mock(FiatPermissionEvaluator)
+  ServiceAccountDAO serviceAccountDAO = Mock(ServiceAccountDAO)
+  FiatService fiatService = Mock(FiatService)
+  FiatClientConfigurationProperties fiatClientConfigurationProperties = Mock(FiatClientConfigurationProperties)
+  FiatPermissionEvaluator fiatPermissionsEvaluator = Mock(FiatPermissionEvaluator)
 
   @Subject
   def controller = new ServiceAccountsController(
-    serviceAccountDAO: serviceAccountDAO,
-    fiatService: fiatService,
-    fiatClientConfigurationProperties: fiatClientConfigurationProperties,
-    fiatPermissionEvaluator: fiatPermissionsEvaluator,
-    roleSync: true
+    Optional.of(serviceAccountDAO),
+    Optional.of(fiatService),
+    fiatClientConfigurationProperties,
+    fiatPermissionsEvaluator,
+    true
   )
 
   def "should invalidate local cache"() {


### PR DESCRIPTION
… exist to allow the serviceAccounts endpoint to be created

This is an additional fix to PR #579 , the service accounts endpoint is also wired up only when the specified backend storage options are selected.  Basically just copied what @ajordens had done with the other applicationDAO service.