### PR TITLE
feat(chaosmonkey): Enforce chaos monkey permissions when enabled

### DIFF
--- a/front50-core/front50-core.gradle
+++ b/front50-core/front50-core.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation "org.springframework.security:spring-security-config"
   implementation "org.springframework.security:spring-security-core"
   implementation "org.springframework.security:spring-security-web"
+  implementation "com.netflix.spinnaker.kork:kork-web"
   api "com.github.ben-manes.caffeine:guava"
 
   implementation "com.netflix.spinnaker.kork:kork-core"

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties;
+import com.netflix.spinnaker.fiat.shared.FiatService;
+import com.netflix.spinnaker.front50.config.FiatConfigurationProperties;
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener;
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener.Type;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.application.Application.Permission;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
+import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
+import com.netflix.spinnaker.kork.exceptions.SystemException;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
+
+/** Wraps the business logic around Application Permissions. */
+@Component
+public class ApplicationPermissionsService {
+
+  private static final Logger log = LoggerFactory.getLogger(ApplicationPermissionsService.class);
+
+  private final ApplicationDAO applicationDAO;
+  private final Optional<FiatService> fiatService;
+  private final Optional<ApplicationPermissionDAO> applicationPermissionDAO;
+  private final FiatConfigurationProperties fiatConfigurationProperties;
+  private final FiatClientConfigurationProperties fiatClientConfigurationProperties;
+  private final Collection<ApplicationPermissionEventListener> applicationPermissionEventListeners;
+
+  public ApplicationPermissionsService(
+      ApplicationDAO applicationDAO,
+      Optional<FiatService> fiatService,
+      Optional<ApplicationPermissionDAO> applicationPermissionDAO,
+      FiatConfigurationProperties fiatConfigurationProperties,
+      FiatClientConfigurationProperties fiatClientConfigurationProperties,
+      Collection<ApplicationPermissionEventListener> applicationPermissionEventListeners) {
+    this.applicationDAO = applicationDAO;
+    this.fiatService = fiatService;
+    this.applicationPermissionDAO = applicationPermissionDAO;
+    this.fiatConfigurationProperties = fiatConfigurationProperties;
+    this.fiatClientConfigurationProperties = fiatClientConfigurationProperties;
+    this.applicationPermissionEventListeners = applicationPermissionEventListeners;
+  }
+
+  public Set<Permission> getAllApplicationPermissions() {
+    Map<String, Permission> actualPermissions =
+        applicationPermissionDAO().all().stream()
+            .map(permission -> new SimpleEntry<>(permission.getName().toLowerCase(), permission))
+            .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
+
+    applicationDAO.all().stream()
+        .filter(app -> !actualPermissions.containsKey(app.getName().toLowerCase()))
+        .forEach(
+            app -> {
+              Permission p = new Permission();
+              p.setName(app.getName());
+              p.setLastModified(-1L);
+              p.setLastModifiedBy("auto-generated");
+              actualPermissions.put(app.getName().toLowerCase(), p);
+            });
+
+    return new HashSet<>(actualPermissions.values());
+  }
+
+  public Permission getApplicationPermission(@Nonnull String appName) {
+    return applicationPermissionDAO().findById(appName);
+  }
+
+  public Permission createApplicationPermission(@Nonnull Permission newPermission) {
+    return performWrite(
+        supportingEventListeners(Type.PRE_CREATE),
+        supportingEventListeners(Type.POST_CREATE),
+        (unused, newPerm) -> {
+          Permission perm = applicationPermissionDAO().create(newPerm.getId(), newPerm);
+          syncUsers(perm, null);
+          return perm;
+        },
+        null,
+        newPermission);
+  }
+
+  public Permission updateApplicationPermission(
+      @Nonnull String appName, @Nonnull Permission newPermission) {
+    return performWrite(
+        supportingEventListeners(Type.PRE_UPDATE),
+        supportingEventListeners(Type.POST_UPDATE),
+        (unused, newPerm) -> {
+          try {
+            Permission oldPerm = applicationPermissionDAO().findById(appName);
+            applicationPermissionDAO().update(appName, newPerm);
+            syncUsers(newPermission, oldPerm);
+          } catch (NotFoundException e) {
+            createApplicationPermission(newPermission);
+          }
+          return newPerm;
+        },
+        null,
+        newPermission);
+  }
+
+  public void deleteApplicationPermission(@Nonnull String appName) {
+    Permission oldPerm;
+    try {
+      oldPerm = applicationPermissionDAO().findById(appName);
+    } catch (NotFoundException e) {
+      // Nothing to see here, we're all done already.
+      return;
+    }
+
+    performWrite(
+        supportingEventListeners(Type.PRE_DELETE),
+        supportingEventListeners(Type.POST_DELETE),
+        (unused, newPerm) -> {
+          applicationPermissionDAO().delete(appName);
+          syncUsers(null, oldPerm);
+          return newPerm;
+        },
+        oldPerm,
+        null);
+  }
+
+  private void syncUsers(Permission newPermission, Permission oldPermission) {
+    if (!fiatClientConfigurationProperties.isEnabled() || !fiatService.isPresent()) {
+      return;
+    }
+
+    // Specifically using an empty list here instead of null, because an empty list will update
+    // the anonymous user's app list.
+    Set<String> roles = new HashSet<>();
+
+    Optional.ofNullable(newPermission)
+        .ifPresent(
+            newPerm -> {
+              Permissions permissions = newPerm.getPermissions();
+              if (permissions != null && permissions.isRestricted()) {
+                roles.addAll(permissions.allGroups());
+              }
+            });
+
+    Optional.ofNullable(oldPermission)
+        .ifPresent(
+            oldPerm -> {
+              Permissions permissions = oldPerm.getPermissions();
+              if (permissions != null && permissions.isRestricted()) {
+                roles.addAll(permissions.allGroups());
+              }
+            });
+
+    if (fiatConfigurationProperties.getRoleSync().isEnabled()) {
+      try {
+        fiatService.get().sync(new ArrayList<>(roles));
+      } catch (RetrofitError e) {
+        log.warn("Error syncing users", e);
+      }
+    }
+  }
+
+  private ApplicationPermissionDAO applicationPermissionDAO() {
+    if (!applicationPermissionDAO.isPresent()) {
+      throw new SystemException(
+          "Configured storage service does not support application permissions");
+    }
+    return applicationPermissionDAO.get();
+  }
+
+  private Permission performWrite(
+      @Nonnull List<ApplicationPermissionEventListener> preEventListeners,
+      @Nonnull List<ApplicationPermissionEventListener> postEventListeners,
+      @Nonnull BiFunction<Permission, Permission, Permission> action,
+      @Nullable Permission originalPermission,
+      @Nullable Permission updatedPermission) {
+
+    try {
+      for (ApplicationPermissionEventListener preEventListener : preEventListeners) {
+        updatedPermission =
+            preEventListener.call(
+                (originalPermission == null) ? null : originalPermission.copy(),
+                (updatedPermission == null) ? null : updatedPermission.copy());
+      }
+
+      updatedPermission =
+          action.apply(
+              (originalPermission == null) ? null : originalPermission.copy(),
+              (updatedPermission == null) ? null : updatedPermission.copy());
+
+      for (ApplicationPermissionEventListener postEventListener : postEventListeners) {
+        updatedPermission =
+            postEventListener.call(
+                (originalPermission == null) ? null : originalPermission.copy(),
+                (updatedPermission == null) ? null : updatedPermission.copy());
+      }
+
+      return updatedPermission;
+    } catch (Exception e) {
+      String name =
+          (originalPermission == null)
+              ? (updatedPermission == null) ? "unknown" : updatedPermission.getName()
+              : originalPermission.getName();
+      log.error("Failed to perform action (name: {})", name);
+      throw e;
+    }
+  }
+
+  private List<ApplicationPermissionEventListener> supportingEventListeners(Type type) {
+    return applicationPermissionEventListeners.stream()
+        .filter(it -> it.supports(type))
+        .collect(Collectors.toList());
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/ChaosMonkeyEventListenerConfigurationProperties.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/ChaosMonkeyEventListenerConfigurationProperties.java
@@ -15,12 +15,17 @@
  */
 package com.netflix.spinnaker.front50.config;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Configuration
-@EnableConfigurationProperties({
-  ChaosMonkeyEventListenerConfigurationProperties.class,
-  FiatConfigurationProperties.class
-})
-public class Front50CoreConfiguration {}
+@Data
+@ConfigurationProperties("spinnaker.chaos-monkey")
+public class ChaosMonkeyEventListenerConfigurationProperties {
+  /** The user role (as it would be known to Fiat) for Chaos Monkey. */
+  String userRole;
+
+  /** @return True if a userRole has been defined. */
+  public boolean isEnabled() {
+    return userRole != null;
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/FiatConfigurationProperties.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/FiatConfigurationProperties.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("fiat")
+public class FiatConfigurationProperties {
+
+  RoleSyncConfigurationProperties roleSync = new RoleSyncConfigurationProperties();
+
+  @Data
+  public static class RoleSyncConfigurationProperties {
+    boolean enabled = true;
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/Front50CoreConfiguration.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/Front50CoreConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(FiatConfigurationProperties.class)
+public class Front50CoreConfiguration {}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/events/ApplicationPermissionEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/events/ApplicationPermissionEventListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.events;
+
+import com.netflix.spinnaker.front50.model.application.Application;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public interface ApplicationPermissionEventListener {
+
+  boolean supports(Type type);
+
+  @Nullable
+  Application.Permission call(
+      @Nullable Application.Permission originalPermission,
+      @Nullable Application.Permission updatedPermission);
+
+  void rollback(@Nonnull Application.Permission originalPermission);
+
+  enum Type {
+    PRE_UPDATE,
+    POST_UPDATE,
+    PRE_CREATE,
+    POST_CREATE,
+    PRE_DELETE,
+    POST_DELETE
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties;
+import com.netflix.spinnaker.front50.events.ApplicationEventListener;
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensures that when Chaos Monkey is enabled (or disabled) on an Application, its permissions are
+ * applied correctly.
+ *
+ * <p>This listens on both Application events, as well as ApplicationPermission events.
+ */
+@Component
+public class ChaosMonkeyEventListener
+    implements ApplicationEventListener, ApplicationPermissionEventListener {
+  private static final Logger log = LoggerFactory.getLogger(ChaosMonkeyEventListener.class);
+
+  private final ApplicationDAO applicationDAO;
+  private final ChaosMonkeyEventListenerConfigurationProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public ChaosMonkeyEventListener(
+      ApplicationDAO applicationDAO,
+      ChaosMonkeyEventListenerConfigurationProperties properties,
+      ObjectMapper objectMapper) {
+    this.applicationDAO = applicationDAO;
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean supports(ApplicationEventListener.Type type) {
+    return properties.isEnabled() && ApplicationEventListener.Type.PRE_UPDATE == type;
+  }
+
+  @Override
+  public Application call(Application originalApplication, Application updatedApplication) {
+    boolean isChaosMonkeyEnabled = isChaosMonkeyEnabled(updatedApplication);
+    if (isChaosMonkeyEnabled(originalApplication) == isChaosMonkeyEnabled) {
+      // Flag didn't change, we don't need to do anything.
+      return updatedApplication;
+    }
+
+    Object rawPermissions = updatedApplication.details().get("permissions");
+    if (!(rawPermissions instanceof Map)) {
+      // Exit early, no permissions config found on the application
+      log.warn("No permissions config found on application '{}'", updatedApplication.getName());
+      return updatedApplication;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> permissionsMap = (Map<String, List<String>>) rawPermissions;
+    if (permissionsMap.isEmpty()) {
+      // An empty permissions map means the application is unrestricted - let's not change this.
+      return updatedApplication;
+    }
+
+    if (isChaosMonkeyEnabled) {
+      // Chaos Monkey is enabled, apply permissions
+      List<String> readPermissions = permissionsMap.computeIfAbsent("READ", k -> new ArrayList<>());
+      if (!readPermissions.contains(properties.getUserRole())) {
+        log.info("Chaos Monkey READ permissions applied for '{}'", updatedApplication.getName());
+        readPermissions.add(properties.getUserRole());
+      }
+      List<String> writePermissions = permissionsMap.get("WRITE");
+      if (!writePermissions.contains(properties.getUserRole())) {
+        log.info("Chaos Monkey WRITE permissions applied for '{}'", updatedApplication.getName());
+        writePermissions.add(properties.getUserRole());
+      }
+    } else {
+      // Chaos Monkey is disabled, revoke permissions
+      log.info(
+          "Revoking Chaos Monkey READ and WRITE permissions for '{}'",
+          updatedApplication.getName());
+      permissionsMap.get("READ").remove(properties.getUserRole());
+      permissionsMap.get("WRITE").remove(properties.getUserRole());
+    }
+
+    return updatedApplication;
+  }
+
+  @Override
+  public void rollback(Application originalApplication) {
+    // Do nothing.
+  }
+
+  @Override
+  public boolean supports(ApplicationPermissionEventListener.Type type) {
+    return properties.isEnabled()
+        && Arrays.asList(
+                ApplicationPermissionEventListener.Type.PRE_CREATE,
+                ApplicationPermissionEventListener.Type.PRE_UPDATE)
+            .contains(type);
+  }
+
+  @Nullable
+  @Override
+  public Application.Permission call(
+      @Nullable Application.Permission originalPermission,
+      @Nullable Application.Permission updatedPermission) {
+    if (updatedPermission == null) {
+      return null;
+    }
+
+    Application application = applicationDAO.findByName(updatedPermission.getName());
+
+    if (isChaosMonkeyEnabled(application)) {
+      applyNewPermissions(updatedPermission, true);
+    } else {
+      applyNewPermissions(updatedPermission, false);
+    }
+
+    return updatedPermission;
+  }
+
+  private void applyNewPermissions(Application.Permission updatedPermission, boolean addRole) {
+    Permissions permissions = updatedPermission.getPermissions();
+
+    Map<Authorization, List<String>> unpackedPermissions = permissions.unpack();
+    unpackedPermissions.forEach(
+        (key, value) -> {
+          List<String> roles = new ArrayList<>(value);
+          if (key == Authorization.READ || key == Authorization.WRITE) {
+            if (addRole) {
+              roles.add(properties.getUserRole());
+            } else {
+              roles.remove(properties.getUserRole());
+            }
+          }
+          unpackedPermissions.put(key, roles);
+        });
+    Permissions newPermissions = Permissions.factory(unpackedPermissions);
+
+    updatedPermission.setPermissions(newPermissions);
+  }
+
+  @Override
+  public void rollback(@Nonnull Application.Permission originalPermission) {
+    // Do nothing.
+  }
+
+  private boolean isChaosMonkeyEnabled(Application application) {
+    Object config = application.details().get("chaosMonkey");
+    if (config == null) {
+      return false;
+    }
+    return objectMapper.convertValue(config, ChaosMonkeyConfig.class).enabled;
+  }
+
+  private static class ChaosMonkeyConfig {
+    public boolean enabled;
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/Application.groovy
@@ -408,6 +408,16 @@ class Application implements Timestamped {
         permissions = b.build()
       }
     }
+
+    Permission copy() {
+      // It's OK to "copy" permissions without actually copying since the object is immutable.
+      return new Permission(
+        name: name,
+        lastModified: lastModified,
+        lastModifiedBy: lastModifiedBy,
+        permissions: permissions
+      )
+    }
   }
 
   static class TrafficGuard {

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.listeners
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties
+import com.netflix.spinnaker.front50.events.ApplicationEventListener
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener
+import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ChaosMonkeyEventListenerSpec extends Specification {
+
+  private final static String CHAOS_MONKEY_PRINCIPAL = "chaosmonkey@example.com"
+
+  def applicationDao = Mock(ApplicationDAO)
+
+  @Subject
+  def subject = new ChaosMonkeyEventListener(
+    applicationDao,
+    new ChaosMonkeyEventListenerConfigurationProperties(
+      userRole: "chaosmonkey@example.com"
+    ),
+    new ObjectMapper()
+  )
+
+  @Unroll
+  void "supports application pre-update events"() {
+    expect:
+    subject.supports(type) == expectedSupport
+
+    where:
+    type                                      || expectedSupport
+    ApplicationEventListener.Type.PRE_CREATE  || false
+    ApplicationEventListener.Type.PRE_UPDATE  || true
+    ApplicationEventListener.Type.PRE_DELETE  || false
+    ApplicationEventListener.Type.POST_CREATE || false
+    ApplicationEventListener.Type.POST_UPDATE || false
+    ApplicationEventListener.Type.POST_DELETE || false
+  }
+
+  @Unroll
+  void "supports application permission pre-create and pre-update events"() {
+    expect:
+    subject.supports(type) == expectedSupport
+
+    where:
+    type                                                || expectedSupport
+    ApplicationPermissionEventListener.Type.PRE_CREATE  || true
+    ApplicationPermissionEventListener.Type.PRE_UPDATE  || true
+    ApplicationPermissionEventListener.Type.PRE_DELETE  || false
+    ApplicationPermissionEventListener.Type.POST_CREATE || false
+    ApplicationPermissionEventListener.Type.POST_UPDATE || false
+    ApplicationPermissionEventListener.Type.POST_DELETE || false
+  }
+
+  @Unroll
+  void "should add chaos monkey permissions during application update"() {
+    given:
+    Application application = new Application(name: "hello")
+    application.details = [
+      "chaosMonkey": [
+        "enabled": chaosMonkeyEnabled
+      ],
+      "permissions": [
+        "READ": readPermissions,
+        "WRITE": writePermissions
+      ]
+    ]
+
+    when:
+    subject.call(application, application)
+
+    then:
+    if (chaosMonkeyEnabled) {
+      application.details().permissions.READ == readPermissions + CHAOS_MONKEY_PRINCIPAL
+      application.details().permissions.WRITE == writePermissions + CHAOS_MONKEY_PRINCIPAL
+    } else {
+      !application.details().permissions.READ.contains(CHAOS_MONKEY_PRINCIPAL)
+      !application.details().permissions.WRITE.contains(CHAOS_MONKEY_PRINCIPAL)
+    }
+
+    where:
+    chaosMonkeyEnabled | readPermissions               | writePermissions
+    true               | ["a"]                         | ["b"]
+    true               | [CHAOS_MONKEY_PRINCIPAL]      | ["a"]
+    true               | ["a"]                         | [CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]
+    false              | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+  }
+
+  @Unroll
+  void "should add chaos monkey permissions during permissions update"() {
+    given:
+    Application.Permission permission = new Application.Permission(
+      name: "hello",
+      lastModifiedBy: "bird person",
+      lastModified: -1L,
+      permissions: new Permissions.Builder()
+        .add(Authorization.READ, readPermissions)
+        .add(Authorization.WRITE, writePermissions)
+        .build()
+    )
+
+    when:
+    subject.call(permission, permission)
+
+    then:
+    1 * applicationDao.findByName(_) >> new Application(details: [
+      "chaosMonkey": [
+        enabled: chaosMonkeyEnabled
+      ]
+    ])
+
+    if (chaosMonkeyEnabled) {
+      permission.getPermissions().get(Authorization.READ) == readPermissions + CHAOS_MONKEY_PRINCIPAL
+      permission.getPermissions().get(Authorization.WRITE) == writePermissions + CHAOS_MONKEY_PRINCIPAL
+    } else {
+      permission.getPermissions().get(Authorization.READ) == readPermissions - CHAOS_MONKEY_PRINCIPAL
+      permission.getPermissions().get(Authorization.WRITE) == writePermissions - CHAOS_MONKEY_PRINCIPAL
+    }
+
+    where:
+    chaosMonkeyEnabled | readPermissions               | writePermissions
+    true               | ["a"]                         | ["b"]
+    true               | [CHAOS_MONKEY_PRINCIPAL]      | ["a"]
+    true               | ["a"]                         | [CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]
+    false              | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+  }
+}

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.model.SqlStorageService
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
 import com.netflix.spinnaker.kork.sql.config.SqlProperties
+import java.time.Clock
 import org.jooq.DSLContext
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -29,7 +30,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import java.time.Clock
 
 @Configuration
 @ConditionalOnProperty("sql.enabled")

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.front50.model.Timestamped
 import com.netflix.spinnaker.front50.model.tag.EntityTagsDAO
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.security.AuthenticatedRequest
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureTimeMillis
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -30,8 +32,6 @@ import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.scheduling.annotation.Scheduled
-import java.util.concurrent.TimeUnit
-import kotlin.system.measureTimeMillis
 
 class StorageServiceMigrator(
   private val dynamicConfigService: DynamicConfigService,

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -37,9 +37,11 @@ import com.netflix.spinnaker.front50.model.sql.PipelineTableDefinition
 import com.netflix.spinnaker.front50.model.sql.ProjectTableDefinition
 import com.netflix.spinnaker.front50.model.sql.transactional
 import com.netflix.spinnaker.front50.model.sql.withRetry
-import com.netflix.spinnaker.kork.sql.routing.withPool
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import com.netflix.spinnaker.kork.sql.routing.withPool
 import com.netflix.spinnaker.security.AuthenticatedRequest
+import java.time.Clock
+import kotlin.system.measureTimeMillis
 import org.jooq.DSLContext
 import org.jooq.exception.SQLDialectNotSupportedException
 import org.jooq.impl.DSL
@@ -47,8 +49,6 @@ import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.table
 import org.slf4j.LoggerFactory
-import java.time.Clock
-import kotlin.system.measureTimeMillis
 
 class SqlStorageService(
   private val objectMapper: ObjectMapper,

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -26,12 +26,12 @@ import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import dev.minutest.ContextBuilder
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import java.time.Clock
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.isEqualTo
-import java.time.Clock
 
 internal object SqlStorageServiceTests : JUnit5Minutests {
 

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/TestDatabase.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/TestDatabase.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import java.sql.SQLException
 import liquibase.Liquibase
 import liquibase.configuration.ConfigurationContainer
 import liquibase.configuration.GlobalConfiguration
@@ -36,7 +37,6 @@ import org.jooq.impl.DataSourceConnectionProvider
 import org.jooq.impl.DefaultConfiguration
 import org.jooq.impl.DefaultDSLContext
 import org.slf4j.LoggerFactory
-import java.sql.SQLException
 
 internal fun initDatabase(jdbcUrl: String, sqlDialect: SQLDialect): DSLContext {
   val dataSource = HikariDataSource(

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/Main.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/Main.groovy
@@ -22,8 +22,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.context.annotation.ComponentScan

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -49,8 +49,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
-import java.util.concurrent.Executors
-
 @Configuration
 @ComponentScan
 @EnableFiatAutoConfig

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ clouddriverVersion=5.3.0
 fiatVersion=1.11.0
 enablePublishing=false
 korkVersion=7.3.0
-spinnakerGradleVersion=7.0.1
+spinnakerGradleVersion=7.2.0
 includeProviders=azure,gcs,oracle,redis,s3,swift,sql
 org.gradle.parallel=true


### PR DESCRIPTION
Enforces that Chaos Monkey has the permissions it needs to terminate instances within an application if enabled. This introduces a new config: `spinnaker.chaos-monkey.user-role`, which should be the principal user that Chaos Monkey works as (e.g. `chaos-monkey@example.com`. Updates to either application settings or application permissions will trigger this event listener.

While working on this, I also moved business logic out of the controller layer and into a service.

The PR is broken into two commits, the first is just moving logic for permissions into `ApplicationPermissionsService`, the second is for adding the chaos monkey functionality.