### PR TITLE
feat(plugins): Adds plugin artifact repository

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -34,6 +34,8 @@ import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineTemplateDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO;
+import com.netflix.spinnaker.front50.model.pluginartifact.DefaultPluginArtifactRepository;
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifactRepository;
 import com.netflix.spinnaker.front50.model.project.DefaultProjectDAO;
 import com.netflix.spinnaker.front50.model.project.ProjectDAO;
 import com.netflix.spinnaker.front50.model.serviceaccount.DefaultServiceAccountDAO;
@@ -238,6 +240,23 @@ public class CommonStorageServiceDAOConfig {
         objectKeyLoader,
         storageServiceConfigurationProperties.getDeliveryConfig().getRefreshMs(),
         storageServiceConfigurationProperties.getDeliveryConfig().getShouldWarmCache(),
+        registry);
+  }
+
+  @Bean
+  PluginArtifactRepository pluginArtifactRepository(
+      StorageService storageService,
+      StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+      ObjectKeyLoader objectKeyLoader,
+      Registry registry) {
+    return new DefaultPluginArtifactRepository(
+        storageService,
+        Schedulers.from(
+            Executors.newFixedThreadPool(
+                storageServiceConfigurationProperties.getPluginArtifact().getThreadPool())),
+        objectKeyLoader,
+        storageServiceConfigurationProperties.getPluginArtifact().getRefreshMs(),
+        storageServiceConfigurationProperties.getPluginArtifact().getShouldWarmCache(),
         registry);
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.groovy
@@ -32,6 +32,7 @@ class StorageServiceConfigurationProperties {
   PerObjectType pipelineTemplate = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
   PerObjectType snapshot = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1))
   PerObjectType deliveryConfig = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
+  PerObjectType pluginArtifact = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1))
 
   // not commonly used outside of Netflix
   PerObjectType entityTags = new PerObjectType(2, TimeUnit.MINUTES.toMillis(5), false)

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.front50.model.delivery.Delivery;
 import com.netflix.spinnaker.front50.model.notification.Notification;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
 import com.netflix.spinnaker.front50.model.project.Project;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
 import com.netflix.spinnaker.front50.model.snapshot.Snapshot;
@@ -41,7 +42,8 @@ public enum ObjectType {
       Application.Permission.class, "applications", "application-permission.json"),
   SNAPSHOT(Snapshot.class, "snapshots", "snapshot.json"),
   ENTITY_TAGS(EntityTags.class, "tags", "entity-tags-metadata.json"),
-  DELIVERY(Delivery.class, "delivery", "delivery-metadata.json");
+  DELIVERY(Delivery.class, "delivery", "delivery-metadata.json"),
+  PLUGIN_ARTIFACT(PluginArtifact.class, "pluginArtifacts", "plugin-artifact-metadata.json");
 
   public final Class<? extends Timestamped> clazz;
   public final String group;

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/DefaultPluginArtifactRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/DefaultPluginArtifactRepository.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pluginartifact;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.ObjectType;
+import com.netflix.spinnaker.front50.model.StorageService;
+import com.netflix.spinnaker.front50.model.StorageServiceSupport;
+import com.netflix.spinnaker.kork.exceptions.IntegrationException;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import rx.Scheduler;
+
+public class DefaultPluginArtifactRepository extends StorageServiceSupport<PluginArtifact>
+    implements PluginArtifactRepository {
+  public DefaultPluginArtifactRepository(
+      StorageService service,
+      Scheduler scheduler,
+      ObjectKeyLoader objectKeyLoader,
+      long refreshIntervalMs,
+      boolean shouldWarmCache,
+      Registry registry) {
+    super(
+        ObjectType.PLUGIN_ARTIFACT,
+        service,
+        scheduler,
+        objectKeyLoader,
+        refreshIntervalMs,
+        shouldWarmCache,
+        registry);
+  }
+
+  @Nonnull
+  @Override
+  public Collection<PluginArtifact> getByService(@Nonnull String service) {
+    return all().stream()
+        .filter(
+            artifact -> artifact.getReleases().stream().anyMatch(r -> r.supportsService(service)))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public PluginArtifact create(String id, PluginArtifact item) {
+    Objects.requireNonNull(item.getId());
+    if (!item.getId().equals(id)) {
+      // Won't happen unless Orca passes a mismatched request path / request body.
+      throw new IntegrationException("The provided id and plugin artifact id do not match");
+    }
+
+    if (item.getCreateTs() == null) {
+      item.setCreateTs(System.currentTimeMillis());
+    } else {
+      item.setLastModified(System.currentTimeMillis());
+    }
+
+    update(id, item);
+    return findById(id);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifact.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifact.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pluginartifact;
+
+import com.netflix.spinnaker.front50.model.Timestamped;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import lombok.Data;
+
+/**
+ * A Spinnaker plugin's release artifact metadata.
+ *
+ * <p>This model is used internally by Spinnaker to track what plugins are available for services to
+ * install, as well as the specific releases that should be installed.
+ */
+@Data
+public class PluginArtifact implements Timestamped {
+  /**
+   * The canonical plugin ID.
+   *
+   * <p>A canonical plugin ID is one that includes the namespace, e.g. {@code netflix.hello-world}
+   */
+  @Nonnull private String id;
+
+  /** The description of the plugin. */
+  private String description;
+
+  /** The plugin provider, typically the name of the author (or company). */
+  private String provider;
+
+  /** A list of plugin artifact releases. */
+  @Nonnull private List<Release> releases = new ArrayList<>();
+
+  /** The time (epoch millis) when the plugin artifact was first created. */
+  private Long createTs;
+
+  /** The last time (epoch millis) this PluginArtifact was modified. */
+  private Long lastModified;
+
+  /** The last principal to modify this PluginArtifact. */
+  private String lastModifiedBy;
+
+  public PluginArtifact() {}
+
+  /** A singular {@code PluginArtifact} release. */
+  @Data
+  public static class Release {
+    public static final Pattern SUPPORTS_PATTERN =
+        Pattern.compile(
+            "^(?<service>[\\w\\-]+)(?<operator>[><=]{1,2})(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$");
+    public static final String SUPPORTS_PATTERN_SERVICE_GROUP = "service";
+    public static final String SUPPORTS_PATTERN_OPERATOR_GROUP = "operator";
+    public static final String SUPPORTS_PATTERN_VERSION_GROUP = "version";
+
+    /**
+     * The version of a plugin artifact release in SemVer format.
+     *
+     * @link https://semver.org/
+     */
+    private String version;
+
+    /** The date of the plugin artifact release. */
+    private String date;
+
+    /**
+     * Spinnaker service support.
+     *
+     * <p>This defines, from the plugin's perspective, what services it supports. This will be used
+     * to narrow what plugins are returned to a requesting service as candidates for installation.
+     * Which release is actually downloaded is handled by the service itself, according to
+     * heuristics that front50 does not care about.
+     *
+     * <p>Each element must follow a "{service}{comparator}{version}" format where:
+     *
+     * <p>1. "{service}" is alphanumeric and dash characters. 2. "{comparator}" is an algebraic
+     * comparison operator (e.g. {@code "<", "<=", ">", ">="}) 3. "{version}" is a SemVer-compatible
+     * version.
+     */
+    private List<String> requires;
+
+    /** The absolute path of the plugin artifact binary. */
+    private String url;
+
+    /** The SHA512 checksum of the plugin binary. */
+    private String sha512sum;
+
+    /**
+     * Defines the state of this release, which can help services to determine what version they
+     * should be installing.
+     */
+    private State state;
+
+    /**
+     * The last time this release was modified, typically defining the last time the {@code active}
+     * flag changed.
+     */
+    private Instant lastModified;
+
+    /** The principal that last modified this release. */
+    private String lastModifiedBy;
+
+    /**
+     * Returns whether or not the release is supported for a particular service.
+     *
+     * <p>This does not perform a version check. It is the responsibility of the service itself to
+     * determine which release to select.
+     *
+     * @param service The service name to check against.
+     */
+    public boolean supportsService(@Nonnull String service) {
+      return requires.stream()
+          .anyMatch(
+              it -> {
+                Matcher m = SUPPORTS_PATTERN.matcher(it);
+                if (m.matches()) {
+                  return m.group(SUPPORTS_PATTERN_SERVICE_GROUP).equals(service);
+                }
+                return false;
+              });
+    }
+
+    public enum State {
+      CANDIDATE,
+      RELEASE
+    }
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pluginartifact;
+
+import com.netflix.spinnaker.front50.model.ItemDAO;
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact.Release;
+import java.util.Collection;
+import javax.annotation.Nonnull;
+
+public interface PluginArtifactRepository extends ItemDAO<PluginArtifact> {
+  /**
+   * Returns a collection of plugins that should be installed by a particular service.
+   *
+   * <p>This is determined by inference, using a {@link Release}'s {@code requires} field.
+   */
+  @Nonnull
+  Collection<PluginArtifact> getByService(@Nonnull String service);
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactService.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pluginartifact;
+
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.validator.GenericValidationErrors;
+import com.netflix.spinnaker.front50.validator.PluginArtifactValidator;
+import com.netflix.spinnaker.kork.exceptions.UserException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+@Component
+public class PluginArtifactService {
+
+  private final PluginArtifactRepository repository;
+  private final List<PluginArtifactValidator> validators;
+
+  public PluginArtifactService(
+      PluginArtifactRepository repository, List<PluginArtifactValidator> validators) {
+    this.repository = repository;
+    this.validators = validators;
+  }
+
+  public Collection<PluginArtifact> findAll() {
+    return repository.all();
+  }
+
+  public Collection<PluginArtifact> findAllByService(@Nonnull String service) {
+    return repository.getByService(service);
+  }
+
+  public PluginArtifact upsert(@Nonnull PluginArtifact pluginArtifact) {
+    validate(pluginArtifact);
+
+    try {
+      repository.findById(pluginArtifact.getId());
+      repository.update(pluginArtifact.getId(), pluginArtifact);
+      return pluginArtifact;
+    } catch (NotFoundException e) {
+      return repository.create(pluginArtifact.getId(), pluginArtifact);
+    }
+  }
+
+  public void delete(@Nonnull String id) {
+    repository.delete(id);
+  }
+
+  public PluginArtifact createRelease(@Nonnull String id, @Nonnull PluginArtifact.Release release) {
+    PluginArtifact artifact = repository.findById(id);
+
+    artifact.getReleases().add(release);
+
+    return upsert(artifact);
+  }
+
+  public PluginArtifact deleteRelease(@Nonnull String id, @Nonnull String releaseVersion) {
+    PluginArtifact artifact = repository.findById(id);
+
+    new ArrayList<>(artifact.getReleases())
+        .forEach(
+            release -> {
+              if (release.getVersion().equals(releaseVersion)) {
+                artifact.getReleases().remove(release);
+              }
+            });
+
+    return upsert(artifact);
+  }
+
+  private void validate(PluginArtifact pluginArtifact) {
+    Errors errors = new GenericValidationErrors(pluginArtifact);
+    validators.forEach(v -> v.validate(pluginArtifact, errors));
+    if (errors.hasErrors()) {
+      throw new ValidationException(errors);
+    }
+  }
+
+  public static class ValidationException extends UserException {
+    Errors errors;
+
+    ValidationException(Errors errors) {
+      this.errors = errors;
+    }
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.validator;
+
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+@Component
+public class HasCanonicalPluginIdValidator implements PluginArtifactValidator {
+
+  private final Pattern pattern = Pattern.compile("[\\w]+\\.[\\w]+");
+
+  @Override
+  public void validate(PluginArtifact pluginArtifact, Errors validationErrors) {
+    if (!pattern.matcher(pluginArtifact.getId()).matches()) {
+      validationErrors.rejectValue(
+          "id",
+          "pluginArtifact.id.invalid",
+          "Plugin Artifact must have a '{namespace}.{id}' canonical format");
+    }
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.validator;
+
+import static com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact.Release.SUPPORTS_PATTERN;
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+@Component
+public class HasValidRequiresFieldsValidator implements PluginArtifactValidator {
+
+  private static final List<String> VALID_OPERATORS = Arrays.asList("<", ">", ">=", "<=");
+
+  @Override
+  public void validate(PluginArtifact pluginArtifact, Errors validationErrors) {
+
+    pluginArtifact
+        .getReleases()
+        .forEach(
+            release -> {
+              release
+                  .getRequires()
+                  .forEach(
+                      requires -> {
+                        Matcher m = SUPPORTS_PATTERN.matcher(requires);
+                        if (!m.matches()) {
+                          validationErrors.reject(
+                              "pluginArtifact.releases.invalidRequiresFormat",
+                              format(
+                                  "Invalid Release requires field formatting (requires '%s')",
+                                  SUPPORTS_PATTERN.pattern()));
+                          return;
+                        }
+
+                        if (!VALID_OPERATORS.contains(
+                            m.group(PluginArtifact.Release.SUPPORTS_PATTERN_OPERATOR_GROUP))) {
+                          validationErrors.reject(
+                              "pluginArtifact.releases.invalidRequiresOperator",
+                              format(
+                                  "Invalid Release requires comparison operator (requires one of: %s)",
+                                  VALID_OPERATORS));
+                        }
+                      });
+            });
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/PluginArtifactValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/PluginArtifactValidator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,22 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.front50.validator;
 
-package com.netflix.spinnaker.front50.model;
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import org.springframework.validation.Errors;
 
-public interface Timestamped {
-  /**
-   * TODO(rz): Move this method into new Identifiable interface. Has nothing to do with timestamps.
-   *
-   * @return
-   */
-  String getId();
-
-  Long getLastModified();
-
-  void setLastModified(Long lastModified);
-
-  String getLastModifiedBy();
-
-  void setLastModifiedBy(String lastModifiedBy);
+/** A {@link PluginArtifact} validator. */
+public interface PluginArtifactValidator {
+  void validate(PluginArtifact pluginArtifact, Errors validationErrors);
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactServiceSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pluginartifact
+
+import com.netflix.spinnaker.front50.exception.NotFoundException
+import com.netflix.spinnaker.front50.validator.PluginArtifactValidator
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PluginArtifactServiceSpec extends Specification {
+
+  PluginArtifactRepository repository = Mock()
+  PluginArtifactValidator validator = Mock()
+
+  @Subject
+  PluginArtifactService subject = new PluginArtifactService(repository, [validator])
+
+  def "upsert conditionally creates or updates"() {
+    given:
+    PluginArtifact pluginArtifact = new PluginArtifact(id: "foo.bar")
+
+    when:
+    subject.upsert(pluginArtifact)
+
+    then:
+    1 * validator.validate(pluginArtifact, _)
+    1 * repository.findById("foo.bar") >> {
+      throw new NotFoundException("k")
+    }
+    1 * repository.create("foo.bar", pluginArtifact) >> pluginArtifact
+    0 * repository.update(_, _)
+
+    when:
+    subject.upsert(pluginArtifact)
+
+    then:
+    1 * validator.validate(pluginArtifact, _)
+    1 * repository.findById("foo.bar") >> pluginArtifact
+    1 * repository.update("foo.bar", pluginArtifact)
+    0 * repository.create(_, _)
+  }
+
+  def "creating a new release appends to plugin artifact releases"() {
+    given:
+    PluginArtifact pluginArtifact = new PluginArtifact(id: "foo.bar")
+    pluginArtifact.releases.add(new PluginArtifact.Release(version: "1.0.0"))
+
+    PluginArtifact.Release newRelease = new PluginArtifact.Release(version: "2.0.0")
+
+    when:
+    def result = subject.createRelease("foo.bar", newRelease)
+
+    then:
+    2 * repository.findById("foo.bar") >> pluginArtifact
+    result.releases*.version == ["1.0.0", "2.0.0"]
+  }
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.pluginartifact
+
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PluginArtifactSpec extends Specification {
+
+  @Unroll
+  def "artifact release supports service"() {
+    given:
+    def release = new PluginArtifact.Release(
+      requires: [
+        "clouddriver>=2.0.0",
+        "orca>7.0.0",
+        "gate>=3.0.0"
+      ]
+    )
+
+    expect:
+    release.supportsService(service) == expectedResult
+
+    where:
+    service       || expectedResult
+    "gate"        || true
+    "echo"        || false
+    "clouddriver" || true
+  }
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidatorSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.validator
+
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact
+import org.springframework.validation.Errors
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class HasCanonicalPluginIdValidatorSpec extends Specification {
+
+  @Subject
+  HasCanonicalPluginIdValidator subject = new HasCanonicalPluginIdValidator()
+
+  @Unroll
+  def "requires a canonical plugin id"() {
+    setup:
+    PluginArtifact pluginArtifact = new PluginArtifact(id: id)
+    Errors errors = new GenericValidationErrors(pluginArtifact)
+
+    when:
+    subject.validate(pluginArtifact, errors)
+
+    then:
+    errors.hasErrors() == hasErrors
+
+    where:
+    id        || hasErrors
+    "foo"     || true
+    "foo/bar" || true
+    "foo.bar" || false
+    "."       || true
+    ".bar"    || true
+    "foo."    || true
+  }
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidatorSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.validator
+
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class HasValidRequiresFieldsValidatorSpec extends Specification {
+
+  @Subject
+  HasValidRequiresFieldsValidator subject = new HasValidRequiresFieldsValidator()
+
+  @Unroll
+  def "requires release with valid requires field formatting"() {
+    setup:
+    def pluginArtifact = new PluginArtifact(
+      releases: [new PluginArtifact.Release(requires: requiresValue)]
+    )
+    def errors = new GenericValidationErrors(pluginArtifact)
+
+    when:
+    subject.validate(pluginArtifact, errors)
+
+    then:
+    errors.hasErrors() == hasErrors
+
+    where:
+    requiresValue         || hasErrors
+    ["gate<=1.0.0"]       || false
+    ["gate>=1.0.0"]       || false
+    ["gate<1.0.0"]        || false
+    ["hello-world=1.0.0"] || true
+    ["gate=1.0.0"]        || true
+    ["gate=foo"]          || true
+  }
+}

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.front50.model.ObjectType.ENTITY_TAGS
 import com.netflix.spinnaker.front50.model.ObjectType.NOTIFICATION
 import com.netflix.spinnaker.front50.model.ObjectType.PIPELINE
 import com.netflix.spinnaker.front50.model.ObjectType.PIPELINE_TEMPLATE
+import com.netflix.spinnaker.front50.model.ObjectType.PLUGIN_ARTIFACT
 import com.netflix.spinnaker.front50.model.ObjectType.PROJECT
 import com.netflix.spinnaker.front50.model.ObjectType.SERVICE_ACCOUNT
 import com.netflix.spinnaker.front50.model.ObjectType.SNAPSHOT
@@ -74,7 +75,8 @@ class SqlStorageService(
       APPLICATION_PERMISSION to DefaultTableDefinition(APPLICATION_PERMISSION, "application_permissions", true),
       SNAPSHOT to DefaultTableDefinition(SNAPSHOT, "snapshots", false),
       ENTITY_TAGS to DefaultTableDefinition(ENTITY_TAGS, "entity_tags", false),
-      DELIVERY to DeliveryTableDefinition()
+      DELIVERY to DeliveryTableDefinition(),
+      PLUGIN_ARTIFACT to DefaultTableDefinition(PLUGIN_ARTIFACT, "plugin_artifacts", false)
     )
   }
 

--- a/front50-sql/src/main/resources/db/changelog-master.yml
+++ b/front50-sql/src/main/resources/db/changelog-master.yml
@@ -41,3 +41,6 @@ databaseChangeLog:
   - include:
       file: changelog/20191112-modify-char-columns-postgres.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20191213-initial-plugin-artifacts-schema.yml
+      relativeToChangelogFile: true

--- a/front50-sql/src/main/resources/db/changelog/20191213-initial-plugin-artifacts-schema.yml
+++ b/front50-sql/src/main/resources/db/changelog/20191213-initial-plugin-artifacts-schema.yml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-plugin-artifacts-table
+      author: robzienert
+      changes:
+        - createTable:
+            tableName: plugin_artifacts
+            columns:
+              - column:
+                  name: id
+                  type: char(255)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: body
+                  type: longtext
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_modified_at
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_modified_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci"
+      rollback:
+        - dropTable:
+            tableName: plugin_artifacts

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginArtifactController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginArtifactController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.controllers;
+
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifactService;
+import java.util.Collection;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/** TODO(rz): What's the permissions model for something like artifacts? */
+@RestController
+@RequestMapping("/pluginArtifacts")
+public class PluginArtifactController {
+
+  private final PluginArtifactService pluginArtifactService;
+
+  public PluginArtifactController(PluginArtifactService pluginArtifactService) {
+    this.pluginArtifactService = pluginArtifactService;
+  }
+
+  @RequestMapping(value = "", method = RequestMethod.GET)
+  Collection<PluginArtifact> list(
+      @RequestParam(value = "service", required = false) String service) {
+    return Optional.ofNullable(service)
+        .map(pluginArtifactService::findAllByService)
+        .orElseGet(pluginArtifactService::findAll);
+  }
+
+  @RequestMapping(value = "", method = RequestMethod.POST)
+  PluginArtifact upsert(@RequestBody PluginArtifact pluginArtifact) {
+    return pluginArtifactService.upsert(pluginArtifact);
+  }
+
+  @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  void delete(@PathVariable String id) {
+    pluginArtifactService.delete(id);
+  }
+
+  @RequestMapping(value = "/{id}/releases", method = RequestMethod.POST)
+  PluginArtifact createRelease(
+      @PathVariable String id, @RequestBody PluginArtifact.Release release) {
+    return pluginArtifactService.createRelease(id, release);
+  }
+
+  @RequestMapping(value = "/{id}/releases/{releaseVersion}", method = RequestMethod.DELETE)
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  PluginArtifact deleteRelease(@PathVariable String id, @PathVariable String releaseVersion) {
+    return pluginArtifactService.deleteRelease(id, releaseVersion);
+  }
+}


### PR DESCRIPTION
This is an optional feature for plugins. This makes front50 the source of
truth of what plugins are available for download by any particular service.
Which plugin release is actually downloaded for a particular service is
determined by the service itself.

⚠️ Going to hold off on merge until I write up the `Front50UpdateRepository` in `kork-plugins`, just getting all of the pieces in place.

Before this is merged, there's question about how much context we put into the repository on initial roll out. Right now I have things written such that plugin releases define what services they support, but nothing much beyond that. Should plugin releases also define service version constraints? I think yes, but I'm unsure how much we need to bite off out of the gate.

This PR just provides services of knowledge on what plugins to download, and where to download them from. It does not provide functionality around plugin downloads or configuration of downloaded plugins.