### PR TITLE
feat(plugins): Plugin binary store service

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/PluginBinaryCacheConfiguration.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/PluginBinaryCacheConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import com.netflix.spinnaker.front50.plugins.CachingPluginBinaryStorageService;
+import com.netflix.spinnaker.front50.plugins.PluginBinaryStorageService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@ConditionalOnBean(PluginBinaryStorageService.class)
+@ConditionalOnProperty(value = "plugin-binary-cache.enabled", matchIfMissing = true)
+public class PluginBinaryCacheConfiguration {
+
+  @Primary
+  @Bean
+  PluginBinaryStorageService cachingPluginBinaryStorageService(
+      PluginBinaryStorageService pluginBinaryStorageService) {
+    return new CachingPluginBinaryStorageService(pluginBinaryStorageService);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfo.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfo.java
@@ -126,6 +126,7 @@ public class PluginInfo implements Timestamped {
      * determine which release to select.
      *
      * @param service The service name to check against.
+     * @return Whether or not the plugin supports the given service
      */
     public boolean supportsService(@Nonnull String service) {
       return Arrays.stream(requires.split(","))

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/PluginInfoRepository.java
@@ -25,6 +25,9 @@ public interface PluginInfoRepository extends ItemDAO<PluginInfo> {
    * Returns a collection of plugins that should be installed by a particular service.
    *
    * <p>This is determined by inference, using a {@link Release}'s {@code requires} field.
+   *
+   * @param service The service to retrieve plugin info for
+   * @return All available plugins for a service
    */
   @Nonnull
   Collection<PluginInfo> getByService(@Nonnull String service);

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/CachingPluginBinaryStorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/CachingPluginBinaryStorageService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.plugins;
+
+import com.netflix.spinnaker.kork.exceptions.SystemException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CachingPluginBinaryStorageService implements PluginBinaryStorageService {
+
+  private static final Path CACHE_PATH;
+
+  private static final Logger log =
+      LoggerFactory.getLogger(CachingPluginBinaryStorageService.class);
+
+  static {
+    try {
+      CACHE_PATH = Files.createTempDirectory("plugin-binaries");
+    } catch (IOException e) {
+      throw new SystemException("Failed to create plugin binaries cache directory", e);
+    }
+  }
+
+  private final PluginBinaryStorageService storageService;
+
+  public CachingPluginBinaryStorageService(PluginBinaryStorageService storageService) {
+    this.storageService = storageService;
+  }
+
+  @Override
+  public void store(@Nonnull String key, @Nonnull byte[] item) {
+    storageService.store(key, item);
+    storeCache(key, item);
+  }
+
+  @Override
+  public void delete(@Nonnull String key) {
+    storageService.delete(key);
+    deleteCache(key);
+  }
+
+  @Nonnull
+  @Override
+  public List<String> listKeys() {
+    return storageService.listKeys();
+  }
+
+  @Nullable
+  @Override
+  public byte[] load(@Nonnull String key) {
+    return loadFromCache(key);
+  }
+
+  private byte[] loadFromCache(String key) {
+    Path binaryPath = CACHE_PATH.resolve("key");
+    if (binaryPath.toFile().exists()) {
+      try {
+        return Files.readAllBytes(binaryPath);
+      } catch (IOException e) {
+        log.error("Failed to read cached binary, falling back to delegate store: {}", key, e);
+      }
+    }
+    return loadInternal(key);
+  }
+
+  private byte[] loadInternal(String key) {
+    byte[] binary = storageService.load(key);
+    if (binary == null) {
+      return null;
+    }
+
+    storeCache(key, binary);
+
+    return binary;
+  }
+
+  private synchronized void storeCache(String key, byte[] binary) {
+    Path binaryPath = CACHE_PATH.resolve(key);
+    if (!binaryPath.toFile().exists()) {
+      try {
+        Files.write(binaryPath, binary, StandardOpenOption.CREATE_NEW);
+      } catch (IOException e) {
+        log.error("Failed to write plugin binary to local filesystem cache: {}", key, e);
+      }
+    }
+  }
+
+  private synchronized void deleteCache(String key) {
+    try {
+      Files.deleteIfExists(CACHE_PATH.resolve(key));
+    } catch (IOException e) {
+      log.error("Failed to delete plugin binary from local filesystem cache: {}", key, e);
+    }
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryAlreadyExistsException.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryAlreadyExistsException.java
@@ -20,8 +20,8 @@ import static java.lang.String.format;
 import com.netflix.spinnaker.kork.exceptions.UserException;
 
 /**
- * Thrown whenever an upload attempt is made on for a plugin ID & version that already has a plugin
- * binary in storage.
+ * Thrown whenever an upload attempt is made on for a plugin ID and version that already has a
+ * plugin binary in storage.
  */
 public class PluginBinaryAlreadyExistsException extends UserException {
 

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryAlreadyExistsException.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryAlreadyExistsException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.plugins;
+
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.kork.exceptions.UserException;
+
+/**
+ * Thrown whenever an upload attempt is made on for a plugin ID & version that already has a plugin
+ * binary in storage.
+ */
+public class PluginBinaryAlreadyExistsException extends UserException {
+
+  public PluginBinaryAlreadyExistsException(String pluginKey) {
+    super(format("Plugin binary already exists for '%s'", pluginKey));
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryStorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryStorageService.java
@@ -26,17 +26,33 @@ public interface PluginBinaryStorageService {
    * Store a new version of a plugin binary.
    *
    * <p>If the key already exists, the storage service should not accept the request.
+   *
+   * @param key The plugin binary key
+   * @param item The plugin binary
    */
   void store(@Nonnull String key, @Nonnull byte[] item);
 
-  /** Deletes an existing plugin binary. */
+  /**
+   * Deletes an existing plugin binary.
+   *
+   * @param key The plugin binary key
+   */
   void delete(@Nonnull String key);
 
-  /** Get a list of all plugin binaries that are currently stored. */
+  /**
+   * Get a list of all plugin binaries that are currently stored.
+   *
+   * @return A list of all plugin binary keys
+   */
   @Nonnull
   List<String> listKeys();
 
-  /** Load a single plugin binary, returning its raw data. */
+  /**
+   * Load a single plugin binary, returning its raw data.
+   *
+   * @param key The plugin binary key
+   * @return The plugin binary, if it exists
+   */
   @Nullable
   byte[] load(@Nonnull String key);
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryStorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/plugins/PluginBinaryStorageService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.plugins;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** A specialized storage service for plugin binaries. */
+public interface PluginBinaryStorageService {
+
+  /**
+   * Store a new version of a plugin binary.
+   *
+   * <p>If the key already exists, the storage service should not accept the request.
+   */
+  void store(@Nonnull String key, @Nonnull byte[] item);
+
+  /** Deletes an existing plugin binary. */
+  void delete(@Nonnull String key);
+
+  /** Get a list of all plugin binaries that are currently stored. */
+  @Nonnull
+  List<String> listKeys();
+
+  /** Load a single plugin binary, returning its raw data. */
+  @Nullable
+  byte[] load(@Nonnull String key);
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/plugins/CachingPluginBinaryStorageServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/plugins/CachingPluginBinaryStorageServiceSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.plugins
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.nio.file.Path
+
+class CachingPluginBinaryStorageServiceSpec extends Specification {
+
+  PluginBinaryStorageService delegate = Mock()
+  @Subject PluginBinaryStorageService subject = new CachingPluginBinaryStorageService(delegate)
+
+  def "cache on store"() {
+    when:
+    subject.store("hello.zip", "world".bytes)
+
+    then:
+    1 * delegate.store("hello.zip", "world".bytes)
+    getCacheFile("hello.zip") == "world"
+  }
+
+  def "clear cache on delete"() {
+    when:
+    subject.delete("hello.zip")
+
+    then:
+    1 * delegate.delete("hello.zip")
+    !getCachePath("hello.zip").toFile().exists()
+  }
+
+  def "store on load"() {
+    when:
+    subject.load("hello.zip")
+
+    then:
+    1 * delegate.load("hello.zip") >> "mom"
+    getCacheFile("hello.zip") == "mom"
+  }
+
+  private Path getCachePath(String key) {
+    return subject.CACHE_PATH.resolve(key)
+  }
+
+  private String getCacheFile(String key) {
+    return new String(getCachePath(key).readBytes())
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -8,35 +8,22 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSClientBuilder;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.appinfo.ApplicationInfoManager;
-import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.front50.model.EventingS3ObjectKeyLoader;
-import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
-import com.netflix.spinnaker.front50.model.S3StorageService;
-import com.netflix.spinnaker.front50.model.StorageService;
-import com.netflix.spinnaker.front50.model.TemporarySQSQueue;
 import com.netflix.spinnaker.kork.aws.bastion.BastionConfig;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Optional;
-import java.util.concurrent.Executors;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.web.client.RestTemplate;
 
 @Configuration
-@ConditionalOnExpression("${spinnaker.s3.enabled:false}")
-@Import(BastionConfig.class)
+@ConditionalOnProperty("spinnaker.s3.enabled")
+@Import({
+  BastionConfig.class,
+  S3StorageServiceConfiguration.class,
+  S3StorageServiceConfiguration.class
+})
 @EnableConfigurationProperties(S3Properties.class)
 public class S3Config extends CommonStorageServiceDAOConfig {
 
@@ -75,102 +62,5 @@ public class S3Config extends CommonStorageServiceDAOConfig {
     }
 
     return client;
-  }
-
-  @Bean
-  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
-  public AmazonSQS awsSQSClient(
-      AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
-    return AmazonSQSClientBuilder.standard()
-        .withCredentials(awsCredentialsProvider)
-        .withClientConfiguration(new ClientConfiguration())
-        .withRegion(s3Properties.getRegion())
-        .build();
-  }
-
-  @Bean
-  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
-  public AmazonSNS awsSNSClient(
-      AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
-    return AmazonSNSClientBuilder.standard()
-        .withCredentials(awsCredentialsProvider)
-        .withClientConfiguration(new ClientConfiguration())
-        .withRegion(s3Properties.getRegion())
-        .build();
-  }
-
-  @Bean
-  @ConditionalOnMissingBean(RestTemplate.class)
-  public RestTemplate restTemplate() {
-    return new RestTemplate();
-  }
-
-  @Bean
-  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
-  public TemporarySQSQueue temporaryQueueSupport(
-      Optional<ApplicationInfoManager> applicationInfoManager,
-      AmazonSQS amazonSQS,
-      AmazonSNS amazonSNS,
-      S3Properties s3Properties) {
-    return new TemporarySQSQueue(
-        amazonSQS,
-        amazonSNS,
-        s3Properties.eventing.getSnsTopicName(),
-        getInstanceId(applicationInfoManager));
-  }
-
-  @Bean
-  @ConditionalOnExpression("${spinnaker.s3.eventing.enabled:false}")
-  public ObjectKeyLoader eventingS3ObjectKeyLoader(
-      ObjectMapper objectMapper,
-      S3Properties s3Properties,
-      StorageService storageService,
-      TemporarySQSQueue temporaryQueueSupport,
-      Registry registry) {
-    return new EventingS3ObjectKeyLoader(
-        Executors.newFixedThreadPool(1),
-        objectMapper,
-        s3Properties,
-        temporaryQueueSupport,
-        storageService,
-        registry,
-        true);
-  }
-
-  @Bean
-  public S3StorageService s3StorageService(AmazonS3 amazonS3, S3Properties s3Properties) {
-    ObjectMapper awsObjectMapper = new ObjectMapper();
-
-    S3StorageService service =
-        new S3StorageService(
-            awsObjectMapper,
-            amazonS3,
-            s3Properties.getBucket(),
-            s3Properties.getRootFolder(),
-            s3Properties.isFailoverEnabled(),
-            s3Properties.getRegion(),
-            s3Properties.getVersioning(),
-            s3Properties.getMaxKeys(),
-            s3Properties.getServerSideEncryption());
-    service.ensureBucketExists();
-
-    return service;
-  }
-
-  /**
-   * This will likely need improvement should it ever need to run in a non-eureka environment.
-   *
-   * @return instance identifier that will be used to create a uniquely named sqs queue
-   */
-  private static String getInstanceId(Optional<ApplicationInfoManager> applicationInfoManager) {
-    if (applicationInfoManager.isPresent()) {
-      return applicationInfoManager.get().getInfo().getInstanceId();
-    }
-
-    try {
-      return InetAddress.getLocalHost().getHostName();
-    } catch (UnknownHostException e) {
-      throw new IllegalStateException(e);
-    }
   }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3EventingConfiguration.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3EventingConfiguration.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.EventingS3ObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.StorageService;
+import com.netflix.spinnaker.front50.model.TemporarySQSQueue;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty({"spinnaker.s3.enabled", "spinnaker.s3.eventing.enabled"})
+public class S3EventingConfiguration {
+
+  @Bean
+  public AmazonSQS awsSQSClient(
+      AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
+    return AmazonSQSClientBuilder.standard()
+        .withCredentials(awsCredentialsProvider)
+        .withClientConfiguration(new ClientConfiguration())
+        .withRegion(s3Properties.getRegion())
+        .build();
+  }
+
+  @Bean
+  public AmazonSNS awsSNSClient(
+      AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
+    return AmazonSNSClientBuilder.standard()
+        .withCredentials(awsCredentialsProvider)
+        .withClientConfiguration(new ClientConfiguration())
+        .withRegion(s3Properties.getRegion())
+        .build();
+  }
+
+  @Bean
+  public TemporarySQSQueue temporaryQueueSupport(
+      Optional<ApplicationInfoManager> applicationInfoManager,
+      AmazonSQS amazonSQS,
+      AmazonSNS amazonSNS,
+      S3Properties s3Properties) {
+    return new TemporarySQSQueue(
+        amazonSQS,
+        amazonSNS,
+        s3Properties.eventing.getSnsTopicName(),
+        getInstanceId(applicationInfoManager));
+  }
+
+  @Bean
+  public ObjectKeyLoader eventingS3ObjectKeyLoader(
+      ObjectMapper objectMapper,
+      S3Properties s3Properties,
+      StorageService storageService,
+      TemporarySQSQueue temporaryQueueSupport,
+      Registry registry) {
+    return new EventingS3ObjectKeyLoader(
+        Executors.newFixedThreadPool(1),
+        objectMapper,
+        s3Properties,
+        temporaryQueueSupport,
+        storageService,
+        registry,
+        true);
+  }
+
+  /**
+   * This will likely need improvement should it ever need to run in a non-eureka environment.
+   *
+   * @return instance identifier that will be used to create a uniquely named sqs queue
+   */
+  private static String getInstanceId(Optional<ApplicationInfoManager> applicationInfoManager) {
+    if (applicationInfoManager.isPresent()) {
+      return applicationInfoManager.get().getInfo().getInstanceId();
+    }
+
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3PluginBinaryServiceConfiguration.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3PluginBinaryServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,20 @@
  */
 package com.netflix.spinnaker.front50.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import com.amazonaws.services.s3.AmazonS3;
+import com.netflix.spinnaker.front50.plugins.PluginBinaryStorageService;
+import com.netflix.spinnaker.front50.plugins.S3PluginBinaryStorageService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
 
 @Configuration
-@EnableConfigurationProperties({
-  ChaosMonkeyEventListenerConfigurationProperties.class,
-  FiatConfigurationProperties.class
-})
-public class Front50CoreConfiguration {
+@ConditionalOnProperty("spinnaker.s3.plugin-binary-storage.enabled")
+public class S3PluginBinaryServiceConfiguration {
 
   @Bean
-  @ConditionalOnMissingBean(RestTemplate.class)
-  public RestTemplate restTemplate() {
-    return new RestTemplate();
+  PluginBinaryStorageService pluginBinaryStorageService(
+      AmazonS3 amazonS3, S3Properties properties) {
+    return new S3PluginBinaryStorageService(amazonS3, properties);
   }
 }

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3StorageServiceConfiguration.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3StorageServiceConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.model.S3StorageService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(value = "spinnaker.s3.storage-service.enabled", matchIfMissing = true)
+public class S3StorageServiceConfiguration {
+
+  @Bean
+  public S3StorageService s3StorageService(AmazonS3 amazonS3, S3Properties s3Properties) {
+    ObjectMapper awsObjectMapper = new ObjectMapper();
+
+    S3StorageService service =
+        new S3StorageService(
+            awsObjectMapper,
+            amazonS3,
+            s3Properties.getBucket(),
+            s3Properties.getRootFolder(),
+            s3Properties.isFailoverEnabled(),
+            s3Properties.getRegion(),
+            s3Properties.getVersioning(),
+            s3Properties.getMaxKeys(),
+            s3Properties.getServerSideEncryption());
+    service.ensureBucketExists();
+
+    return service;
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/plugins/S3PluginBinaryStorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/plugins/S3PluginBinaryStorageService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.plugins;
+
+import static java.lang.String.format;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import com.google.common.hash.Hashing;
+import com.google.common.io.ByteStreams;
+import com.netflix.spinnaker.front50.config.S3Properties;
+import com.netflix.spinnaker.kork.exceptions.SystemException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class S3PluginBinaryStorageService implements PluginBinaryStorageService {
+
+  private final AmazonS3 amazonS3;
+  private final S3Properties properties;
+
+  public S3PluginBinaryStorageService(AmazonS3 amazonS3, S3Properties properties) {
+    this.amazonS3 = amazonS3;
+    this.properties = properties;
+  }
+
+  @Override
+  public void store(@Nonnull String key, @Nonnull byte[] item) {
+    if (amazonS3.doesObjectExist(properties.getBucket(), buildObjectKey(key))) {
+      throw new PluginBinaryAlreadyExistsException(key);
+    }
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(item.length);
+    metadata.setContentMD5(
+        Base64.getEncoder().encodeToString(Hashing.md5().hashBytes(item).asBytes()));
+
+    amazonS3.putObject(
+        properties.getBucket(), buildObjectKey(key), new ByteArrayInputStream(item), metadata);
+  }
+
+  @Override
+  public void delete(@Nonnull String key) {
+    amazonS3.deleteObject(properties.getBucket(), buildObjectKey(key));
+  }
+
+  @Nonnull
+  @Override
+  public List<String> listKeys() {
+    ObjectListing listing =
+        amazonS3.listObjects(
+            new ListObjectsRequest(properties.getBucket(), buildFolder(), null, null, 1000));
+    List<S3ObjectSummary> summaries = listing.getObjectSummaries();
+
+    while (listing.isTruncated()) {
+      listing = amazonS3.listNextBatchOfObjects(listing);
+      summaries.addAll(listing.getObjectSummaries());
+    }
+
+    return summaries.stream()
+        .map(S3ObjectSummary::getKey)
+        .filter(k -> k.endsWith(".zip"))
+        .collect(Collectors.toList());
+  }
+
+  @Nullable
+  @Override
+  public byte[] load(@Nonnull String key) {
+    S3Object object;
+    try {
+      object = amazonS3.getObject(properties.getBucket(), buildObjectKey(key));
+    } catch (AmazonS3Exception e) {
+      if (e.getStatusCode() == 404) {
+        return null;
+      }
+      throw e;
+    }
+
+    try {
+      return ByteStreams.toByteArray(object.getObjectContent());
+    } catch (IOException e) {
+      throw new SystemException(format("Failed to read object contents: %s", key), e);
+    }
+  }
+
+  private String buildFolder() {
+    return properties.getRootFolder() + "/pluginBinaries";
+  }
+
+  private String buildObjectKey(String key) {
+    return (buildFolder() + "/" + key).replaceAll("//", "/");
+  }
+}

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginBinaryController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginBinaryController.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.controllers;
+
+import static java.lang.String.format;
+
+import com.google.common.hash.Hashing;
+import com.netflix.spinnaker.front50.plugins.PluginBinaryStorageService;
+import com.netflix.spinnaker.kork.exceptions.SystemException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/pluginBinaries")
+public class PluginBinaryController {
+
+  private final PluginBinaryStorageService pluginBinaryStorageService;
+
+  public PluginBinaryController(PluginBinaryStorageService pluginBinaryStorageService) {
+    this.pluginBinaryStorageService = pluginBinaryStorageService;
+  }
+
+  @PostMapping("/{id}/{version}")
+  @ResponseStatus(HttpStatus.CREATED)
+  void upload(
+      @PathVariable String id,
+      @PathVariable String version,
+      @RequestParam("sha512sum") String sha512sum,
+      @RequestBody byte[] body) {
+    verifyChecksum(body, sha512sum);
+    pluginBinaryStorageService.store(getKey(id, version), body);
+  }
+
+  @GetMapping("/{id}/{version}")
+  ResponseEntity<byte[]> getBinary(@PathVariable String id, @PathVariable String version) {
+    return ResponseEntity.ok()
+        .header("Content-Type", "application/octet-stream")
+        .body(pluginBinaryStorageService.load(getKey(id, version)));
+  }
+
+  private static String getKey(String id, String version) {
+    return format("%s/%s.zip", id, version);
+  }
+
+  private void verifyChecksum(byte[] body, String sha512sum) {
+    String sha = Hashing.sha512().hashBytes(body).toString();
+    if (!sha.equals(sha512sum)) {
+      throw new SystemException("Plugin binary checksum does not match expected checksum value")
+          .setRetryable(true);
+    }
+  }
+}


### PR DESCRIPTION
Refactors `front50-s3` config so that the StorageService can decoupled from S3 configuration. Added a new storage service just for plugin binaries that can use different (already available) blob stores. Only wrote an S3 implementation for now since that's all Netflix cares about.

Also wrote a little local filesystem cache that delegates to actual storage services.

Additional steps:

1. Get the gradle plugin to work with these endpoints
2. Get the plugin framework to download from front50

For Front50 plugin bootstrapping itself, its plugins will need to be baked into the image, or sourced from an already existing Front50 deployment.