### PR TITLE
feat(plugin-registry): Plugin registry with SQL implementation and protobuf as data interchange format

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugin/PluginRepository.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugin/PluginRepository.java
@@ -1,0 +1,96 @@
+package com.netflix.spinnaker.front50.model.plugin;
+
+import java.util.List;
+
+public interface PluginRepository<T> {
+  /**
+   * Inserts or updates the specified plugin.
+   *
+   * @param data The plugin data to store
+   */
+  void upsert(UpsertData<T> data);
+
+  /**
+   * Returns the plugin by the specified name.
+   *
+   * @param criteria The criteria by which to get the plugin.
+   * @return The plugin object.
+   */
+  T get(GetCriteria criteria);
+
+  /**
+   * Get all plugins based on the criteria.
+   *
+   * @param criteria The criteria by which to filter plugins by.
+   * @return A list of matching plugins.
+   */
+  List<T> list(ListCriteria criteria);
+
+  class GetCriteria {
+    public GetCriteria(String namespace, String name) {
+      this.namespace = namespace;
+      this.name = name;
+    }
+
+    public String getNamespace() {
+      return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+      this.namespace = namespace;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    private String namespace;
+    private String name;
+  }
+
+  class ListCriteria {
+    public ListCriteria(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public boolean getEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    private boolean enabled;
+  }
+
+  class UpsertData<T> {
+    public UpsertData(T plugin, String modifiedBy) {
+      this.plugin = plugin;
+      this.modifiedBy = modifiedBy;
+    }
+
+    public T getPlugin() {
+      return plugin;
+    }
+
+    public void setPlugin(T plugin) {
+      this.plugin = plugin;
+    }
+
+    public String getModifiedBy() {
+      return modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+      this.modifiedBy = modifiedBy;
+    }
+
+    private T plugin;
+    private String modifiedBy;
+  }
+}

--- a/front50-protobuf/front50-protobuf.gradle
+++ b/front50-protobuf/front50-protobuf.gradle
@@ -1,0 +1,45 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
+  }
+}
+
+apply plugin: 'java'
+apply plugin: 'com.google.protobuf'
+
+ext {
+  protobufVersion = '3.2.+'
+}
+
+dependencies {
+  api "com.google.protobuf:protobuf-java:${protobufVersion}"
+}
+
+protobuf {
+  protoc {
+    artifact = "com.google.protobuf:protoc:$protobufVersion"
+  }
+
+  generateProtoTasks {
+    ofSourceSet('main').each { task ->
+      task.builtins {
+        java {
+          outputSubDir = 'java'
+        }
+      }
+      task.descriptorSetOptions.includeImports = true
+    }
+  }
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir "${protobuf.generatedFilesBaseDir}/main/grpc"
+      srcDir "${protobuf.generatedFilesBaseDir}/main/java"
+    }
+  }
+}

--- a/front50-protobuf/src/main/proto/com/netflix/spinnaker/front50/proto/plugins.proto
+++ b/front50-protobuf/src/main/proto/com/netflix/spinnaker/front50/proto/plugins.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+option java_package = "com.netflix.spinnaker.front50.proto";
+option java_multiple_files = true;
+
+message Plugin {
+  // ex: "fast-properties"
+  string name = 1;
+
+  // ex: "netflix"
+  string namespace = 2;
+
+  // ex: "Provides rollout safety of runtime application
+  // config via pipelines"
+  string description = 3;
+
+  // ex: "Netflix"
+  string author = 4;
+
+  // ex: "1.0.0"
+  string version = 5;
+
+  // ex: "netflix/somedep>=1.x"
+  repeated string dependencies = 6;
+
+  // ex: "clouddriver>=5.33.0"
+  repeated string required_versions = 7;
+
+  // A list of extension points that the plugin implements.
+  // e.g. "pipelineStage"
+  repeated string capabilities = 8;
+
+  // Whether or not the plugin is enabled. An unset value
+  // should be considered as true.
+  bool enabled = 9;
+
+  // If the plugin is in-process and this flag is set to true,
+  // the plugin will be embedded into the process without
+  // isolation, allowing full modification of the application
+  // lifecycle. This is inherently unsafe and caution must be
+  // used setting this field.
+  bool in_process_unsafe = 10;
+}
+
+message Plugins {
+  repeated Plugin plugin = 1;
+}
+

--- a/front50-protobuf/src/test/resources/event.txt
+++ b/front50-protobuf/src/test/resources/event.txt
@@ -1,0 +1,10 @@
+name: "somePlugin-2"
+namespace: "netflix"
+description: "A really cool plugin"
+author: "netflix"
+version: "1.0.0"
+dependencies: ["some-dep"]
+required_versions: ["required-version"]
+capabilities: ["some-capability"]
+enabled: true
+in_process_unsafe: false

--- a/front50-protobuf/src/test/resources/test.txt
+++ b/front50-protobuf/src/test/resources/test.txt
@@ -1,0 +1,5 @@
+cat src/test/resources/event.txt | protoc --encode "Plugin" src/main/proto/com/netflix/spinnaker/front50/proto/plugins.proto | curl -H "X-SPINNAKER-USER: person@example.com" -H "Content-Type: application/x-protobuf" -X POST http://localhost:7101/plugins --data-binary @-
+
+curl -H "X-SPINNAKER-USER: person@example.com" -H "Content-Type: application/x-protobuf" -X GET http://localhost:7101/plugins/somePlugin/netflix
+
+curl -H "X-SPINNAKER-USER: person@example.com" -H "Content-Type: application/x-protobuf" -X GET http://localhost:7101/plugins

--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -6,6 +6,8 @@ dependencies {
     runtimeOnly project(":front50-sql-mysql")
   }
 
+  implementation project(":front50-protobuf")
+
   implementation "com.netflix.spinnaker.kork:kork-sql"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
 

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.model.SqlStorageService
+import com.netflix.spinnaker.front50.model.plugin.SqlPluginRepository
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
 import com.netflix.spinnaker.kork.sql.config.SqlProperties
 import org.jooq.DSLContext
@@ -48,5 +49,13 @@ class SqlConfiguration : CommonStorageServiceDAOConfig() {
       Clock.systemDefaultZone(),
       sqlProperties.retries,
       1000
+    )
+
+  @Bean
+  fun sqlPluginRepository(
+    jooq: DSLContext
+  ): SqlPluginRepository =
+    SqlPluginRepository(
+      jooq
     )
 }

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/plugin/SqlPluginRepository.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/plugin/SqlPluginRepository.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.plugin
+
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.UpsertData
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.GetCriteria
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.ListCriteria
+import com.netflix.spinnaker.front50.proto.Plugin
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.jooq.SelectJoinStep
+import org.jooq.impl.DSL.currentTimestamp
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.select
+import org.jooq.impl.DSL.table
+import org.slf4j.LoggerFactory
+import java.sql.Timestamp
+
+class SqlPluginRepository(
+  private val jooq: DSLContext
+) : PluginRepository<Plugin> {
+
+  override fun upsert(data: UpsertData<Plugin>) =
+    jooq.transactional { ctx ->
+      val plugin = data.plugin
+      val modifiedBy = data.modifiedBy
+      val timestamp = ctx.fetchValue(select(currentTimestamp()))
+
+      ctx.insertInto(
+        PLUGINS,
+        NAME,
+        NAMESPACE,
+        DESCRIPTION,
+        AUTHOR,
+        VERSION,
+        REQUIRED_VERSIONS,
+        DEPENDENCIES,
+        CAPABILITIES,
+        ENABLED,
+        IN_PROCESS_UNSAFE,
+        CREATED_AT,
+        LAST_MODIFIED_AT,
+        LAST_MODIFIED_BY
+      ).values(
+        plugin.name,
+        plugin.namespace,
+        plugin.description,
+        plugin.author,
+        plugin.version,
+        plugin.requiredVersionsList.commaDelimited(),
+        plugin.dependenciesList.commaDelimited(),
+        plugin.capabilitiesList.commaDelimited(),
+        plugin.enabled,
+        plugin.inProcessUnsafe,
+        timestamp,
+        timestamp,
+        modifiedBy
+      ).onDuplicateKeyUpdate()
+        .set(DESCRIPTION, plugin.description)
+        .set(AUTHOR, plugin.author)
+        .set(VERSION, plugin.version)
+        .set(REQUIRED_VERSIONS, plugin.requiredVersionsList.commaDelimited())
+        .set(DEPENDENCIES, plugin.dependenciesList.commaDelimited())
+        .set(CAPABILITIES, plugin.capabilitiesList.commaDelimited())
+        .set(ENABLED, plugin.enabled)
+        .set(IN_PROCESS_UNSAFE, plugin.inProcessUnsafe)
+        .set(LAST_MODIFIED_AT, timestamp)
+        .set(LAST_MODIFIED_BY, modifiedBy)
+        .execute()
+    }
+
+  override fun get(criteria: GetCriteria): Plugin =
+    jooq.read { ctx ->
+      ctx.selectFromPlugins()
+        .where(NAME.eq(criteria.name))
+        .and(NAMESPACE.eq(criteria.namespace))
+        .fetchOptional()
+        .orElseThrow {
+          NotFoundException("Plugin not found - " +
+            "name: ${criteria.name}, " +
+            "namespace: ${criteria.namespace}")
+        }
+        .toPlugin()
+    }
+
+  override fun list(criteria: ListCriteria): List<Plugin> =
+    jooq.read { ctx ->
+      ctx.selectFromPlugins()
+        .where(ENABLED.eq(criteria.enabled))
+        .fetch()
+        .map { it.toPlugin() }
+    }
+
+  private fun Record.toPlugin(): Plugin =
+    Plugin.newBuilder()
+      .setName(this.get(NAME))
+      .setNamespace(this.get(NAMESPACE))
+      .setDescription(this.get(DESCRIPTION))
+      .setAuthor(this.get(AUTHOR))
+      .setVersion(this.get(VERSION))
+      .addAllRequiredVersions(this.get(REQUIRED_VERSIONS).commaDelimitedToList())
+      .addAllDependencies(this.get(DEPENDENCIES).commaDelimitedToList())
+      .addAllCapabilities(this.get(CAPABILITIES).commaDelimitedToList())
+      .setEnabled(this.get(ENABLED))
+      .setInProcessUnsafe(this.get(IN_PROCESS_UNSAFE))
+      .build()
+
+  private fun DSLContext.selectFromPlugins(): SelectJoinStep<*> =
+    this.select(
+      NAME,
+      NAMESPACE,
+      DESCRIPTION,
+      AUTHOR,
+      VERSION,
+      REQUIRED_VERSIONS,
+      DEPENDENCIES,
+      CAPABILITIES,
+      ENABLED,
+      IN_PROCESS_UNSAFE
+    ).from(PLUGINS)
+
+  private fun List<String>.commaDelimited() = this.joinToString(",")
+
+  private fun String.commaDelimitedToList(): List<String> =
+    this.split(",").map { it.trim() }
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  companion object {
+    private val PLUGINS = table("plugins")
+
+    private val NAME = field("name", String::class.java)
+    private val NAMESPACE = field("namespace", String::class.java)
+    private val DESCRIPTION = field("description", String::class.java)
+    private val AUTHOR = field("author", String::class.java)
+    private val VERSION = field("version", String::class.java)
+    private val REQUIRED_VERSIONS = field("required_versions", String::class.java)
+    private val DEPENDENCIES = field("dependencies", String::class.java)
+    private val CAPABILITIES = field("capabilities", String::class.java)
+    private val ENABLED = field("enabled", Boolean::class.java)
+    private val IN_PROCESS_UNSAFE = field("in_process_unsafe", Boolean::class.java)
+    private val CREATED_AT = field("created_at", Timestamp::class.java)
+    private val LAST_MODIFIED_AT = field("last_modified_at", Timestamp::class.java)
+    private val LAST_MODIFIED_BY = field("last_modified_by", String::class.java)
+  }
+}

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/plugin/sql.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/plugin/sql.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.plugin
+
+import io.github.resilience4j.retry.annotation.Retry
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+// TODO(csmalley): Unify front50 around this usage of resilience4j
+
+@Retry(name = "sqlTransaction")
+internal fun DSLContext.transactional(fn: (DSLContext) -> Unit) {
+  transaction { ctx ->
+    fn(DSL.using(ctx))
+  }
+}
+
+@Retry(name = "sqlRead")
+internal fun <T> DSLContext.read(fn: (DSLContext) -> T): T {
+  return fn(this)
+}

--- a/front50-sql/src/main/resources/db/changelog-master.yml
+++ b/front50-sql/src/main/resources/db/changelog-master.yml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: changelog/20190530-add-is-deleted-indexes.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20191025-initial-plugins-schema.yml
+      relativeToChangelogFile: true

--- a/front50-sql/src/main/resources/db/changelog/20191025-initial-plugins-schema.yml
+++ b/front50-sql/src/main/resources/db/changelog/20191025-initial-plugins-schema.yml
@@ -1,0 +1,94 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-plugins-table
+      author: csmalley
+      changes:
+        - createTable:
+            tableName: plugins
+            columns:
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: namespace
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: author
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dependencies
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: required_versions
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: capabilities
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: enabled
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: in_process_unsafe
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_modified_at
+                  type: timestamp
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_modified_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci"
+      rollback:
+        - dropTable:
+            tableName: plugins
+  - changeSet:
+      id: plugins-table-primary-key
+      author: csmalley
+      changes:
+      - addPrimaryKey:
+          constraintName: pk_plugin_id
+          tableName: plugins
+          columnNames: name, namespace
+      rollback:
+        - dropPrimaryKey:
+            constraintName: pk_plugin_id
+            tableName: plugins

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/plugin/SqlPluginRepositoryTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/plugin/SqlPluginRepositoryTests.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.plugin
+
+import com.netflix.spinnaker.front50.model.flushAll
+import com.netflix.spinnaker.front50.model.initDatabase
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.GetCriteria
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.ListCriteria
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.UpsertData
+import com.netflix.spinnaker.front50.proto.Plugin
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.jooq.SQLDialect
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.assertDoesNotThrow
+import strikt.api.expect
+import strikt.api.expectThrows
+
+internal object SqlPluginRepositoryTests : JUnit5Minutests {
+  private val jooq = initDatabase(
+    "jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
+    SQLDialect.MYSQL
+  )
+
+  private val sqlPluginRepository = SqlPluginRepository(jooq)
+  private val pluginBuilder = Plugin.newBuilder()
+    .setName("name")
+    .setNamespace("namespace")
+    .setVersion("1.0.0")
+    .setAuthor("author")
+    .addAllCapabilities(mutableListOf("a-capability", "another-capability"))
+    .addAllRequiredVersions(mutableListOf("clouddriver>=1", "orca>=2"))
+    .addAllDependencies(mutableListOf("a-necessary-thing"))
+    .setEnabled(true)
+    .setInProcessUnsafe(false)
+
+  fun tests() = rootContext {
+
+    after {
+      jooq.flushAll()
+    }
+
+    context("Upsert, get, list plugins") {
+
+      test("Able to get a plugin") {
+        val plugin = pluginBuilder.build()
+        sqlPluginRepository.upsert(UpsertData(plugin, "someone"))
+
+        val result = sqlPluginRepository.get(GetCriteria(plugin.namespace, plugin.name))
+
+        expect {
+          assert(result == plugin)
+        }
+      }
+
+      test("throws NotFoundException when plugin does not exist") {
+        expectThrows<NotFoundException> {
+          val criteria = GetCriteria("foo", "bar")
+          sqlPluginRepository.get(criteria)
+        }
+      }
+
+      test("Able to upsert a new plugin") {
+        val plugin = pluginBuilder.build()
+
+        expect {
+          assertDoesNotThrow {
+            sqlPluginRepository.upsert(UpsertData(plugin, "someone"))
+          }
+        }
+      }
+
+      test("Able to upsert an existing plugin and change a field") {
+        val plugin = pluginBuilder.build()
+        val updatedPlugin = pluginBuilder.setAuthor("new-author").build()
+
+        sqlPluginRepository.upsert(UpsertData(plugin, "someone"))
+        sqlPluginRepository.upsert(UpsertData(updatedPlugin, "someone"))
+
+        expect {
+          val pluginsResult = sqlPluginRepository.list(ListCriteria(true))
+          assert(pluginsResult.size == 1)
+
+          val pluginResult = sqlPluginRepository.get(GetCriteria(updatedPlugin.namespace, updatedPlugin.name))
+          assert(pluginResult == updatedPlugin)
+        }
+      }
+
+      test("Able to list enabled and disabled plugins") {
+        val enabledPlugin = pluginBuilder.build()
+        val disabledPlugin = pluginBuilder
+          .setName("other-name")
+          .setNamespace("other-namespace")
+          .setEnabled(false)
+          .build()
+
+        sqlPluginRepository.upsert(UpsertData(enabledPlugin, "someone"))
+        sqlPluginRepository.upsert(UpsertData(disabledPlugin, "someone"))
+
+        mutableListOf(true, false).forEach { enabled ->
+          val pluginsResult = sqlPluginRepository.list(ListCriteria(enabled))
+          expect {
+            assert(pluginsResult.size == 1)
+            if (enabled) assert(pluginsResult.first().enabled)
+            else assert(!pluginsResult.first().enabled)
+          }
+        }
+      }
+    }
+  }
+
+  @JvmStatic
+  @AfterAll
+  fun shutdown() {
+    jooq.close()
+  }
+}

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -30,6 +30,9 @@ configurations.all {
 }
 
 dependencies {
+  implementation project(":front50-protobuf")
+  implementation project(":front50-sql")
+
   implementation project(":front50-core")
   implementation project(":front50-migrations")
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
 import org.springframework.http.HttpStatus
+import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
@@ -155,5 +156,10 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
           timestamp        : System.currentTimeMillis()
       ]
     }
+  }
+
+  @Bean
+  ProtobufHttpMessageConverter protobufHttpMessageConverter() {
+    return new ProtobufHttpMessageConverter()
   }
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginController.java
@@ -1,0 +1,64 @@
+package com.netflix.spinnaker.front50.controllers;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository;
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.GetCriteria;
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.ListCriteria;
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.UpsertData;
+import com.netflix.spinnaker.front50.proto.Plugin;
+import com.netflix.spinnaker.front50.proto.Plugins;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "plugins")
+@ConditionalOnExpression("${spinnaker.plugins.enabled:false}")
+public class PluginController {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private PluginRepository<Plugin> pluginRepository;
+
+  public PluginController(PluginRepository pluginRepository) {
+    this.pluginRepository = pluginRepository;
+  }
+
+  @RequestMapping(method = RequestMethod.POST)
+  public void upsert(@RequestBody Plugin plugin) {
+    String modifiedBy = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous");
+    UpsertData<Plugin> upsertData = new UpsertData<>(plugin, modifiedBy);
+    pluginRepository.upsert(upsertData);
+  }
+
+  @RequestMapping(method = RequestMethod.GET)
+  public Plugins list(
+      @RequestParam(required = false, value = "enabled", defaultValue = "true") boolean enabled) {
+    ListCriteria listCriteria = new ListCriteria(enabled);
+    return Plugins.newBuilder().addAllPlugin(pluginRepository.list(listCriteria)).build();
+  }
+
+  @RequestMapping(value = "{namespace}/{name}", method = RequestMethod.GET)
+  public Plugin get(@PathVariable String namespace, @PathVariable String name) {
+    GetCriteria getCriteria = new GetCriteria(namespace, name);
+    return pluginRepository.get(getCriteria);
+  }
+
+  @ExceptionHandler(NotFoundException.class)
+  @ResponseStatus(NOT_FOUND)
+  void onNotFound(@NotNull NotFoundException e) {
+    log.error(e.getMessage());
+  }
+
+  @ExceptionHandler(HttpMessageConversionException.class)
+  @ResponseStatus(BAD_REQUEST)
+  void onParseFailure(HttpMessageConversionException e) {
+    log.error(e.getMessage());
+  }
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PluginControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PluginControllerSpec.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.GetCriteria
+import com.netflix.spinnaker.front50.model.plugin.PluginRepository.ListCriteria
+import com.netflix.spinnaker.front50.proto.Plugin
+import com.netflix.spinnaker.front50.proto.Plugins
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+class PluginControllerSpec extends Specification {
+
+  Plugin.Builder pluginBuilder
+
+  Plugin plugin
+
+  PluginRepository<Plugin> pluginRepository
+
+  MockMvc mockMvc
+
+  @Subject
+  PluginController controller
+
+  void setup() {
+    pluginBuilder = Plugin.newBuilder()
+      .setName("name")
+      .setNamespace("namespace")
+      .setVersion("1.0.0")
+      .setAuthor("author")
+      .addAllCapabilities(["a-capability", "another-capability"])
+      .addAllRequiredVersions(["clouddriver>=1", "orca>=2"])
+      .addAllDependencies(["a-necessary-thing"])
+      .setEnabled(true)
+      .setInProcessUnsafe(false)
+
+    plugin = pluginBuilder.build()
+
+    pluginRepository = Stub(PluginRepository)
+
+    controller = new PluginController(pluginRepository)
+
+    mockMvc = MockMvcBuilders
+      .standaloneSetup(controller)
+      .setHandlerExceptionResolvers(createExceptionResolver())
+      .setMessageConverters([new ProtobufHttpMessageConverter()] as HttpMessageConverter<?>[])
+      .build()
+  }
+
+  private static ExceptionHandlerExceptionResolver createExceptionResolver() {
+    def resolver = new SimpleExceptionHandlerExceptionResolver()
+    resolver.afterPropertiesSet()
+    return resolver
+  }
+
+  def "mvcmock - post plugin"() {
+    when:
+    def response = mockMvc
+      .perform(post("/plugins")
+        .contentType("application/x-protobuf")
+        .content(plugin.toByteArray()))
+      .andExpect(status().isOk())
+      .andReturn()
+      .response
+
+    then:
+    assert response.status == 200
+  }
+
+  def "mvcmock - get plugin"() {
+    given:
+    pluginRepository.get(_ as GetCriteria) >> plugin
+
+    when:
+    def response = mockMvc
+      .perform(get("/plugins/namespace/name")
+        .contentType("application/x-protobuf"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .response
+      .contentAsByteArray
+
+    Plugin result = Plugin.parseFrom(response)
+
+    then:
+    assert plugin == result
+  }
+
+  def "mvcmock - get a plugin that doesn't exist"() {
+    given:
+    pluginRepository.get(_ as GetCriteria) >> { throw new NotFoundException() }
+
+    when:
+    def response = mockMvc
+      .perform(get("/plugins/namespace/name")
+        .contentType("application/x-protobuf"))
+      .andExpect(status().is4xxClientError())
+      .andReturn()
+      .response
+
+    then:
+    assert response.status == 404
+  }
+
+  def "mvcmock - list plugins"() {
+    given:
+    pluginRepository.list(_ as ListCriteria) >> [plugin]
+
+    when:
+    def response = mockMvc
+      .perform(get("/plugins?enabled=true")
+        .contentType("application/x-protobuf"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .response
+      .contentAsByteArray
+
+    and:
+    Plugins result = Plugins.parseFrom(response)
+    List<Plugin> responseList = result.pluginList
+
+    then:
+    assert responseList == [plugin]
+  }
+
+  def "gets a plugin"() {
+    when:
+    pluginRepository.get(_ as GetCriteria) >> plugin
+
+    and:
+    def result = controller.get(plugin.namespace, plugin.name)
+
+    then:
+    assert result == plugin
+  }
+
+  def "lists plugins"() {
+    when:
+    pluginRepository.list(_ as ListCriteria) >> [plugin]
+
+    and:
+    Plugins result = controller.list(true)
+    List<Plugin> pluginList = result.getPluginList()
+
+    then:
+    assert pluginList == [plugin]
+  }
+
+  def "upserts a plugin"() {
+    when:
+    controller.upsert(plugin)
+
+    then:
+    noExceptionThrown()
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,8 @@ include 'front50-web',
     'front50-azure',
     'front50-swift',
     'front50-oracle',
-    'front50-bom'
+    'front50-bom',
+    'front50-protobuf'
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
Initially gRPC was explored, but there were too many unknowns to include with this scope of work.  We explored the gRPC story around authorization, authentication, logging, metrics, exception handling - that will all need to be a separate scope of work.

This implementation uses Protobuf via REST, which should be a good pattern for us to start using as we migrate to Protobuf and eventually gRPC.  