### PR TITLE
fix(storage): Fix errors on eventual consistency of storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,11 @@ allprojects { project ->
       testImplementation("org.hamcrest:hamcrest-core")
       testRuntimeOnly("cglib:cglib-nodep")
       testRuntimeOnly("org.objenesis:objenesis")
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine" // Required for Spock tests to execute along with Junit5 tests.
+    }
+
+    test {
+      useJUnitPlatform()
     }
   }
 }

--- a/front50-core/front50-core.gradle
+++ b/front50-core/front50-core.gradle
@@ -32,4 +32,8 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-hystrix"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
+
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.platform:junit-platform-runner"
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageService.java
@@ -49,6 +49,31 @@ public interface StorageService {
     }
   }
 
+  /**
+   * Stores the provided object into the persistent store, using the provided key.
+   *
+   * <p>Implementations may modify the object before storing it (such as to add timestamps) but must
+   * do so on the provided object so that the input object reflects exactly what was stored in the
+   * persistent store upon returning from this function.
+   *
+   * <p>In other words, given the sequence of calls
+   *
+   * <pre>{@code
+   * storeObject(objectType, objectKey, item)
+   * newItem = loadObject(objectType, objectKey)
+   * }</pre>
+   *
+   * the implementation must guarantee that {@code newItem.equals(item)}.
+   *
+   * <p>This, in particular, precludes implementations from copying/serializing the input item and
+   * mutating that copy/serialization before storing it. It also precludes implementations that have
+   * triggers at the storage layer that mutate items upon storing.
+   *
+   * @param objectType The type of object to store
+   * @param objectKey The key under which to store the object
+   * @param item The object to store
+   * @param <T> The type of object to store
+   */
   <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T item);
 
   Map<String, Long> listObjectKeys(ObjectType objectType);

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -230,11 +230,30 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
     }
   }
 
-  public void update(String id, T item) {
+  /**
+   * Updates the persistent store with the provided item.
+   *
+   * <p>The item may be mutated prior to being stored, but this method guarantees that the state of
+   * the input item upon returning from this method reflects exactly what was stored.
+   *
+   * @param id The id of the item to be stored
+   * @param item The item to be stored
+   */
+  public final void update(String id, T item) {
+    preUpdate(id, item);
     item.setLastModifiedBy(AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
     item.setLastModified(System.currentTimeMillis());
     service.storeObject(objectType, buildObjectKey(id), item);
   }
+
+  /**
+   * Implementations may override this method to perform any implementation-specific mutations or
+   * validations on the input item before storing it in the persistent store.
+   *
+   * @param id The id of the item being updated
+   * @param item The item being updated
+   */
+  public void preUpdate(String id, T item) {}
 
   public void delete(String id) {
     service.deleteObject(objectType, buildObjectKey(id));

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
@@ -61,9 +61,8 @@ public class DefaultApplicationDAO extends StorageServiceSupport<Application>
   }
 
   @Override
-  public void update(String id, Application application) {
+  public void preUpdate(String id, Application application) {
     application.setName(id);
-    super.update(id, application);
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
@@ -57,7 +57,7 @@ public class DefaultApplicationDAO extends StorageServiceSupport<Application>
     }
 
     update(id, application);
-    return findById(id);
+    return application;
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
@@ -44,17 +44,12 @@ public class DefaultApplicationPermissionDAO extends StorageServiceSupport<Appli
 
   @Override
   public Application.Permission create(String id, Application.Permission permission) {
-    return upsert(id, permission);
+    update(id, permission);
+    return findById(id);
   }
 
   @Override
-  public void update(String id, Application.Permission permission) {
-    upsert(id, permission);
-  }
-
-  private Application.Permission upsert(String id, Application.Permission permission) {
+  public void preUpdate(String id, Application.Permission permission) {
     permission.setName(id);
-    super.update(id, permission);
-    return findById(id);
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
@@ -45,7 +45,7 @@ public class DefaultApplicationPermissionDAO extends StorageServiceSupport<Appli
   @Override
   public Application.Permission create(String id, Application.Permission permission) {
     update(id, permission);
-    return findById(id);
+    return permission;
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/delivery/DefaultDeliveryRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/delivery/DefaultDeliveryRepository.java
@@ -71,6 +71,6 @@ public class DefaultDeliveryRepository extends StorageServiceSupport<Delivery>
     // todo eb: what other validation needs to happen here?
 
     update(id, deliveryConfig);
-    return findById(id);
+    return deliveryConfig;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
@@ -88,6 +88,6 @@ public class DefaultPipelineDAO extends StorageServiceSupport<Pipeline> implemen
     Assert.notNull(item.getName(), "name field must NOT be null!");
 
     update(id, item);
-    return findById(id);
+    return item;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
@@ -77,6 +77,6 @@ public class DefaultPipelineStrategyDAO extends StorageServiceSupport<Pipeline>
     item.setId(id);
 
     update(id, item);
-    return findById(id);
+    return item;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineTemplateDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineTemplateDAO.java
@@ -49,6 +49,6 @@ public class DefaultPipelineTemplateDAO extends StorageServiceSupport<PipelineTe
     Assert.notEmpty(item.getScopes(), "scopes field must have at least ONE scope!");
 
     update(id, item);
-    return findById(id);
+    return item;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/DefaultPluginInfoRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugininfo/DefaultPluginInfoRepository.java
@@ -69,6 +69,6 @@ public class DefaultPluginInfoRepository extends StorageServiceSupport<PluginInf
     }
 
     update(id, item);
-    return findById(id);
+    return item;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
@@ -60,6 +60,6 @@ public class DefaultProjectDAO extends StorageServiceSupport<Project> implements
     item.setId(id);
 
     update(id, item);
-    return findById(id);
+    return item;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
@@ -45,7 +45,7 @@ public class DefaultServiceAccountDAO extends StorageServiceSupport<ServiceAccou
   @Override
   public ServiceAccount create(String id, ServiceAccount permission) {
     update(id, permission);
-    return findById(id);
+    return permission;
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
@@ -44,17 +44,12 @@ public class DefaultServiceAccountDAO extends StorageServiceSupport<ServiceAccou
 
   @Override
   public ServiceAccount create(String id, ServiceAccount permission) {
-    return upsert(id, permission);
+    update(id, permission);
+    return findById(id);
   }
 
   @Override
-  public void update(String id, ServiceAccount permission) {
-    upsert(id, permission);
-  }
-
-  private ServiceAccount upsert(String id, ServiceAccount permission) {
+  public void preUpdate(String id, ServiceAccount permission) {
     permission.setName(id);
-    super.update(id, permission);
-    return findById(id);
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
@@ -52,7 +52,7 @@ public class DefaultSnapshotDAO extends StorageServiceSupport<Snapshot> implemen
     item.setId(id);
     item.setTimestamp(System.currentTimeMillis());
 
-    super.update(id, item);
-    return findById(id);
+    update(id, item);
+    return item;
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
@@ -47,7 +47,7 @@ public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags>
   @Override
   public EntityTags create(String id, EntityTags tag) {
     update(id, tag);
-    return findById(id);
+    return tag;
   }
 
   @Override

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
@@ -46,18 +46,13 @@ public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags>
 
   @Override
   public EntityTags create(String id, EntityTags tag) {
-    return upsert(id, tag);
+    update(id, tag);
+    return findById(id);
   }
 
   @Override
-  public void update(String id, EntityTags tag) {
-    upsert(id, tag);
-  }
-
-  private EntityTags upsert(String id, EntityTags tag) {
+  public void preUpdate(String id, EntityTags tag) {
     Objects.requireNonNull(id);
-    super.update(id, tag);
-    return findById(id);
   }
 
   @Override

--- a/front50-core/src/test/java/com/netflix/spinnaker/front50/model/EventuallyConsistentStorageService.java
+++ b/front50-core/src/test/java/com/netflix/spinnaker/front50/model/EventuallyConsistentStorageService.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A storage service that keeps all objects in memory. In order to simulate eventual consistency,
+ * mutating operations are not reflected by accessors until the {@code flush()} method is called on
+ * the storage service.
+ */
+@NotThreadSafe
+public class EventuallyConsistentStorageService implements StorageService {
+  private final Map<ObjectType, ObjectStore<?>> storage = new HashMap<>();
+  private final Queue<Runnable> pendingOperations = new LinkedList<>();
+
+  /** Make any pending mutations to the repository visible to read operations. */
+  public void flush() {
+    while (!pendingOperations.isEmpty()) {
+      pendingOperations.remove().run();
+    }
+  }
+
+  @Override
+  public void ensureBucketExists() {}
+
+  @Override
+  public boolean supportsVersioning() {
+    return false;
+  }
+
+  @Override
+  public <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey)
+      throws NotFoundException {
+    // We are forced to do an unchecked cast here as ObjectType is not parametrized with its
+    // class type (and cannot be given that it is an enum).
+    @SuppressWarnings("unchecked")
+    T result = (T) getObjectStore(objectType).get(objectKey);
+    return result;
+  }
+
+  @Override
+  public void deleteObject(ObjectType objectType, String objectKey) {
+    pendingOperations.add(() -> getObjectStore(objectType).delete(objectKey));
+  }
+
+  @Override
+  public <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T item) {
+    pendingOperations.add(
+        () -> {
+          // We are forced to do an unchecked cast here as ObjectType is not parametrized with its
+          // class type (and cannot be given that it is an enum).
+          @SuppressWarnings("unchecked")
+          ObjectStore<T> store = (ObjectStore<T>) getObjectStore(objectType);
+          store.put(objectKey, item);
+        });
+  }
+
+  @Override
+  public Map<String, Long> listObjectKeys(ObjectType objectType) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T extends Timestamped> Collection<T> listObjectVersions(
+      ObjectType objectType, String objectKey, int maxResults) throws NotFoundException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLastModified(ObjectType objectType) {
+    throw new UnsupportedOperationException();
+  }
+
+  private <T extends Timestamped> ObjectStore<? extends Timestamped> getObjectStore(
+      ObjectType objectType) {
+    return storage.computeIfAbsent(objectType, o -> new ObjectStore<>(objectType.clazz));
+  }
+
+  @NotThreadSafe
+  private static final class ObjectStore<T extends Timestamped> {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final Class<T> objectClass;
+    private final Map<String, String> store = new HashMap<>();
+
+    ObjectStore(Class<T> objectClass) {
+      this.objectClass = objectClass;
+    }
+
+    public void put(String objectKey, T item) {
+      String serializedObject;
+      try {
+        serializedObject = objectMapper.writeValueAsString(item);
+      } catch (JsonProcessingException e) {
+        throw new UncheckedIOException(e);
+      }
+      store.put(objectKey, serializedObject);
+    }
+
+    public T get(String objectKey) {
+      String serializedObject = store.get(objectKey);
+      if (serializedObject == null) {
+        throw new NotFoundException(String.format("Object with key %s not found", objectKey));
+      }
+      try {
+        return objectMapper.readValue(serializedObject, objectClass);
+      } catch (JsonProcessingException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    public void delete(String objectKey) {
+      store.remove(objectKey);
+    }
+  }
+}

--- a/front50-core/src/test/java/com/netflix/spinnaker/front50/model/EventuallyConsistentStorageServiceTest.java
+++ b/front50-core/src/test/java/com/netflix/spinnaker/front50/model/EventuallyConsistentStorageServiceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.application.Application;
+import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
+import org.junit.jupiter.api.Test;
+
+public class EventuallyConsistentStorageServiceTest {
+  private static final String KEY = "my-key";
+  private static final String OTHER_KEY = "my-other-key";
+
+  @Test
+  void emptyRepository() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> storageService.loadObject(ObjectType.APPLICATION, KEY));
+  }
+
+  @Test
+  void storeAndRetreive() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+
+    Application application = new Application();
+    application.setName("my-app");
+    application.setDescription("my-description");
+
+    storageService.storeObject(ObjectType.APPLICATION, KEY, application);
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> storageService.loadObject(ObjectType.APPLICATION, KEY));
+
+    storageService.flush();
+
+    Application result = storageService.loadObject(ObjectType.APPLICATION, KEY);
+    assertThat(result.getName()).isEqualTo(application.getName());
+    assertThat(result.getDescription()).isEqualTo(application.getDescription());
+  }
+
+  @Test
+  void storeAndUpdate() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+
+    Application application = new Application();
+    application.setName("my-app");
+    application.setDescription("my-description");
+
+    storageService.storeObject(ObjectType.APPLICATION, KEY, application);
+    storageService.flush();
+
+    Application newApplication = new Application();
+    newApplication.setName("new-app");
+    newApplication.setDescription("new-description");
+
+    storageService.storeObject(ObjectType.APPLICATION, KEY, newApplication);
+
+    Application result = storageService.loadObject(ObjectType.APPLICATION, KEY);
+    assertThat(result.getName()).isEqualTo(application.getName());
+    assertThat(result.getDescription()).isEqualTo(application.getDescription());
+
+    storageService.flush();
+
+    Application newResult = storageService.loadObject(ObjectType.APPLICATION, KEY);
+    assertThat(newResult.getName()).isEqualTo(newApplication.getName());
+    assertThat(newResult.getDescription()).isEqualTo(newApplication.getDescription());
+  }
+
+  @Test
+  void storeAndDelete() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+
+    Application application = new Application();
+    application.setName("my-app");
+    application.setDescription("my-description");
+    storageService.storeObject(ObjectType.APPLICATION, KEY, application);
+    storageService.flush();
+
+    storageService.deleteObject(ObjectType.APPLICATION, KEY);
+
+    Application result = storageService.loadObject(ObjectType.APPLICATION, KEY);
+    assertThat(result.getName()).isEqualTo(application.getName());
+    assertThat(result.getDescription()).isEqualTo(application.getDescription());
+
+    storageService.flush();
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> storageService.loadObject(ObjectType.APPLICATION, KEY));
+  }
+
+  @Test
+  void sameTypeDifferentKeys() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+
+    Application application = new Application();
+    application.setName("my-app");
+    application.setDescription("my-description");
+
+    storageService.storeObject(ObjectType.APPLICATION, KEY, application);
+    storageService.flush();
+
+    Application newApplication = new Application();
+    newApplication.setName("new-app");
+    newApplication.setDescription("new-description");
+
+    storageService.storeObject(ObjectType.APPLICATION, OTHER_KEY, newApplication);
+    storageService.flush();
+
+    Application result = storageService.loadObject(ObjectType.APPLICATION, KEY);
+    assertThat(result.getName()).isEqualTo(application.getName());
+    assertThat(result.getDescription()).isEqualTo(application.getDescription());
+
+    Application otherResult = storageService.loadObject(ObjectType.APPLICATION, OTHER_KEY);
+    assertThat(otherResult.getName()).isEqualTo(newApplication.getName());
+    assertThat(otherResult.getDescription()).isEqualTo(newApplication.getDescription());
+  }
+
+  @Test
+  void sameKeyDifferentTypes() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+
+    Application application = new Application();
+    application.setName("my-app");
+    application.setDescription("my-description");
+    storageService.storeObject(ObjectType.APPLICATION, KEY, application);
+    storageService.flush();
+
+    Pipeline pipeline = new Pipeline();
+    pipeline.setName("my-pipeline");
+    storageService.storeObject(ObjectType.PIPELINE, KEY, pipeline);
+    storageService.flush();
+
+    Application applicationResult = storageService.loadObject(ObjectType.APPLICATION, KEY);
+    assertThat(applicationResult.getName()).isEqualTo(application.getName());
+    assertThat(applicationResult.getDescription()).isEqualTo(application.getDescription());
+
+    Pipeline pipelineResult = storageService.loadObject(ObjectType.PIPELINE, KEY);
+    assertThat(pipelineResult.getName()).isEqualTo(pipeline.getName());
+  }
+}

--- a/front50-core/src/test/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAOTest.java
+++ b/front50-core/src/test/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAOTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.application;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.front50.exception.NotFoundException;
+import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.EventuallyConsistentStorageService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import rx.schedulers.Schedulers;
+
+public class DefaultApplicationDAOTest {
+  private static final String KEY = "my-key";
+
+  @Test
+  void eventuallyConsistentStore() {
+    EventuallyConsistentStorageService storageService = new EventuallyConsistentStorageService();
+    ApplicationDAO applicationDAO =
+        new DefaultApplicationDAO(
+            storageService,
+            Schedulers.from(Executors.newFixedThreadPool(1)),
+            new DefaultObjectKeyLoader(storageService),
+            0,
+            false,
+            new NoopRegistry());
+
+    Application application = new Application();
+    application.setName("my-app");
+    application.setDescription("my-description");
+
+    // Documenting a bug that currently exists; in the event of an eventually consistent storage
+    // service, application creation will fail because we attempt to fetch the newly-created object
+    // as part of the creation call.
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> applicationDAO.create(KEY, application));
+  }
+}

--- a/front50-core/src/test/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAOTest.java
+++ b/front50-core/src/test/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAOTest.java
@@ -16,10 +16,9 @@
 
 package com.netflix.spinnaker.front50.model.application;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.NoopRegistry;
-import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.EventuallyConsistentStorageService;
 import java.util.concurrent.Executors;
@@ -45,10 +44,11 @@ public class DefaultApplicationDAOTest {
     application.setName("my-app");
     application.setDescription("my-description");
 
-    // Documenting a bug that currently exists; in the event of an eventually consistent storage
-    // service, application creation will fail because we attempt to fetch the newly-created object
-    // as part of the creation call.
-    assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> applicationDAO.create(KEY, application));
+    applicationDAO.create(KEY, application);
+    storageService.flush();
+
+    Application result = applicationDAO.findById(KEY);
+    assertThat(result.getName()).isEqualTo(application.getName());
+    assertThat(result.getDescription()).isEqualTo(application.getDescription());
   }
 }


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5557 which was found by the integration tests; this applies the second solution outlined there "Instead of fetching the object from storage after creating it, just return the object we placed in storage.".

* test(storage): Add some tests 

  Add a new test implementation of StorageService that simulates an eventually consistent storage backend, and tests on this new implementation.

  Also add a test on DefaultApplicationDAO to document the current behavior which is to throw an exception when creating an application against an eventually consistent data store.

* refactor(storage): Strengthen contract of StorageService 

  A StorageService should not implement any business logic and should just store the provided item to the backing store as given.

  There are a couple of places where the storage service sets a modified timestamp (in the Azure and SQL backends); arguably this should be done upstream so that this is independent of the backing store but for now we'll leave those there.

  Add javadoc to storeObject to explicitly strengthen the contract of this method, which all current implementations respect. In particular, require that the input object reflect exactly what was stored in the persistent store upon returning from the method. Thus, implmementations can mutatate the input object before storing it, but must ensure that mutation is reflected on the input object.

* refactor(core): Strengthen contract of StorageServiceSupport.update 

  Now that StorageService.storeObject explicitly guarantees that the state of the object upon returning from the function relfects exactly what was stored, we can strengthen the contract of StorageServiceSupport.update.

  In particular, we'll allow update to modify the supplied object (for example to add last modified data) but will require that the state of the input object at the end of update reflect exactly what was stored to the persistent store.

  In order to help enforce this contract, we'll make update final so that implementations cannot override it in a way incompatible with this contract. There were a few implementations that did override update, but these all just did pre-update mutation/validation then called super.update. To handle these cases, expose a preUpdate function where implementations can specify this pre-update mutation/validation.

* fix(storage): Short-circuit findById after update 

  Now that we have strengthened the contract of update, we can short-circuit places where we call update to store an object, then immediately call findById to get it back again. Given this strengthened contract, we are guaranteed that the object in the persistent store is identical to the object we just stored and can avoid an extra call to the persistent store.

  This is particularly important for persistent stores that don't have strong read-after-write consistency (such as s3). In these cases, immediately fetching the the object we just wrote may actually return a prior version of the object (or a 404 if the object was just created). Returning the object we know we just wrote avoids this race condition between our call to fetch the object and the eventual consistency of the data store.
