### PR TITLE
feat(sql): Conditionally allow MySQL Connector to be excluded from the build

### DIFF
--- a/front50-sql-mysql/front50-sql-mysql.gradle
+++ b/front50-sql-mysql/front50-sql-mysql.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  implementation "mysql:mysql-connector-java:8.0.12"
+  runtimeOnly "mysql:mysql-connector-java:8.0.12"
 }

--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -2,7 +2,9 @@ apply from: "$rootDir/gradle/kotlin.gradle"
 
 dependencies {
   implementation project(":front50-core")
-  implementation project(":front50-sql-mysql")
+  if (!rootProject.hasProperty("excludeSqlDrivers")) {
+    runtimeOnly project(":front50-sql-mysql")
+  }
 
   implementation "com.netflix.spinnaker.kork:kork-sql"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"


### PR DESCRIPTION
This change allows a custom build of Spinnaker to exclude the `mysql-connector-java` driver from the generated distribution with a build command like:

`./gradlew front50-web:installDist -x test -PexcludeSqlDrivers`

The driver is included in the build by default, so the build results are not changed for existing open-source and custom builds. 

The Gradle dependency types were changed from `implementation` to `runtimeOnly` to reflect the fact that `mysql-connector-java` is not needed for compilation. 