### PR TITLE
fix(fiat): roll back fiat to 1.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Wed Oct 23 19:56:36 UTC 2019
 clouddriverVersion=5.3.0
-fiatVersion=1.7.1
+fiatVersion=1.5.1
 enablePublishing=false
 spinnakerGradleVersion=7.0.1
 korkVersion=6.14.3


### PR DESCRIPTION
Upgrading the fiat library version to >= 1.6.0 fills the front50 logs with this error:
groovy.lang.MissingMethodException: No signature of method: com.netflix.spinnaker.fiat.model.resources.Permissions.isEmpty() is applicable for argument types: () values: []

This is because that method was removed in spinnaker/fiat#481 (which went into fiat 1.6.0). It's called from front50 in `ApplicationsController#78`.