### PR TITLE
feat(s3): Add aws-java-sdk-sts to support roles provided by EKS pod identity webhook

### DIFF
--- a/front50-s3/front50-s3.gradle
+++ b/front50-s3/front50-s3.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.netflix.spinnaker.kork:kork-hystrix"
   implementation "com.amazonaws:aws-java-sdk-s3"
+  implementation "com.amazonaws:aws-java-sdk-sts"
 
   testImplementation project(":front50-test")
 }


### PR DESCRIPTION
We are running Spinnaker on EKS and would like to grant the front50 pods permissions to S3 through the EKS pod identity webhook. Currently this fails with

```
Unable to load AWS credentials from any provider in the chain: 
[...]
WebIdentityTokenCredentialsProvider: To use assume role profiles the aws-java-sdk-sts module must be on the class path., 
[...]
Internal Server Error
```

Therefore I would like to include the `aws-java-sdk-sts`.