### PR TITLE
chore(azure): Default storageContainerName

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageProperties.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageProperties.java
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AzureStorageProperties {
   private String storageAccountKey;
   private String storageAccountName;
-  private String storageContainerName;
+  private String storageContainerName = "spinnaker";
 
   public String getStorageConnectionString() {
     return "DefaultEndpointsProtocol=https;"


### PR DESCRIPTION
This defaulting was happening in Halyard, and will be removed from kleat (which does not default parameters that are not supplied and instead leaves this defaulting to the consuming service).

In order to support kleat, add the defaulting here; this won't affect existing Halyard users as Halyard will continue to write this field (meaning the deafult won't be used for them).