### PR TITLE
fix(permissions): Add abstract class ChaosMonkeyEventListener and chaos monkey ApplicationPermissionEventListener implementation

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
@@ -109,22 +109,27 @@ public class ApplicationPermissionsService {
   }
 
   public Permission updateApplicationPermission(
-      @Nonnull String appName, @Nonnull Permission newPermission) {
+      @Nonnull String appName, @Nonnull Permission newPermission, boolean skipListeners) {
+    if (skipListeners) {
+      return update(appName, newPermission);
+    }
     return performWrite(
         supportingEventListeners(Type.PRE_UPDATE),
         supportingEventListeners(Type.POST_UPDATE),
-        (unused, newPerm) -> {
-          try {
-            Permission oldPerm = applicationPermissionDAO().findById(appName);
-            applicationPermissionDAO().update(appName, newPerm);
-            syncUsers(newPermission, oldPerm);
-          } catch (NotFoundException e) {
-            createApplicationPermission(newPermission);
-          }
-          return newPerm;
-        },
+        (unused, newPerm) -> update(appName, newPerm),
         null,
         newPermission);
+  }
+
+  private Permission update(@Nonnull String appName, @Nonnull Permission newPermission) {
+    try {
+      Permission oldPerm = applicationPermissionDAO().findById(appName);
+      applicationPermissionDAO().update(appName, newPermission);
+      syncUsers(newPermission, oldPerm);
+    } catch (NotFoundException e) {
+      createApplicationPermission(newPermission);
+    }
+    return newPermission;
   }
 
   public void deleteApplicationPermission(@Nonnull String appName) {

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListener.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.ApplicationPermissionsService;
+import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties;
+import com.netflix.spinnaker.front50.events.ApplicationEventListener;
+import com.netflix.spinnaker.front50.model.application.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensures that when Chaos Monkey is enabled (or disabled) on an Application, its permissions are
+ * applied correctly.
+ *
+ * <p>This listens on both Application update events.
+ */
+@Component
+public class ChaosMonkeyApplicationEventListener extends ChaosMonkeyEventListener
+    implements ApplicationEventListener {
+  private static final Logger log =
+      LoggerFactory.getLogger(ChaosMonkeyApplicationEventListener.class);
+
+  private final ApplicationPermissionsService applicationPermissionsService;
+
+  public ChaosMonkeyApplicationEventListener(
+      ApplicationPermissionsService applicationPermissionsService,
+      ChaosMonkeyEventListenerConfigurationProperties properties,
+      ObjectMapper objectMapper) {
+    super(properties, objectMapper);
+    this.applicationPermissionsService = applicationPermissionsService;
+  }
+
+  @Override
+  public boolean supports(ApplicationEventListener.Type type) {
+    return properties.isEnabled() && ApplicationEventListener.Type.PRE_UPDATE == type;
+  }
+
+  @Override
+  public Application call(Application originalApplication, Application updatedApplication) {
+    Application.Permission permission =
+        applicationPermissionsService.getApplicationPermission(updatedApplication.getName());
+
+    if (!permission.getPermissions().isRestricted()) {
+      return updatedApplication;
+    }
+
+    if (isChaosMonkeyEnabled(updatedApplication)) {
+      applyNewPermissions(permission, true);
+    } else {
+      applyNewPermissions(permission, false);
+    }
+
+    Application.Permission updatedPermission =
+        applicationPermissionsService.updateApplicationPermission(
+            updatedApplication.getName(), permission, true);
+
+    log.debug(
+        "Updated application `{}` with permissions `{}`",
+        updatedApplication.getName(),
+        updatedPermission.getPermissions().toString());
+
+    return updatedApplication;
+  }
+
+  @Override
+  public void rollback(Application originalApplication) {
+    // Do nothing.
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListener.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties;
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensures that when Chaos Monkey is enabled (or disabled) on an Application, its permissions are
+ * applied correctly.
+ *
+ * <p>This listens on Application Permission update events.
+ */
+@Component
+public class ChaosMonkeyApplicationPermissionEventListener extends ChaosMonkeyEventListener
+    implements ApplicationPermissionEventListener {
+  private static final Logger log =
+      LoggerFactory.getLogger(ChaosMonkeyApplicationEventListener.class);
+
+  private final ApplicationDAO applicationDAO;
+
+  public ChaosMonkeyApplicationPermissionEventListener(
+      ApplicationDAO applicationDAO,
+      ChaosMonkeyEventListenerConfigurationProperties properties,
+      ObjectMapper objectMapper) {
+    super(properties, objectMapper);
+    this.applicationDAO = applicationDAO;
+  }
+
+  @Override
+  public boolean supports(ApplicationPermissionEventListener.Type type) {
+    return properties.isEnabled()
+        && Arrays.asList(
+                ApplicationPermissionEventListener.Type.PRE_CREATE,
+                ApplicationPermissionEventListener.Type.PRE_UPDATE)
+            .contains(type);
+  }
+
+  @Nullable
+  @Override
+  public Application.Permission call(
+      @Nullable Application.Permission originalPermission,
+      @Nullable Application.Permission updatedPermission) {
+    if (updatedPermission == null || !updatedPermission.getPermissions().isRestricted()) {
+      return null;
+    }
+
+    Application application = applicationDAO.findByName(updatedPermission.getName());
+
+    if (isChaosMonkeyEnabled(application)) {
+      applyNewPermissions(updatedPermission, true);
+    } else {
+      applyNewPermissions(updatedPermission, false);
+    }
+
+    return updatedPermission;
+  }
+
+  @Override
+  public void rollback(@Nonnull Application.Permission originalPermission) {
+    // Do nothing.
+  }
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListenerSpec.groovy
@@ -26,14 +26,14 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-class ChaosMonkeyEventListenerSpec extends Specification {
+class ChaosMonkeyApplicationEventListenerSpec extends Specification {
 
   private final static String CHAOS_MONKEY_PRINCIPAL = "chaosmonkey@example.com"
 
   def applicationPermissionsService = Mock(ApplicationPermissionsService)
 
   @Subject
-  def subject = new ChaosMonkeyEventListener(
+  def subject = new ChaosMonkeyApplicationEventListener(
     applicationPermissionsService,
     new ChaosMonkeyEventListenerConfigurationProperties(
       userRole: CHAOS_MONKEY_PRINCIPAL
@@ -87,7 +87,7 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     )
 
     applicationPermissionsService.getApplicationPermission(application.name) >> permission
-    applicationPermissionsService.updateApplicationPermission(application.name, _ as Application.Permission) >> updatedPermissions
+    applicationPermissionsService.updateApplicationPermission(application.name, _ as Application.Permission, true) >> updatedPermissions
 
     when:
     subject.call(application, application)
@@ -102,9 +102,11 @@ class ChaosMonkeyEventListenerSpec extends Specification {
     true               | ["a"]                                           | [CHAOS_MONKEY_PRINCIPAL]                        | ["a", CHAOS_MONKEY_PRINCIPAL] | []
     true               | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
     true               | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    true               | [CHAOS_MONKEY_PRINCIPAL]                        | []                                              | []                            | []
     false              | ["a"]                                           | ["b"]                                           | ["a"]                         | ["b"]
     false              | ["a", CHAOS_MONKEY_PRINCIPAL]                   | ["b", CHAOS_MONKEY_PRINCIPAL]                   | ["a"]                         | ["b"]
     false              | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
     false              | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    false              | [CHAOS_MONKEY_PRINCIPAL]                        | []                                              | []                            | []
   }
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListenerSpec.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.listeners
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.front50.config.ChaosMonkeyEventListenerConfigurationProperties
+import com.netflix.spinnaker.front50.events.ApplicationPermissionEventListener
+import com.netflix.spinnaker.front50.model.application.Application
+import com.netflix.spinnaker.front50.model.application.ApplicationDAO
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ChaosMonkeyApplicationPermissionEventListenerSpec extends Specification {
+  private final static String CHAOS_MONKEY_PRINCIPAL = "chaosmonkey@example.com"
+
+  def applicationDao = Mock(ApplicationDAO)
+
+  @Subject
+  def subject = new ChaosMonkeyApplicationPermissionEventListener(
+    applicationDao,
+    new ChaosMonkeyEventListenerConfigurationProperties(
+      userRole: CHAOS_MONKEY_PRINCIPAL
+    ),
+    new ObjectMapper()
+  )
+
+  @Unroll
+  void "supports application permission events"() {
+    expect:
+    subject.supports(type) == expectedSupport
+
+    where:
+    type                                                || expectedSupport
+    ApplicationPermissionEventListener.Type.PRE_CREATE  || true
+    ApplicationPermissionEventListener.Type.PRE_UPDATE  || true
+    ApplicationPermissionEventListener.Type.PRE_DELETE  || false
+    ApplicationPermissionEventListener.Type.POST_CREATE || false
+    ApplicationPermissionEventListener.Type.POST_UPDATE || false
+    ApplicationPermissionEventListener.Type.POST_DELETE || false
+  }
+
+  @Unroll
+  void "should add chaos monkey permissions during application permission update"() {
+    given:
+    Application application = new Application(name: "hello")
+    application.details = [
+      "chaosMonkey": [
+        "enabled": chaosMonkeyEnabled
+      ]
+    ]
+
+    Application.Permission permission = new Application.Permission(
+      name: "hello",
+      lastModifiedBy: "bird person",
+      lastModified: -1L,
+      permissions: new Permissions.Builder()
+        .add(Authorization.READ, readPermissions)
+        .add(Authorization.WRITE, writePermissions)
+        .build()
+    )
+
+    Application.Permission updatedPermissions = new Application.Permission(
+      name: "hello",
+      lastModifiedBy: "bird person",
+      lastModified: -1L,
+      permissions: new Permissions.Builder()
+        .add(Authorization.READ, readPermissionsExpected)
+        .add(Authorization.WRITE, writePermissionsExpected)
+        .build()
+    )
+
+    when:
+    1 * applicationDao.findByName(_) >> new Application(details:["chaosMonkey":[enabled:chaosMonkeyEnabled]])
+    subject.call(permission, permission)
+
+    then:
+    permission.getPermissions() == updatedPermissions.getPermissions()
+
+    where:
+    chaosMonkeyEnabled | readPermissions                                 | writePermissions                                | readPermissionsExpected       | writePermissionsExpected
+    true               | ["a"]                                           | ["b"]                                           | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
+    true               | [CHAOS_MONKEY_PRINCIPAL]                        | ["a"]                                           | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a"]                                           | [CHAOS_MONKEY_PRINCIPAL]                        | ["a", CHAOS_MONKEY_PRINCIPAL] | []
+    true               | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
+    true               | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    true               | [CHAOS_MONKEY_PRINCIPAL]                        | []                                              | []                            | []
+    false              | ["a"]                                           | ["b"]                                           | ["a"]                         | ["b"]
+    false              | ["a", CHAOS_MONKEY_PRINCIPAL]                   | ["b", CHAOS_MONKEY_PRINCIPAL]                   | ["a"]                         | ["b"]
+    false              | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
+    false              | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []
+    false              | [CHAOS_MONKEY_PRINCIPAL]                        | []                                              | []                            | []
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PermissionsController.groovy
@@ -57,7 +57,7 @@ public class PermissionsController {
   Application.Permission updateApplicationPermission(
       @PathVariable String appName,
       @RequestBody Application.Permission newPermission) {
-    return permissionsService.updateApplicationPermission(appName, newPermission)
+    return permissionsService.updateApplicationPermission(appName, newPermission, false)
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/applications/{appName:.+}")


### PR DESCRIPTION
https://github.com/spinnaker/front50/pull/673 intoruduced a circular dependency between `ChaosMonkeyEventListener` and `ApplicationPermissionsService` which this resolves.  
Otherwise, it's the same basic change which resolves this issue:

Once we remove chaos monkey permissions sent via Deck, this will allow us to persist chaos monkey permissions when Deck submits a permissions map (either empty or with permissions).