### PR TITLE
chore(release): Use the alpine containers instead of openjdk

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,7 +1,7 @@
-FROM openjdk:8-jre-alpine
+FROM alpine:3.10
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/front50-web/build/install/front50 /opt/front50
-RUN apk --no-cache add --update bash
+RUN apk --no-cache add --update bash openjdk8-jre
 RUN adduser -D -S spinnaker
 USER spinnaker
 CMD ["/opt/front50/bin/front50"]


### PR DESCRIPTION
The container we had been using hasn't been updated in months. See
spinnaker/spinnaker#5204.