### PR TITLE
Revert "fix(plugins): Add GET by pluginId"

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactService.java
@@ -46,10 +46,6 @@ public class PluginArtifactService {
     return repository.getByService(service);
   }
 
-  public PluginArtifact findById(@Nonnull String pluginId) {
-    return repository.findById(pluginId);
-  }
-
   public PluginArtifact upsert(@Nonnull PluginArtifact pluginArtifact) {
     validate(pluginArtifact);
 

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginArtifactController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginArtifactController.java
@@ -47,11 +47,6 @@ public class PluginArtifactController {
         .orElseGet(pluginArtifactService::findAll);
   }
 
-  @RequestMapping(value = "", method = RequestMethod.GET)
-  PluginArtifact get(@RequestParam(value = "pluginId") String pluginId) {
-    return pluginArtifactService.findById(pluginId);
-  }
-
   @RequestMapping(value = "", method = RequestMethod.POST)
   PluginArtifact upsert(@RequestBody PluginArtifact pluginArtifact) {
     return pluginArtifactService.upsert(pluginArtifact);


### PR DESCRIPTION
Reverts spinnaker/front50#670

This is causing a startup issue in my local instance:

```
Caused by: java.lang.IllegalStateException: Ambiguous mapping. Cannot map 'pluginArtifactController' method 
java.util.Collection<com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact> com.netflix.spinnaker.front50.controllers.PluginArtifactController.list(java.lang.String)
to {GET /pluginArtifacts}: There is already 'pluginArtifactController' bean method
com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact com.netflix.spinnaker.front50.controllers.PluginArtifactController.get(java.lang.String) mapped.

```