### PR TITLE
chore(dependencies): Unpin org.jetbrains.kotlin

### DIFF
--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -17,16 +17,6 @@
 apply plugin: "nebula.kotlin"
 apply plugin: "kotlin-spring"
 
-configurations.all {
-  resolutionStrategy {
-    eachDependency { details ->
-      if (details.requested.group == "org.jetbrains.kotlin") {
-        details.useVersion "1.3.10"
-      }
-    }
-  }
-}
-
 compileKotlin {
   kotlinOptions {
     languageVersion = "1.3"


### PR DESCRIPTION
Bumping kork on front50 is failing because at some point recently we upgraded kotlin, and it looks like it has a new artifact that isn't in the pinned version.

I'm not sure why the pin was added initially, but the tests all pass when it is removed. When this is removed, kork can successfully be bumped.
