### PR TITLE
refactor(plugins): Rename from PluginArtifact to PluginInfo

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -34,8 +34,8 @@ import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineTemplateDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO;
-import com.netflix.spinnaker.front50.model.pluginartifact.DefaultPluginArtifactRepository;
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifactRepository;
+import com.netflix.spinnaker.front50.model.plugininfo.DefaultPluginInfoRepository;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfoRepository;
 import com.netflix.spinnaker.front50.model.project.DefaultProjectDAO;
 import com.netflix.spinnaker.front50.model.project.ProjectDAO;
 import com.netflix.spinnaker.front50.model.serviceaccount.DefaultServiceAccountDAO;
@@ -244,19 +244,19 @@ public class CommonStorageServiceDAOConfig {
   }
 
   @Bean
-  PluginArtifactRepository pluginArtifactRepository(
+  PluginInfoRepository pluginInfoRepository(
       StorageService storageService,
       StorageServiceConfigurationProperties storageServiceConfigurationProperties,
       ObjectKeyLoader objectKeyLoader,
       Registry registry) {
-    return new DefaultPluginArtifactRepository(
+    return new DefaultPluginInfoRepository(
         storageService,
         Schedulers.from(
             Executors.newFixedThreadPool(
-                storageServiceConfigurationProperties.getPluginArtifact().getThreadPool())),
+                storageServiceConfigurationProperties.getPluginInfo().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getPluginArtifact().getRefreshMs(),
-        storageServiceConfigurationProperties.getPluginArtifact().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getPluginInfo().getRefreshMs(),
+        storageServiceConfigurationProperties.getPluginInfo().getShouldWarmCache(),
         registry);
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.groovy
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.groovy
@@ -32,7 +32,7 @@ class StorageServiceConfigurationProperties {
   PerObjectType pipelineTemplate = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
   PerObjectType snapshot = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1))
   PerObjectType deliveryConfig = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1))
-  PerObjectType pluginArtifact = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1))
+  PerObjectType pluginInfo = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1))
 
   // not commonly used outside of Netflix
   PerObjectType entityTags = new PerObjectType(2, TimeUnit.MINUTES.toMillis(5), false)

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.front50.model.delivery.Delivery;
 import com.netflix.spinnaker.front50.model.notification.Notification;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
 import com.netflix.spinnaker.front50.model.project.Project;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
 import com.netflix.spinnaker.front50.model.snapshot.Snapshot;
@@ -43,7 +43,7 @@ public enum ObjectType {
   SNAPSHOT(Snapshot.class, "snapshots", "snapshot.json"),
   ENTITY_TAGS(EntityTags.class, "tags", "entity-tags-metadata.json"),
   DELIVERY(Delivery.class, "delivery", "delivery-metadata.json"),
-  PLUGIN_ARTIFACT(PluginArtifact.class, "pluginArtifacts", "plugin-artifact-metadata.json");
+  PLUGIN_INFO(PluginInfo.class, "pluginInfo", "plugin-info-metadata.json");
 
   public final Class<? extends Timestamped> clazz;
   public final String group;

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/DefaultPluginInfoRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/DefaultPluginInfoRepository.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.pluginartifact;
+package com.netflix.spinnaker.front50.model.plugininfo;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
@@ -27,9 +27,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import rx.Scheduler;
 
-public class DefaultPluginArtifactRepository extends StorageServiceSupport<PluginArtifact>
-    implements PluginArtifactRepository {
-  public DefaultPluginArtifactRepository(
+public class DefaultPluginInfoRepository extends StorageServiceSupport<PluginInfo>
+    implements PluginInfoRepository {
+  public DefaultPluginInfoRepository(
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
@@ -37,7 +37,7 @@ public class DefaultPluginArtifactRepository extends StorageServiceSupport<Plugi
       boolean shouldWarmCache,
       Registry registry) {
     super(
-        ObjectType.PLUGIN_ARTIFACT,
+        ObjectType.PLUGIN_INFO,
         service,
         scheduler,
         objectKeyLoader,
@@ -48,19 +48,18 @@ public class DefaultPluginArtifactRepository extends StorageServiceSupport<Plugi
 
   @Nonnull
   @Override
-  public Collection<PluginArtifact> getByService(@Nonnull String service) {
+  public Collection<PluginInfo> getByService(@Nonnull String service) {
     return all().stream()
-        .filter(
-            artifact -> artifact.getReleases().stream().anyMatch(r -> r.supportsService(service)))
+        .filter(info -> info.getReleases().stream().anyMatch(r -> r.supportsService(service)))
         .collect(Collectors.toList());
   }
 
   @Override
-  public PluginArtifact create(String id, PluginArtifact item) {
+  public PluginInfo create(String id, PluginInfo item) {
     Objects.requireNonNull(item.getId());
     if (!item.getId().equals(id)) {
       // Won't happen unless Orca passes a mismatched request path / request body.
-      throw new IntegrationException("The provided id and plugin artifact id do not match");
+      throw new IntegrationException("The provided id and plugin info id do not match");
     }
 
     if (item.getCreateTs() == null) {

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfo.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.pluginartifact;
+package com.netflix.spinnaker.front50.model.plugininfo;
 
 import com.netflix.spinnaker.front50.model.Timestamped;
 import java.time.Instant;
@@ -25,13 +25,13 @@ import javax.annotation.Nonnull;
 import lombok.Data;
 
 /**
- * A Spinnaker plugin's release artifact metadata.
+ * A Spinnaker plugin's artifact information.
  *
  * <p>This model is used internally by Spinnaker to track what plugins are available for services to
  * install, as well as the specific releases that should be installed.
  */
 @Data
-public class PluginArtifact implements Timestamped {
+public class PluginInfo implements Timestamped {
   /**
    * The canonical plugin ID.
    *
@@ -45,21 +45,21 @@ public class PluginArtifact implements Timestamped {
   /** The plugin provider, typically the name of the author (or company). */
   private String provider;
 
-  /** A list of plugin artifact releases. */
+  /** A list of plugin releases. */
   @Nonnull private List<Release> releases = new ArrayList<>();
 
-  /** The time (epoch millis) when the plugin artifact was first created. */
+  /** The time (epoch millis) when the plugin info was first created. */
   private Long createTs;
 
-  /** The last time (epoch millis) this PluginArtifact was modified. */
+  /** The last time (epoch millis) this PluginInfo was modified. */
   private Long lastModified;
 
-  /** The last principal to modify this PluginArtifact. */
+  /** The last principal to modify this PluginInfo. */
   private String lastModifiedBy;
 
-  public PluginArtifact() {}
+  public PluginInfo() {}
 
-  /** A singular {@code PluginArtifact} release. */
+  /** A singular {@code PluginInfo} release. */
   @Data
   public static class Release {
     public static final Pattern SUPPORTS_PATTERN =
@@ -70,13 +70,13 @@ public class PluginArtifact implements Timestamped {
     public static final String SUPPORTS_PATTERN_VERSION_GROUP = "version";
 
     /**
-     * The version of a plugin artifact release in SemVer format.
+     * The version of a plugin release in SemVer format.
      *
      * @link https://semver.org/
      */
     private String version;
 
-    /** The date of the plugin artifact release. */
+    /** The date of the plugin release. */
     private String date;
 
     /**

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoRepository.java
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.pluginartifact;
+package com.netflix.spinnaker.front50.model.plugininfo;
 
 import com.netflix.spinnaker.front50.model.ItemDAO;
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact.Release;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo.Release;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 
-public interface PluginArtifactRepository extends ItemDAO<PluginArtifact> {
+public interface PluginInfoRepository extends ItemDAO<PluginInfo> {
   /**
    * Returns a collection of plugins that should be installed by a particular service.
    *
    * <p>This is determined by inference, using a {@link Release}'s {@code requires} field.
    */
   @Nonnull
-  Collection<PluginArtifact> getByService(@Nonnull String service);
+  Collection<PluginInfo> getByService(@Nonnull String service);
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoService.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.pluginartifact;
+package com.netflix.spinnaker.front50.model.plugininfo;
 
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.validator.GenericValidationErrors;
-import com.netflix.spinnaker.front50.validator.PluginArtifactValidator;
+import com.netflix.spinnaker.front50.validator.PluginInfoValidator;
 import com.netflix.spinnaker.kork.exceptions.UserException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,38 +27,37 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 @Component
-public class PluginArtifactService {
+public class PluginInfoService {
 
-  private final PluginArtifactRepository repository;
-  private final List<PluginArtifactValidator> validators;
+  private final PluginInfoRepository repository;
+  private final List<PluginInfoValidator> validators;
 
-  public PluginArtifactService(
-      PluginArtifactRepository repository, List<PluginArtifactValidator> validators) {
+  public PluginInfoService(PluginInfoRepository repository, List<PluginInfoValidator> validators) {
     this.repository = repository;
     this.validators = validators;
   }
 
-  public Collection<PluginArtifact> findAll() {
+  public Collection<PluginInfo> findAll() {
     return repository.all();
   }
 
-  public Collection<PluginArtifact> findAllByService(@Nonnull String service) {
+  public Collection<PluginInfo> findAllByService(@Nonnull String service) {
     return repository.getByService(service);
   }
 
-  public PluginArtifact findById(@Nonnull String pluginId) {
+  public PluginInfo findById(@Nonnull String pluginId) {
     return repository.findById(pluginId);
   }
 
-  public PluginArtifact upsert(@Nonnull PluginArtifact pluginArtifact) {
-    validate(pluginArtifact);
+  public PluginInfo upsert(@Nonnull PluginInfo pluginInfo) {
+    validate(pluginInfo);
 
     try {
-      repository.findById(pluginArtifact.getId());
-      repository.update(pluginArtifact.getId(), pluginArtifact);
-      return pluginArtifact;
+      repository.findById(pluginInfo.getId());
+      repository.update(pluginInfo.getId(), pluginInfo);
+      return pluginInfo;
     } catch (NotFoundException e) {
-      return repository.create(pluginArtifact.getId(), pluginArtifact);
+      return repository.create(pluginInfo.getId(), pluginInfo);
     }
   }
 
@@ -66,31 +65,31 @@ public class PluginArtifactService {
     repository.delete(id);
   }
 
-  public PluginArtifact createRelease(@Nonnull String id, @Nonnull PluginArtifact.Release release) {
-    PluginArtifact artifact = repository.findById(id);
+  public PluginInfo createRelease(@Nonnull String id, @Nonnull PluginInfo.Release release) {
+    PluginInfo pluginInfo = repository.findById(id);
 
-    artifact.getReleases().add(release);
+    pluginInfo.getReleases().add(release);
 
-    return upsert(artifact);
+    return upsert(pluginInfo);
   }
 
-  public PluginArtifact deleteRelease(@Nonnull String id, @Nonnull String releaseVersion) {
-    PluginArtifact artifact = repository.findById(id);
+  public PluginInfo deleteRelease(@Nonnull String id, @Nonnull String releaseVersion) {
+    PluginInfo pluginInfo = repository.findById(id);
 
-    new ArrayList<>(artifact.getReleases())
+    new ArrayList<>(pluginInfo.getReleases())
         .forEach(
             release -> {
               if (release.getVersion().equals(releaseVersion)) {
-                artifact.getReleases().remove(release);
+                pluginInfo.getReleases().remove(release);
               }
             });
 
-    return upsert(artifact);
+    return upsert(pluginInfo);
   }
 
-  private void validate(PluginArtifact pluginArtifact) {
-    Errors errors = new GenericValidationErrors(pluginArtifact);
-    validators.forEach(v -> v.validate(pluginArtifact, errors));
+  private void validate(PluginInfo pluginInfo) {
+    Errors errors = new GenericValidationErrors(pluginInfo);
+    validators.forEach(v -> v.validate(pluginInfo, errors));
     if (errors.hasErrors()) {
       throw new ValidationException(errors);
     }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidator.java
@@ -15,23 +15,23 @@
  */
 package com.netflix.spinnaker.front50.validator;
 
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 @Component
-public class HasCanonicalPluginIdValidator implements PluginArtifactValidator {
+public class HasCanonicalPluginIdValidator implements PluginInfoValidator {
 
   private final Pattern pattern = Pattern.compile("[\\w]+\\.[\\w]+");
 
   @Override
-  public void validate(PluginArtifact pluginArtifact, Errors validationErrors) {
-    if (!pattern.matcher(pluginArtifact.getId()).matches()) {
+  public void validate(PluginInfo pluginInfo, Errors validationErrors) {
+    if (!pattern.matcher(pluginInfo.getId()).matches()) {
       validationErrors.rejectValue(
           "id",
-          "pluginArtifact.id.invalid",
-          "Plugin Artifact must have a '{namespace}.{id}' canonical format");
+          "pluginInfo.id.invalid",
+          "Plugin Info must have a '{namespace}.{id}' canonical format");
     }
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidator.java
@@ -15,10 +15,10 @@
  */
 package com.netflix.spinnaker.front50.validator;
 
-import static com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact.Release.SUPPORTS_PATTERN;
+import static com.netflix.spinnaker.front50.model.plugininfo.PluginInfo.Release.SUPPORTS_PATTERN;
 import static java.lang.String.format;
 
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -26,14 +26,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 @Component
-public class HasValidRequiresFieldsValidator implements PluginArtifactValidator {
+public class HasValidRequiresFieldsValidator implements PluginInfoValidator {
 
   private static final List<String> VALID_OPERATORS = Arrays.asList("<", ">", ">=", "<=");
 
   @Override
-  public void validate(PluginArtifact pluginArtifact, Errors validationErrors) {
+  public void validate(PluginInfo pluginInfo, Errors validationErrors) {
 
-    pluginArtifact
+    pluginInfo
         .getReleases()
         .forEach(
             release -> {
@@ -44,7 +44,7 @@ public class HasValidRequiresFieldsValidator implements PluginArtifactValidator 
                         Matcher m = SUPPORTS_PATTERN.matcher(requires);
                         if (!m.matches()) {
                           validationErrors.reject(
-                              "pluginArtifact.releases.invalidRequiresFormat",
+                              "pluginInfo.releases.invalidRequiresFormat",
                               format(
                                   "Invalid Release requires field formatting (requires '%s')",
                                   SUPPORTS_PATTERN.pattern()));
@@ -52,9 +52,9 @@ public class HasValidRequiresFieldsValidator implements PluginArtifactValidator 
                         }
 
                         if (!VALID_OPERATORS.contains(
-                            m.group(PluginArtifact.Release.SUPPORTS_PATTERN_OPERATOR_GROUP))) {
+                            m.group(PluginInfo.Release.SUPPORTS_PATTERN_OPERATOR_GROUP))) {
                           validationErrors.reject(
-                              "pluginArtifact.releases.invalidRequiresOperator",
+                              "pluginInfo.releases.invalidRequiresOperator",
                               format(
                                   "Invalid Release requires comparison operator (requires one of: %s)",
                                   VALID_OPERATORS));

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/PluginInfoValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/PluginInfoValidator.java
@@ -15,10 +15,10 @@
  */
 package com.netflix.spinnaker.front50.validator;
 
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
 import org.springframework.validation.Errors;
 
-/** A {@link PluginArtifact} validator. */
-public interface PluginArtifactValidator {
-  void validate(PluginArtifact pluginArtifact, Errors validationErrors);
+/** A {@link PluginInfo} validator. */
+public interface PluginInfoValidator {
+  void validate(PluginInfo pluginInfo, Errors validationErrors);
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoServiceSpec.groovy
@@ -13,58 +13,58 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.pluginartifact
+package com.netflix.spinnaker.front50.model.plugininfo
 
 import com.netflix.spinnaker.front50.exception.NotFoundException
-import com.netflix.spinnaker.front50.validator.PluginArtifactValidator
+import com.netflix.spinnaker.front50.validator.PluginInfoValidator
 import spock.lang.Specification
 import spock.lang.Subject
 
-class PluginArtifactServiceSpec extends Specification {
+class PluginInfoServiceSpec extends Specification {
 
-  PluginArtifactRepository repository = Mock()
-  PluginArtifactValidator validator = Mock()
+  PluginInfoRepository repository = Mock()
+  PluginInfoValidator validator = Mock()
 
   @Subject
-  PluginArtifactService subject = new PluginArtifactService(repository, [validator])
+  PluginInfoService subject = new PluginInfoService(repository, [validator])
 
   def "upsert conditionally creates or updates"() {
     given:
-    PluginArtifact pluginArtifact = new PluginArtifact(id: "foo.bar")
+    PluginInfo pluginInfo = new PluginInfo(id: "foo.bar")
 
     when:
-    subject.upsert(pluginArtifact)
+    subject.upsert(pluginInfo)
 
     then:
-    1 * validator.validate(pluginArtifact, _)
+    1 * validator.validate(pluginInfo, _)
     1 * repository.findById("foo.bar") >> {
       throw new NotFoundException("k")
     }
-    1 * repository.create("foo.bar", pluginArtifact) >> pluginArtifact
+    1 * repository.create("foo.bar", pluginInfo) >> pluginInfo
     0 * repository.update(_, _)
 
     when:
-    subject.upsert(pluginArtifact)
+    subject.upsert(pluginInfo)
 
     then:
-    1 * validator.validate(pluginArtifact, _)
-    1 * repository.findById("foo.bar") >> pluginArtifact
-    1 * repository.update("foo.bar", pluginArtifact)
+    1 * validator.validate(pluginInfo, _)
+    1 * repository.findById("foo.bar") >> pluginInfo
+    1 * repository.update("foo.bar", pluginInfo)
     0 * repository.create(_, _)
   }
 
-  def "creating a new release appends to plugin artifact releases"() {
+  def "creating a new release appends to plugin info releases"() {
     given:
-    PluginArtifact pluginArtifact = new PluginArtifact(id: "foo.bar")
-    pluginArtifact.releases.add(new PluginArtifact.Release(version: "1.0.0"))
+    PluginInfo pluginInfo = new PluginInfo(id: "foo.bar")
+    pluginInfo.releases.add(new PluginInfo.Release(version: "1.0.0"))
 
-    PluginArtifact.Release newRelease = new PluginArtifact.Release(version: "2.0.0")
+    PluginInfo.Release newRelease = new PluginInfo.Release(version: "2.0.0")
 
     when:
     def result = subject.createRelease("foo.bar", newRelease)
 
     then:
-    2 * repository.findById("foo.bar") >> pluginArtifact
+    2 * repository.findById("foo.bar") >> pluginInfo
     result.releases*.version == ["1.0.0", "2.0.0"]
   }
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoSpec.groovy
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.pluginartifact
+package com.netflix.spinnaker.front50.model.plugininfo
 
 
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class PluginArtifactSpec extends Specification {
+class PluginInfoSpec extends Specification {
 
   @Unroll
-  def "artifact release supports service"() {
+  def "plugin info release supports service"() {
     given:
-    def release = new PluginArtifact.Release(
+    def release = new PluginInfo.Release(
       requires: [
         "clouddriver>=2.0.0",
         "orca>7.0.0",

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidatorSpec.groovy
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.front50.validator
 
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo
 import org.springframework.validation.Errors
 import spock.lang.Specification
 import spock.lang.Subject
@@ -29,11 +29,11 @@ class HasCanonicalPluginIdValidatorSpec extends Specification {
   @Unroll
   def "requires a canonical plugin id"() {
     setup:
-    PluginArtifact pluginArtifact = new PluginArtifact(id: id)
-    Errors errors = new GenericValidationErrors(pluginArtifact)
+    PluginInfo pluginInfo = new PluginInfo(id: id)
+    Errors errors = new GenericValidationErrors(pluginInfo)
 
     when:
-    subject.validate(pluginArtifact, errors)
+    subject.validate(pluginInfo, errors)
 
     then:
     errors.hasErrors() == hasErrors

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidatorSpec.groovy
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.front50.validator
 
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -28,13 +28,13 @@ class HasValidRequiresFieldsValidatorSpec extends Specification {
   @Unroll
   def "requires release with valid requires field formatting"() {
     setup:
-    def pluginArtifact = new PluginArtifact(
-      releases: [new PluginArtifact.Release(requires: requiresValue)]
+    def pluginInfo = new PluginInfo(
+      releases: [new PluginInfo.Release(requires: requiresValue)]
     )
-    def errors = new GenericValidationErrors(pluginArtifact)
+    def errors = new GenericValidationErrors(pluginInfo)
 
     when:
-    subject.validate(pluginArtifact, errors)
+    subject.validate(pluginInfo, errors)
 
     then:
     errors.hasErrors() == hasErrors

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.front50.model.ObjectType.ENTITY_TAGS
 import com.netflix.spinnaker.front50.model.ObjectType.NOTIFICATION
 import com.netflix.spinnaker.front50.model.ObjectType.PIPELINE
 import com.netflix.spinnaker.front50.model.ObjectType.PIPELINE_TEMPLATE
-import com.netflix.spinnaker.front50.model.ObjectType.PLUGIN_ARTIFACT
+import com.netflix.spinnaker.front50.model.ObjectType.PLUGIN_INFO
 import com.netflix.spinnaker.front50.model.ObjectType.PROJECT
 import com.netflix.spinnaker.front50.model.ObjectType.SERVICE_ACCOUNT
 import com.netflix.spinnaker.front50.model.ObjectType.SNAPSHOT
@@ -76,7 +76,7 @@ class SqlStorageService(
       SNAPSHOT to DefaultTableDefinition(SNAPSHOT, "snapshots", false),
       ENTITY_TAGS to DefaultTableDefinition(ENTITY_TAGS, "entity_tags", false),
       DELIVERY to DeliveryTableDefinition(),
-      PLUGIN_ARTIFACT to DefaultTableDefinition(PLUGIN_ARTIFACT, "plugin_artifacts", false)
+      PLUGIN_INFO to DefaultTableDefinition(PLUGIN_INFO, "plugin_info", false)
     )
   }
 

--- a/front50-sql/src/main/resources/db/changelog-master.yml
+++ b/front50-sql/src/main/resources/db/changelog-master.yml
@@ -44,3 +44,6 @@ databaseChangeLog:
   - include:
       file: changelog/20191213-initial-plugin-artifacts-schema.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200113-rename-plugin-artifacts-to-plugin-info.yml
+      relativeToChangelogFile: true

--- a/front50-sql/src/main/resources/db/changelog/20200113-rename-plugin-artifacts-to-plugin-info.yml
+++ b/front50-sql/src/main/resources/db/changelog/20200113-rename-plugin-artifacts-to-plugin-info.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: rename-plugin-artifacts-to-plugin-info
+      author: jonsie
+      changes:
+        - renameTable:
+            newTableName: plugin_info
+            oldTableName: plugin_artifacts
+      rollback:
+        - renameTable:
+            newTableName: plugin_artifacts
+            oldTableName: plugin_info

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginInfoController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginInfoController.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.spinnaker.front50.controllers;
 
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifact;
-import com.netflix.spinnaker.front50.model.pluginartifact.PluginArtifactService;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugininfo.PluginInfoService;
 import java.util.Collection;
 import java.util.Optional;
 import org.springframework.http.HttpStatus;
@@ -28,50 +28,48 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-/** TODO(rz): What's the permissions model for something like artifacts? */
+/** TODO(rz): What's the permissions model for something like plugin info? */
 @RestController
-@RequestMapping("/pluginArtifacts")
-public class PluginArtifactController {
+@RequestMapping("/pluginInfo")
+public class PluginInfoController {
 
-  private final PluginArtifactService pluginArtifactService;
+  private final PluginInfoService pluginInfoService;
 
-  public PluginArtifactController(PluginArtifactService pluginArtifactService) {
-    this.pluginArtifactService = pluginArtifactService;
+  public PluginInfoController(PluginInfoService pluginInfoService) {
+    this.pluginInfoService = pluginInfoService;
   }
 
   @RequestMapping(value = "", method = RequestMethod.GET)
-  Collection<PluginArtifact> list(
-      @RequestParam(value = "service", required = false) String service) {
+  Collection<PluginInfo> list(@RequestParam(value = "service", required = false) String service) {
     return Optional.ofNullable(service)
-        .map(pluginArtifactService::findAllByService)
-        .orElseGet(pluginArtifactService::findAll);
+        .map(pluginInfoService::findAllByService)
+        .orElseGet(pluginInfoService::findAll);
   }
 
   @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-  PluginArtifact get(@PathVariable String id) {
-    return pluginArtifactService.findById(id);
+  PluginInfo get(@PathVariable String id) {
+    return pluginInfoService.findById(id);
   }
 
   @RequestMapping(value = "", method = RequestMethod.POST)
-  PluginArtifact upsert(@RequestBody PluginArtifact pluginArtifact) {
-    return pluginArtifactService.upsert(pluginArtifact);
+  PluginInfo upsert(@RequestBody PluginInfo pluginInfo) {
+    return pluginInfoService.upsert(pluginInfo);
   }
 
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   void delete(@PathVariable String id) {
-    pluginArtifactService.delete(id);
+    pluginInfoService.delete(id);
   }
 
   @RequestMapping(value = "/{id}/releases", method = RequestMethod.POST)
-  PluginArtifact createRelease(
-      @PathVariable String id, @RequestBody PluginArtifact.Release release) {
-    return pluginArtifactService.createRelease(id, release);
+  PluginInfo createRelease(@PathVariable String id, @RequestBody PluginInfo.Release release) {
+    return pluginInfoService.createRelease(id, release);
   }
 
   @RequestMapping(value = "/{id}/releases/{releaseVersion}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  PluginArtifact deleteRelease(@PathVariable String id, @PathVariable String releaseVersion) {
-    return pluginArtifactService.deleteRelease(id, releaseVersion);
+  PluginInfo deleteRelease(@PathVariable String id, @PathVariable String releaseVersion) {
+    return pluginInfoService.deleteRelease(id, releaseVersion);
   }
 }


### PR DESCRIPTION
We decided this rename makes sense for the following reasons:

- It follows existing pf4j terminology (https://github.com/pf4j/pf4j-update/blob/master/src/main/java/org/pf4j/update/PluginInfo.java)
- It more accurately describes this resource - the resource being plugin artifact information vs. the actual plugin artifact (which will be stored elsewhere).