### PR TITLE
refactor(core): clean up halconfig/front50.yml

### DIFF
--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton Front50 configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `front50-web/config/front50.yml`
+or set a default in the code reading the config property.

--- a/halconfig/front50.yml
+++ b/halconfig/front50.yml
@@ -2,9 +2,6 @@ server:
   port: ${services.front50.port:8080}
   address: ${services.front50.host:localhost}
 
-cassandra:
-  enabled: false
-
 hystrix:
   command:
     default.execution.isolation.thread.timeoutInMilliseconds: 15000

--- a/halconfig/front50.yml
+++ b/halconfig/front50.yml
@@ -1,14 +1,3 @@
 server:
   port: ${services.front50.port:8080}
   address: ${services.front50.host:localhost}
-
-hystrix:
-  command:
-    default.execution.isolation.thread.timeoutInMilliseconds: 15000
-  threadpool:
-    DefaultNotificationDAO:
-      coreSize: 25
-      maxQueueSize: 100
-    DefaultPipelineDAO:
-      coreSize: 25
-      maxQueueSize: 100


### PR DESCRIPTION
* refactor(core): add README to halconfig directory 

* refactor(core): remove cassandra config from halconfig/front50.yml 

  Cassandra was [removed](https://github.com/spinnaker/front50/pull/353) as a storage provider in 2018, so we should no longer need this config block disabling it.
