### PR TITLE
feat(authorization): Add create restriction to application creation

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -95,6 +95,7 @@ public class ApplicationsController {
   }
 
   // TODO(ttomsu): Think through application creation permissions.
+  @PreAuthorize("@fiatPermissionEvaluator.canCreate('APPLICATION', app)")
   @ApiOperation(value = "", notes = "Create an application")
   @RequestMapping(method = RequestMethod.POST)
   Application create(@RequestBody final Application app) {

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -94,7 +94,6 @@ public class ApplicationsController {
     return results
   }
 
-  // TODO(ttomsu): Think through application creation permissions.
   @PreAuthorize("@fiatPermissionEvaluator.canCreate('APPLICATION', app)")
   @ApiOperation(value = "", notes = "Create an application")
   @RequestMapping(method = RequestMethod.POST)


### PR DESCRIPTION
Having added `canCreate` to fiat, we can now use it here to restrict application creation