### PR TITLE
feat(plugins): Add get by ID endpoint to PluginArtifactController

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pluginartifact/PluginArtifactService.java
@@ -46,6 +46,10 @@ public class PluginArtifactService {
     return repository.getByService(service);
   }
 
+  public PluginArtifact findById(@Nonnull String pluginId) {
+    return repository.findById(pluginId);
+  }
+
   public PluginArtifact upsert(@Nonnull PluginArtifact pluginArtifact) {
     validate(pluginArtifact);
 

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginArtifactController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginArtifactController.java
@@ -47,6 +47,11 @@ public class PluginArtifactController {
         .orElseGet(pluginArtifactService::findAll);
   }
 
+  @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+  PluginArtifact get(@PathVariable String id) {
+    return pluginArtifactService.findById(id);
+  }
+
   @RequestMapping(value = "", method = RequestMethod.POST)
   PluginArtifact upsert(@RequestBody PluginArtifact pluginArtifact) {
     return pluginArtifactService.upsert(pluginArtifact);


### PR DESCRIPTION
This will support the writing of the `Front50UpdateRepository` in `kork`, which is caputred in https://github.com/spinnaker/spinnaker/issues/5241

Specifically, this will satisfy pf4j's `UpdateRepository`:

https://github.com/pf4j/pf4j-update/blob/master/src/main/java/org/pf4j/update/UpdateRepository.java#L49