### PR TITLE
chore(vulnerabilities): resolve CVEs and other security issues

### DIFF
--- a/front50-swift/front50-swift.gradle
+++ b/front50-swift/front50-swift.gradle
@@ -27,7 +27,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.kork:kork-hystrix"
   implementation "org.springframework:spring-web"
-  implementation 'org.pacesys:openstack4j:3.0.3'
+  implementation 'org.pacesys:openstack4j:3.2.0'
 
   testImplementation project(":front50-test")
 }


### PR DESCRIPTION
Upgrade openstack4j version.
Fix CVE-2016-9606 and CVE-2016-6346 caused by resteasy-jaxrs.