### PR TITLE
feat(core): Add endpoint to get current pipeline definition

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
@@ -97,6 +98,13 @@ class PipelineController {
   Collection<Pipeline> getHistory(@PathVariable String id,
                                   @RequestParam(value = "limit", defaultValue = "20") int limit) {
     return pipelineDAO.history(id, limit)
+  }
+
+  @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
+  @PostAuthorize("hasPermission(returnObject.application, 'APPLICATION', 'READ')")
+  @RequestMapping(value = '{id:.+}/get', method = RequestMethod.GET)
+  Pipeline get(@PathVariable String id) {
+    return pipelineDAO.findById(id)
   }
 
   @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission() and hasPermission(#pipeline.application, 'APPLICATION', 'WRITE') and @authorizationSupport.hasRunAsUserPermission(#pipeline)")


### PR DESCRIPTION
There's currently no endpoint in front50 to get the current pipeline definition; consumers need to call the history endpoint with a limit of 1 and take the single returned element.

Let's make the API simpler for consumers who just want the current definition by giving them an endpoint to return it.

Forcing consumers to call the /history endpoint has led to performance issues, as that endpoint is often much slower than a call to get the current definition. Some backing stores have optimized to short-circuit the limit=1 case (s3 in #316), but others (including GCS) are still very slow even in the limit=1 case.

We could (and potentially should) make the same optimization to other backing stores. But I think the fundamental issue here is that we have rare, slow history-type requests and frequent (ideally) fast
current-state requests going to the same endpoint. This PR creates that distinction, and consumers can elect to use the new endpoint going forward.