### PR TITLE
fix(permissions): Only remove chaos monkey if it is the only permission, plus small code cleanup

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListener.java
@@ -60,11 +60,7 @@ public class ChaosMonkeyApplicationEventListener extends ChaosMonkeyEventListene
       return updatedApplication;
     }
 
-    if (isChaosMonkeyEnabled(updatedApplication)) {
-      applyNewPermissions(permission, true);
-    } else {
-      applyNewPermissions(permission, false);
-    }
+    applyNewPermissions(permission, isChaosMonkeyEnabled(updatedApplication));
 
     Application.Permission updatedPermission =
         applicationPermissionsService.updateApplicationPermission(

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListener.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListener.java
@@ -69,11 +69,7 @@ public class ChaosMonkeyApplicationPermissionEventListener extends ChaosMonkeyEv
 
     Application application = applicationDAO.findByName(updatedPermission.getName());
 
-    if (isChaosMonkeyEnabled(application)) {
-      applyNewPermissions(updatedPermission, true);
-    } else {
-      applyNewPermissions(updatedPermission, false);
-    }
+    applyNewPermissions(updatedPermission, isChaosMonkeyEnabled(application));
 
     return updatedPermission;
   }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationEventListenerSpec.groovy
@@ -99,6 +99,7 @@ class ChaosMonkeyApplicationEventListenerSpec extends Specification {
     chaosMonkeyEnabled | readPermissions                                 | writePermissions                                | readPermissionsExpected       | writePermissionsExpected
     true               | ["a"]                                           | ["b"]                                           | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
     true               | [CHAOS_MONKEY_PRINCIPAL]                        | ["a"]                                           | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a", CHAOS_MONKEY_PRINCIPAL]                   | ["b", CHAOS_MONKEY_PRINCIPAL]                   | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
     true               | ["a"]                                           | [CHAOS_MONKEY_PRINCIPAL]                        | ["a", CHAOS_MONKEY_PRINCIPAL] | []
     true               | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
     true               | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListenerSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/listeners/ChaosMonkeyApplicationPermissionEventListenerSpec.groovy
@@ -97,6 +97,7 @@ class ChaosMonkeyApplicationPermissionEventListenerSpec extends Specification {
     chaosMonkeyEnabled | readPermissions                                 | writePermissions                                | readPermissionsExpected       | writePermissionsExpected
     true               | ["a"]                                           | ["b"]                                           | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
     true               | [CHAOS_MONKEY_PRINCIPAL]                        | ["a"]                                           | []                            | ["a", CHAOS_MONKEY_PRINCIPAL]
+    true               | ["a", CHAOS_MONKEY_PRINCIPAL]                   | ["b", CHAOS_MONKEY_PRINCIPAL]                   | ["a", CHAOS_MONKEY_PRINCIPAL] | ["b", CHAOS_MONKEY_PRINCIPAL]
     true               | ["a"]                                           | [CHAOS_MONKEY_PRINCIPAL]                        | ["a", CHAOS_MONKEY_PRINCIPAL] | []
     true               | [CHAOS_MONKEY_PRINCIPAL]                        | [CHAOS_MONKEY_PRINCIPAL]                        | []                            | []
     true               | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | [CHAOS_MONKEY_PRINCIPAL,CHAOS_MONKEY_PRINCIPAL] | []                            | []


### PR DESCRIPTION
In my glee to make sure we never ended up in a situation that locked people out, I got a bit carried away with removing permissions.  I really hope this is the final solution here.  Also includes a small code cleanup.