### PR TITLE
fix(permissions): Update and persist chaos monkey permissions on application PRE_UPDATE event

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
@@ -18,17 +18,13 @@ package com.netflix.spinnaker.front50.listeners;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.fiat.model.Authorization;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.front50.ApplicationPermissionsService;
 import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties;
 import com.netflix.spinnaker.front50.events.ApplicationEventListener;
-import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener;
 import com.netflix.spinnaker.front50.model.application.Application;
-import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -37,22 +33,21 @@ import org.springframework.stereotype.Component;
  * Ensures that when Chaos Monkey is enabled (or disabled) on an Application, its permissions are
  * applied correctly.
  *
- * <p>This listens on both Application events, as well as ApplicationPermission events.
+ * <p>This listens on both Application events.
  */
 @Component
-public class ChaosMonkeyEventListener
-    implements ApplicationEventListener, ApplicationPermissionEventListener {
+public class ChaosMonkeyEventListener implements ApplicationEventListener {
   private static final Logger log = LoggerFactory.getLogger(ChaosMonkeyEventListener.class);
 
-  private final ApplicationDAO applicationDAO;
+  private final ApplicationPermissionsService applicationPermissionsService;
   private final ChaosMonkeyEventListenerConfigurationProperties properties;
   private final ObjectMapper objectMapper;
 
   public ChaosMonkeyEventListener(
-      ApplicationDAO applicationDAO,
+      ApplicationPermissionsService applicationPermissionsService,
       ChaosMonkeyEventListenerConfigurationProperties properties,
       ObjectMapper objectMapper) {
-    this.applicationDAO = applicationDAO;
+    this.applicationPermissionsService = applicationPermissionsService;
     this.properties = properties;
     this.objectMapper = objectMapper;
   }
@@ -64,46 +59,27 @@ public class ChaosMonkeyEventListener
 
   @Override
   public Application call(Application originalApplication, Application updatedApplication) {
-    boolean isChaosMonkeyEnabled = isChaosMonkeyEnabled(updatedApplication);
-    if (isChaosMonkeyEnabled(originalApplication) == isChaosMonkeyEnabled) {
-      // Flag didn't change, we don't need to do anything.
+    Application.Permission permission =
+        applicationPermissionsService.getApplicationPermission(updatedApplication.getName());
+
+    if (!permission.getPermissions().isRestricted()) {
       return updatedApplication;
     }
 
-    Object rawPermissions = updatedApplication.details().get("permissions");
-    if (!(rawPermissions instanceof Map)) {
-      // Exit early, no permissions config found on the application
-      log.warn("No permissions config found on application '{}'", updatedApplication.getName());
-      return updatedApplication;
-    }
-
-    @SuppressWarnings("unchecked")
-    Map<String, List<String>> permissionsMap = (Map<String, List<String>>) rawPermissions;
-    if (permissionsMap.isEmpty()) {
-      // An empty permissions map means the application is unrestricted - let's not change this.
-      return updatedApplication;
-    }
-
-    if (isChaosMonkeyEnabled) {
-      // Chaos Monkey is enabled, apply permissions
-      List<String> readPermissions = permissionsMap.computeIfAbsent("READ", k -> new ArrayList<>());
-      if (!readPermissions.contains(properties.getUserRole())) {
-        log.info("Chaos Monkey READ permissions applied for '{}'", updatedApplication.getName());
-        readPermissions.add(properties.getUserRole());
-      }
-      List<String> writePermissions = permissionsMap.get("WRITE");
-      if (!writePermissions.contains(properties.getUserRole())) {
-        log.info("Chaos Monkey WRITE permissions applied for '{}'", updatedApplication.getName());
-        writePermissions.add(properties.getUserRole());
-      }
+    if (isChaosMonkeyEnabled(updatedApplication)) {
+      applyNewPermissions(permission, true);
     } else {
-      // Chaos Monkey is disabled, revoke permissions
-      log.info(
-          "Revoking Chaos Monkey READ and WRITE permissions for '{}'",
-          updatedApplication.getName());
-      permissionsMap.get("READ").remove(properties.getUserRole());
-      permissionsMap.get("WRITE").remove(properties.getUserRole());
+      applyNewPermissions(permission, false);
     }
+
+    Application.Permission updatedPermission =
+        applicationPermissionsService.updateApplicationPermission(
+            updatedApplication.getName(), permission);
+
+    log.debug(
+        "Updated application `{}` with permissions `{}`",
+        updatedApplication.getName(),
+        updatedPermission.getPermissions().toString());
 
     return updatedApplication;
   }
@@ -111,35 +87,6 @@ public class ChaosMonkeyEventListener
   @Override
   public void rollback(Application originalApplication) {
     // Do nothing.
-  }
-
-  @Override
-  public boolean supports(ApplicationPermissionEventListener.Type type) {
-    return properties.isEnabled()
-        && Arrays.asList(
-                ApplicationPermissionEventListener.Type.PRE_CREATE,
-                ApplicationPermissionEventListener.Type.PRE_UPDATE)
-            .contains(type);
-  }
-
-  @Nullable
-  @Override
-  public Application.Permission call(
-      @Nullable Application.Permission originalPermission,
-      @Nullable Application.Permission updatedPermission) {
-    if (updatedPermission == null) {
-      return null;
-    }
-
-    Application application = applicationDAO.findByName(updatedPermission.getName());
-
-    if (isChaosMonkeyEnabled(application)) {
-      applyNewPermissions(updatedPermission, true);
-    } else {
-      applyNewPermissions(updatedPermission, false);
-    }
-
-    return updatedPermission;
   }
 
   private void applyNewPermissions(Application.Permission updatedPermission, boolean addRole) {
@@ -151,7 +98,10 @@ public class ChaosMonkeyEventListener
           List<String> roles = new ArrayList<>(value);
           if (key == Authorization.READ || key == Authorization.WRITE) {
             if (addRole) {
-              roles.add(properties.getUserRole());
+              // Only add the chaos monkey role if it doesn't already exist
+              if (!hasChaosMonkeyPermissions(updatedPermission, key)) {
+                roles.add(properties.getUserRole());
+              }
             } else {
               roles.remove(properties.getUserRole());
             }
@@ -163,17 +113,20 @@ public class ChaosMonkeyEventListener
     updatedPermission.setPermissions(newPermissions);
   }
 
-  @Override
-  public void rollback(@Nonnull Application.Permission originalPermission) {
-    // Do nothing.
-  }
-
   private boolean isChaosMonkeyEnabled(Application application) {
     Object config = application.details().get("chaosMonkey");
     if (config == null) {
       return false;
     }
     return objectMapper.convertValue(config, ChaosMonkeyConfig.class).enabled;
+  }
+
+  private boolean hasChaosMonkeyPermissions(
+      Application.Permission updatedPermission, Authorization authorizationType) {
+    return updatedPermission
+        .getPermissions()
+        .get(authorizationType)
+        .contains(properties.getUserRole());
   }
 
   private static class ChaosMonkeyConfig {

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
@@ -96,12 +96,15 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     permission.getPermissions() == updatedPermissions.getPermissions()
 
     where:
-    chaosMonkeyEnabled | readPermissions               | writePermissions               | readPermissionsExpected       | writePermissionsExpected
-    true               | ["a"]                         | ["b"]                          | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
-    true               | [CHAOS_MONKEY_PRINCIPAL]      | ["a"]                          | [CHAOS_MONKEY_PRINCIPAL]      | ["a", CHAOS_MONKEY_PRINCIPAL]
-    true               | ["a"]                         | [CHAOS_MONKEY_PRINCIPAL]       | ["a", CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL]
-    true               | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]       | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]
-    false              | ["a"]                         | ["b"]                          | ["a"]                         | ["b"]
-    false              | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]  | ["a"]                         | ["b"]
+    chaosMonkeyEnabled | readPermissions                                 | writePermissions                                | readPermissionsExpected       | writePermissionsExpected
+    true               | ["a"]                                           | ["b"]                                           | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]                        | ["a"]                                           | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a"]                                           | [CHAOS_MONKEY_PRINCIPAL]                        | ["a", CHAOS_MONKEY_PRINCIPAL] | []
+    true               | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
+    true               | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    false              | ["a"]                                           | ["b"]                                           | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL]                   | ["b", CHAOS_MONKEY_PRINCIPAL]                   | ["a"]                         | ["b"]
+    false              | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
+    false              | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
   }
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
@@ -93,12 +93,7 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     subject.call(application, application)
 
     then:
-    if (chaosMonkeyEnabled) {
-      permission == updatedPermissions
-    } else {
-      permission.getPermissions().get(Authorization.READ) == readPermissionsExpected
-      permission.getPermissions().get(Authorization.WRITE) == writePermissionsExpected
-    }
+    permission.getPermissions() == updatedPermissions.getPermissions()
 
     where:
     chaosMonkeyEnabled | readPermissions               | writePermissions               | readPermissionsExpected       | writePermissionsExpected

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
@@ -18,11 +18,10 @@ package com.netflix.spinnaker.front50.listeners
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.front50.ApplicationPermissionsService
 import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties
 import com.netflix.spinnaker.front50.events.ApplicationEventListener
-import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener
 import com.netflix.spinnaker.front50.model.application.Application
-import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -31,13 +30,13 @@ class ChaosMonkeyEventListenerSpec extends Specification {
 
   private final static String CHAOS_MONKEY_PRINCIPAL = "chaosmonkey@example.com"
 
-  def applicationDao = Mock(ApplicationDAO)
+  def applicationPermissionsService = Mock(ApplicationPermissionsService)
 
   @Subject
   def subject = new ChaosMonkeyEventListener(
-    applicationDao,
+    applicationPermissionsService,
     new ChaosMonkeyEventListenerConfigurationProperties(
-      userRole: "chaosmonkey@example.com"
+      userRole: CHAOS_MONKEY_PRINCIPAL
     ),
     new ObjectMapper()
   )
@@ -58,59 +57,15 @@ class ChaosMonkeyEventListenerSpec extends Specification {
   }
 
   @Unroll
-  void "supports application permission pre-create and pre-update events"() {
-    expect:
-    subject.supports(type) == expectedSupport
-
-    where:
-    type                                                || expectedSupport
-    ApplicationPermissionEventListener.Type.PRE_CREATE  || true
-    ApplicationPermissionEventListener.Type.PRE_UPDATE  || true
-    ApplicationPermissionEventListener.Type.PRE_DELETE  || false
-    ApplicationPermissionEventListener.Type.POST_CREATE || false
-    ApplicationPermissionEventListener.Type.POST_UPDATE || false
-    ApplicationPermissionEventListener.Type.POST_DELETE || false
-  }
-
-  @Unroll
   void "should add chaos monkey permissions during application update"() {
     given:
     Application application = new Application(name: "hello")
     application.details = [
       "chaosMonkey": [
         "enabled": chaosMonkeyEnabled
-      ],
-      "permissions": [
-        "READ": readPermissions,
-        "WRITE": writePermissions
       ]
     ]
 
-    when:
-    subject.call(application, application)
-
-    then:
-    if (chaosMonkeyEnabled) {
-      application.details().permissions.READ == readPermissions + CHAOS_MONKEY_PRINCIPAL
-      application.details().permissions.WRITE == writePermissions + CHAOS_MONKEY_PRINCIPAL
-    } else {
-      !application.details().permissions.READ.contains(CHAOS_MONKEY_PRINCIPAL)
-      !application.details().permissions.WRITE.contains(CHAOS_MONKEY_PRINCIPAL)
-    }
-
-    where:
-    chaosMonkeyEnabled | readPermissions               | writePermissions
-    true               | ["a"]                         | ["b"]
-    true               | [CHAOS_MONKEY_PRINCIPAL]      | ["a"]
-    true               | ["a"]                         | [CHAOS_MONKEY_PRINCIPAL]
-    true               | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]
-    false              | ["a"]                         | ["b"]
-    false              | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
-  }
-
-  @Unroll
-  void "should add chaos monkey permissions during permissions update"() {
-    given:
     Application.Permission permission = new Application.Permission(
       name: "hello",
       lastModifiedBy: "bird person",
@@ -121,31 +76,37 @@ class ChaosMonkeyEventListenerSpec extends Specification {
         .build()
     )
 
+    Application.Permission updatedPermissions = new Application.Permission(
+      name: "hello",
+      lastModifiedBy: "bird person",
+      lastModified: -1L,
+      permissions: new Permissions.Builder()
+        .add(Authorization.READ, readPermissionsExpected)
+        .add(Authorization.WRITE, writePermissionsExpected)
+        .build()
+    )
+
+    applicationPermissionsService.getApplicationPermission(application.name) >> permission
+    applicationPermissionsService.updateApplicationPermission(application.name, _ as Application.Permission) >> updatedPermissions
+
     when:
-    subject.call(permission, permission)
+    subject.call(application, application)
 
     then:
-    1 * applicationDao.findByName(_) >> new Application(details: [
-      "chaosMonkey": [
-        enabled: chaosMonkeyEnabled
-      ]
-    ])
-
     if (chaosMonkeyEnabled) {
-      permission.getPermissions().get(Authorization.READ) == readPermissions + CHAOS_MONKEY_PRINCIPAL
-      permission.getPermissions().get(Authorization.WRITE) == writePermissions + CHAOS_MONKEY_PRINCIPAL
+      permission == updatedPermissions
     } else {
-      permission.getPermissions().get(Authorization.READ) == readPermissions - CHAOS_MONKEY_PRINCIPAL
-      permission.getPermissions().get(Authorization.WRITE) == writePermissions - CHAOS_MONKEY_PRINCIPAL
+      permission.getPermissions().get(Authorization.READ) == readPermissionsExpected
+      permission.getPermissions().get(Authorization.WRITE) == writePermissionsExpected
     }
 
     where:
-    chaosMonkeyEnabled | readPermissions               | writePermissions
-    true               | ["a"]                         | ["b"]
-    true               | [CHAOS_MONKEY_PRINCIPAL]      | ["a"]
-    true               | ["a"]                         | [CHAOS_MONKEY_PRINCIPAL]
-    true               | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]
-    false              | ["a"]                         | ["b"]
-    false              | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+    chaosMonkeyEnabled | readPermissions               | writePermissions               | readPermissionsExpected       | writePermissionsExpected
+    true               | ["a"]                         | ["b"]                          | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]      | ["a"]                          | [CHAOS_MONKEY_PRINCIPAL]      | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a"]                         | [CHAOS_MONKEY_PRINCIPAL]       | ["a", CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]       | [CHAOS_MONKEY_PRINCIPAL]      | [CHAOS_MONKEY_PRINCIPAL]
+    false              | ["a"]                         | ["b"]                          | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]  | ["a"]                         | ["b"]
   }
 }


### PR DESCRIPTION
The previous implementation was flawed for a few reasons.

1) ApplicationDAO does not persist permissions, so the implementation of `ApplicationEventListener` did nothing.
2) When a user updates Chaos Monkey permissions from Deck, permissions are not passed to the Orca task `UpsertApplicationTask`, which means that the chaos monkey `ApplicationPermissionEventListener` implementation would not be triggered.
3) When the chaos monkey `ApplicationPermissionEventListener` was triggered (via an Application permissions update event, like saving perms through Deck), a check to see if the permissions were unrestricted did not exist.  This would lock people out of READ and WRITE permissions since only the chaos monkey permission would be applied.

This fix addresses these issues.  I've removed the implementation `ApplicationPermissionEventListener`, and instead we use the `ApplicationPermissionsService` in the `ApplicationEventListener` implementation to ensure permissions are persisted.