### PR TITLE
fix(permissions): Apply chaos monkey permissions on application update permissions event

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
@@ -109,22 +109,27 @@ public class ApplicationPermissionsService {
   }
 
   public Permission updateApplicationPermission(
-      @Nonnull String appName, @Nonnull Permission newPermission) {
+      @Nonnull String appName, @Nonnull Permission newPermission, boolean skipListeners) {
+    if (skipListeners) {
+      return update(appName, newPermission);
+    }
     return performWrite(
         supportingEventListeners(Type.PRE_UPDATE),
         supportingEventListeners(Type.POST_UPDATE),
-        (unused, newPerm) -> {
-          try {
-            Permission oldPerm = applicationPermissionDAO().findById(appName);
-            applicationPermissionDAO().update(appName, newPerm);
-            syncUsers(newPermission, oldPerm);
-          } catch (NotFoundException e) {
-            createApplicationPermission(newPermission);
-          }
-          return newPerm;
-        },
+        (unused, newPerm) -> update(appName, newPerm),
         null,
         newPermission);
+  }
+
+  private Permission update(@Nonnull String appName, @Nonnull Permission newPermission) {
+    try {
+      Permission oldPerm = applicationPermissionDAO().findById(appName);
+      applicationPermissionDAO().update(appName, newPermission);
+      syncUsers(newPermission, oldPerm);
+    } catch (NotFoundException e) {
+      createApplicationPermission(newPermission);
+    }
+    return newPermission;
   }
 
   public void deleteApplicationPermission(@Nonnull String appName) {

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
@@ -24,11 +24,7 @@ import com.netflix.spinnaker.front50.events.ApplicationEventListener;
 import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener;
 import com.netflix.spinnaker.front50.model.application.Application;
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -113,7 +109,7 @@ public class ChaosMonkeyEventListener
   public Application.Permission call(
       @Nullable Application.Permission originalPermission,
       @Nullable Application.Permission updatedPermission) {
-    if (updatedPermission == null) {
+    if (updatedPermission == null || !updatedPermission.getPermissions().isRestricted()) {
       return null;
     }
 

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListener.java
@@ -21,11 +21,16 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.front50.ApplicationPermissionsService;
 import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties;
 import com.netflix.spinnaker.front50.events.ApplicationEventListener;
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener;
 import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -37,17 +42,21 @@ import org.springframework.stereotype.Component;
  * <p>This listens on both Application events.
  */
 @Component
-public class ChaosMonkeyEventListener implements ApplicationEventListener {
+public class ChaosMonkeyEventListener
+    implements ApplicationEventListener, ApplicationPermissionEventListener {
   private static final Logger log = LoggerFactory.getLogger(ChaosMonkeyEventListener.class);
 
+  private final ApplicationDAO applicationDAO;
   private final ApplicationPermissionsService applicationPermissionsService;
   private final ChaosMonkeyEventListenerConfigurationProperties properties;
   private final ObjectMapper objectMapper;
 
   public ChaosMonkeyEventListener(
+      ApplicationDAO applicationDAO,
       ApplicationPermissionsService applicationPermissionsService,
       ChaosMonkeyEventListenerConfigurationProperties properties,
       ObjectMapper objectMapper) {
+    this.applicationDAO = applicationDAO;
     this.applicationPermissionsService = applicationPermissionsService;
     this.properties = properties;
     this.objectMapper = objectMapper;
@@ -75,7 +84,7 @@ public class ChaosMonkeyEventListener implements ApplicationEventListener {
 
     Application.Permission updatedPermission =
         applicationPermissionsService.updateApplicationPermission(
-            updatedApplication.getName(), permission);
+            updatedApplication.getName(), permission, true);
 
     log.debug(
         "Updated application `{}` with permissions `{}`",
@@ -87,6 +96,40 @@ public class ChaosMonkeyEventListener implements ApplicationEventListener {
 
   @Override
   public void rollback(Application originalApplication) {
+    // Do nothing.
+  }
+
+  @Override
+  public boolean supports(ApplicationPermissionEventListener.Type type) {
+    return properties.isEnabled()
+        && Arrays.asList(
+                ApplicationPermissionEventListener.Type.PRE_CREATE,
+                ApplicationPermissionEventListener.Type.PRE_UPDATE)
+            .contains(type);
+  }
+
+  @Nullable
+  @Override
+  public Application.Permission call(
+      @Nullable Application.Permission originalPermission,
+      @Nullable Application.Permission updatedPermission) {
+    if (updatedPermission == null) {
+      return null;
+    }
+
+    Application application = applicationDAO.findByName(updatedPermission.getName());
+
+    if (isChaosMonkeyEnabled(application)) {
+      applyNewPermissions(updatedPermission, true);
+    } else {
+      applyNewPermissions(updatedPermission, false);
+    }
+
+    return updatedPermission;
+  }
+
+  @Override
+  public void rollback(@Nonnull Application.Permission originalPermission) {
     // Do nothing.
   }
 

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyEventListenerSpec.groovy
@@ -21,7 +21,9 @@ import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.front50.ApplicationPermissionsService
 import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties
 import com.netflix.spinnaker.front50.events.ApplicationEventListener
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener
 import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -31,9 +33,11 @@ class ChaosMonkeyEventListenerSpec extends Specification {
   private final static String CHAOS_MONKEY_PRINCIPAL = "chaosmonkey@example.com"
 
   def applicationPermissionsService = Mock(ApplicationPermissionsService)
+  def applicationDao = Mock(ApplicationDAO)
 
   @Subject
   def subject = new ChaosMonkeyEventListener(
+    applicationDao,
     applicationPermissionsService,
     new ChaosMonkeyEventListenerConfigurationProperties(
       userRole: CHAOS_MONKEY_PRINCIPAL
@@ -54,6 +58,21 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     ApplicationEventListener.Type.POST_CREATE || false
     ApplicationEventListener.Type.POST_UPDATE || false
     ApplicationEventListener.Type.POST_DELETE || false
+  }
+
+  @Unroll
+  void "supports application permission pre-create and pre-update events"() {
+    expect:
+    subject.supports(type) == expectedSupport
+
+    where:
+    type                                                || expectedSupport
+    ApplicationPermissionEventListener.Type.PRE_CREATE || true
+    ApplicationPermissionEventListener.Type.PRE_UPDATE  || true
+    ApplicationPermissionEventListener.Type.PRE_DELETE  || false
+    ApplicationPermissionEventListener.Type.POST_CREATE || false
+    ApplicationPermissionEventListener.Type.POST_UPDATE || false
+    ApplicationPermissionEventListener.Type.POST_DELETE || false
   }
 
   @Unroll
@@ -87,7 +106,7 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     )
 
     applicationPermissionsService.getApplicationPermission(application.name) >> permission
-    applicationPermissionsService.updateApplicationPermission(application.name, _ as Application.Permission) >> updatedPermissions
+    applicationPermissionsService.updateApplicationPermission(application.name, _ as Application.Permission, true) >> updatedPermissions
 
     when:
     subject.call(application, application)
@@ -96,15 +115,65 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     permission.getPermissions() == updatedPermissions.getPermissions()
 
     where:
-    chaosMonkeyEnabled | readPermissions                                 | writePermissions                                | readPermissionsExpected       | writePermissionsExpected
-    true               | ["a"]                                           | ["b"]                                           | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
-    true               | [CHAOS_MONKEY_PRINCIPAL]                        | ["a"]                                           | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
-    true               | ["a"]                                           | [CHAOS_MONKEY_PRINCIPAL]                        | ["a", CHAOS_MONKEY_PRINCIPAL] | []
-    true               | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
-    true               | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
-    false              | ["a"]                                           | ["b"]                                           | ["a"]                         | ["b"]
-    false              | ["a", CHAOS_MONKEY_PRINCIPAL]                   | ["b", CHAOS_MONKEY_PRINCIPAL]                   | ["a"]                         | ["b"]
-    false              | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
-    false              | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    chaosMonkeyEnabled | readPermissions                                  | writePermissions                                 | readPermissionsExpected       | writePermissionsExpected
+    true               | ["a"]                                            | ["b"]                                            | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]                         | ["a"]                                            | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a"]                                            | [CHAOS_MONKEY_PRINCIPAL]                         | ["a", CHAOS_MONKEY_PRINCIPAL] | []
+    true               | [CHAOS_MONKEY_PRINCIPAL]                         | [CHAOS_MONKEY_PRINCIPAL]                         | []                            | []
+    true               | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    false              | ["a"]                                            | ["b"]                                            | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL]                    | ["b", CHAOS_MONKEY_PRINCIPAL]                    | ["a"]                         | ["b"]
+    false              | [CHAOS_MONKEY_PRINCIPAL]                         | [CHAOS_MONKEY_PRINCIPAL]                         | []                            | []
+    false              | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | []                            | []
+  }
+
+  @Unroll
+  void "should add chaos monkey permissions during application permissions update"() {
+    given:
+    Application application = new Application(name: "hello")
+    application.details = [
+      "chaosMonkey": [
+        "enabled": chaosMonkeyEnabled
+      ]
+    ]
+
+    Application.Permission permission = new Application.Permission(
+      name: "hello",
+      lastModifiedBy: "bird person",
+      lastModified: -1L,
+      permissions: new Permissions.Builder()
+        .add(Authorization.READ, readPermissions)
+        .add(Authorization.WRITE, writePermissions)
+        .build()
+    )
+
+    Application.Permission updatedPermissions = new Application.Permission(
+      name: "hello",
+      lastModifiedBy: "bird person",
+      lastModified: -1L,
+      permissions: new Permissions.Builder()
+        .add(Authorization.READ, readPermissionsExpected)
+        .add(Authorization.WRITE, writePermissionsExpected)
+        .build()
+    )
+
+    when:
+    subject.call(permission, permission)
+
+    then:
+    1 * applicationDao.findByName(_) >> new Application(details:["chaosMonkey":[enabled:chaosMonkeyEnabled]])
+    permission.getPermissions() == updatedPermissions.getPermissions()
+
+    where:
+    chaosMonkeyEnabled | readPermissions                                  | writePermissions                                 | readPermissionsExpected       | writePermissionsExpected
+    true               | ["a"]                                            | ["b"]                                            | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]                         | ["a"]                                            | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a"]                                            | [CHAOS_MONKEY_PRINCIPAL]                         | ["a", CHAOS_MONKEY_PRINCIPAL] | []
+    true               | [CHAOS_MONKEY_PRINCIPAL]                         | [CHAOS_MONKEY_PRINCIPAL]                         | []                            | []
+    true               | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    false              | ["a"]                                            | ["b"]                                            | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL]                    | ["b", CHAOS_MONKEY_PRINCIPAL]                    | ["a"]                         | ["b"]
+    false              | [CHAOS_MONKEY_PRINCIPAL]                         | [CHAOS_MONKEY_PRINCIPAL]                         | []                            | []
+    false              | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL, CHAOS_MONKEY_PRINCIPAL] | []                            | []
   }
 }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
@@ -57,7 +57,7 @@ public class PermissionsController {
   Application.Permission updateApplicationPermission(
       @PathVariable String appName,
       @RequestBody Application.Permission newPermission) {
-    return permissionsService.updateApplicationPermission(appName, newPermission)
+    return permissionsService.updateApplicationPermission(appName, newPermission, false)
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/applications/{appName:.+}")


### PR DESCRIPTION
Once we remove chaos monkey permissions sent via Deck, this will allow us to persist chaos monkey permissions when Deck submits a permissions map (either empty or with permissions).