### PR TITLE
fix(plugins): add an option for strict plugin loading

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ clouddriverVersion=5.47.1
 fiatVersion=1.14.0
 enablePublishing=false
 spinnakerGradleVersion=7.2.0
-korkVersion=7.25.1
+korkVersion=7.25.13
 org.gradle.parallel=true
 includeProviders=azure,gcs,oracle,redis,s3,swift,sql


### PR DESCRIPTION
This PR is part of a series of PRs for allowing relaxed plugin loading by adding a config option to turn strict plugin loading on or off. See https://docs.google.com/document/d/1yFDrpkCCV7Vp0wN0gDc9GTbTOBoIzNo-tGj1-vVjq04/edit?usp=sharing for more info