### PR TITLE
fix(kork): use a context object instead of raw MDC access

### DIFF
--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -9,6 +9,7 @@ dependencies {
 
   implementation "com.netflix.spinnaker.kork:kork-sql"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
+  implementation "com.netflix.spinnaker.kork:kork-web"
 
   implementation "io.strikt:strikt-core"
   implementation "com.netflix.hystrix:hystrix-core"
@@ -28,7 +29,6 @@ dependencies {
 
   // Only used for Initializing Datasource. For actual CRUD, test containers preferred.
   testImplementation "com.h2database:h2"
-
 }
 
 test {

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfiguration.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfiguration.kt
@@ -22,9 +22,7 @@ import com.netflix.spinnaker.front50.model.CompositeStorageService
 import com.netflix.spinnaker.front50.model.StorageService
 import com.netflix.spinnaker.front50.model.tag.EntityTagsDAO
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
-import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
 import com.netflix.spinnaker.kork.web.context.RequestContextProvider
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -42,10 +40,6 @@ class CompositeStorageServiceConfiguration(
   private val dynamicConfigService: DynamicConfigService,
   private val registry: Registry
 ) {
-  @Bean
-  @ConditionalOnMissingBean
-  fun contextProvider(): RequestContextProvider = AuthenticatedRequestContextProvider()
-
   @Bean
   @Primary
   @ConditionalOnProperty("spinnaker.migration.compositeStorageService.enabled")

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
@@ -20,12 +20,16 @@ import com.netflix.spinnaker.front50.config.StorageServiceConfigurationPropertie
 import com.netflix.spinnaker.front50.migrations.StorageServiceMigrator
 import com.netflix.spinnaker.front50.model.CompositeStorageService
 import com.netflix.spinnaker.front50.model.SqlStorageService
+import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
+import com.netflix.spinnaker.kork.web.context.RequestContextProvider
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import strikt.api.expectThat
@@ -62,4 +66,8 @@ internal class CompositeStorageServiceConfigurationTests {
 @SpringBootApplication
 @Import(CompositeStorageServiceConfiguration::class, SqlConfiguration::class)
 @EnableConfigurationProperties(StorageServiceConfigurationProperties::class)
-internal class CompositeStorageServiceConfigurationTestApp
+internal class CompositeStorageServiceConfigurationTestApp {
+  @Bean
+  @ConditionalOnMissingBean
+  fun contextProvider(): RequestContextProvider = AuthenticatedRequestContextProvider()
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
 import com.netflix.spinnaker.front50.model.project.ProjectDAO
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
+import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
+import com.netflix.spinnaker.kork.web.context.RequestContextProvider
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -135,6 +137,11 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
   @Bean
   FiatAccessDeniedExceptionHandler fiatAccessDeniedExceptionHandler() {
     return new FiatAccessDeniedExceptionHandler()
+  }
+
+  @Bean
+  RequestContextProvider requestContextProvider() {
+    return new AuthenticatedRequestContextProvider()
   }
 
   @ControllerAdvice

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-#Tue Jan 28 20:41:53 UTC 2020
+#Wed Feb 05 21:46:35 UTC 2020
 clouddriverVersion=5.47.1
 fiatVersion=1.13.1
 enablePublishing=false
+korkVersion=7.16.4
 spinnakerGradleVersion=7.2.0
-korkVersion=7.15.1
-org.gradle.parallel=true
 includeProviders=azure,gcs,oracle,redis,s3,swift,sql
+org.gradle.parallel=true


### PR DESCRIPTION
Turns out to be more boilerplate than I like, but at the end of the day I just want a bean that lets me access the request context instead of directly grabbing values in and out of the MDC