### PR TITLE
feat(core): Filter by v2 and group template versions

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
@@ -68,11 +68,20 @@ public class V2PipelineTemplateController {
 
   @Autowired ObjectMapper objectMapper;
 
-  // TODO(jacobkiefer): Add fiat authz
+  // TODO(louisjimenez): Deprecated. Will be replaced with /versions endpoint starting with 1.19.
   @RequestMapping(value = "", method = RequestMethod.GET)
   List<PipelineTemplate> list(
       @RequestParam(required = false, value = "scopes") List<String> scopes) {
     return (List<PipelineTemplate>) getPipelineTemplateDAO().getPipelineTemplatesByScope(scopes);
+  }
+
+  // TODO(jacobkiefer): Add fiat authz
+  @RequestMapping(value = "versions", method = RequestMethod.GET)
+  Map<String, List<PipelineTemplate>> listVersions(
+      @RequestParam(required = false, value = "scopes") List<String> scopes) {
+    return getPipelineTemplateDAO().getPipelineTemplatesByScope(scopes).stream()
+        .filter(pt -> pt.getOrDefault("schema", "").equals("v2"))
+        .collect(Collectors.groupingBy(PipelineTemplate::undecoratedId));
   }
 
   @RequestMapping(value = "", method = RequestMethod.POST)


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/4670

This updates the list pipeline templates endpoint to return a map of pipeline templates grouped and sorted by their ids. It also adds filtering to only return v2 templates. This supports displaying versioning in the UI and Spin.

Related PRs:
[Gate](https://github.com/spinnaker/gate/pull/989)
[Deck](https://github.com/spinnaker/deck/pull/7708)
[Spin](https://github.com/spinnaker/spin/pull/235)