### PR TITLE
fix(s3): Update aws-sdk to v1.11.717

### DIFF
--- a/front50-s3/front50-s3.gradle
+++ b/front50-s3/front50-s3.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-aws"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.netflix.spinnaker.kork:kork-hystrix"
-  implementation "com.amazonaws:aws-java-sdk-s3"
-  implementation "com.amazonaws:aws-java-sdk-sts"
+  implementation "com.amazonaws:aws-java-sdk-s3:1.11.717"
+  implementation "com.amazonaws:aws-java-sdk-sts:1.11.717"
 
   testImplementation project(":front50-test")
 }

--- a/front50-test/front50-test.gradle
+++ b/front50-test/front50-test.gradle
@@ -20,5 +20,5 @@ dependencies {
 
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.spockframework:spock-core"
-  implementation "com.amazonaws:aws-java-sdk-s3"
+  implementation "com.amazonaws:aws-java-sdk-s3:1.11.717"
 }

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -48,7 +48,7 @@ dependencies {
 
   testImplementation project(":front50-test")
   testImplementation project(":front50-s3")
-  testImplementation "com.amazonaws:aws-java-sdk-s3"
+  testImplementation "com.amazonaws:aws-java-sdk-s3:1.11.717"
 
   // Add each included cloud provider project as a runtime dependency
   gradle.includedProviderProjects.each {


### PR DESCRIPTION
Trying to assume an IAM role with the EKS pod identity webhook results in a stackoverflow error with Spinnaker v1.19.0 (Front 50 v0.22.0). The issue is described in https://github.com/aws/aws-sdk-java/issues/2136 and updating the aws-sdk should fix it.

Edit: I just saw https://github.com/spinnaker/spinnaker/issues/5521 and https://github.com/spinnaker/kork/pull/523
I don't know how the dependency management is supposed to work here, but in the current master the aws-sdk version still resolves to 1.11.415