### PR TITLE
feat(plugins): Plugin version pinning

### DIFF
--- a/front50-core/front50-core.gradle
+++ b/front50-core/front50-core.gradle
@@ -32,4 +32,5 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-hystrix"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
+  implementation "com.netflix.spinnaker.moniker:moniker"
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -34,8 +34,10 @@ import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineTemplateDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO;
-import com.netflix.spinnaker.front50.model.plugininfo.DefaultPluginInfoRepository;
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfoRepository;
+import com.netflix.spinnaker.front50.model.plugins.DefaultPluginInfoRepository;
+import com.netflix.spinnaker.front50.model.plugins.DefaultPluginVersionPinningRepository;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfoRepository;
+import com.netflix.spinnaker.front50.model.plugins.PluginVersionPinningRepository;
 import com.netflix.spinnaker.front50.model.project.DefaultProjectDAO;
 import com.netflix.spinnaker.front50.model.project.ProjectDAO;
 import com.netflix.spinnaker.front50.model.serviceaccount.DefaultServiceAccountDAO;
@@ -250,6 +252,23 @@ public class CommonStorageServiceDAOConfig {
       ObjectKeyLoader objectKeyLoader,
       Registry registry) {
     return new DefaultPluginInfoRepository(
+        storageService,
+        Schedulers.from(
+            Executors.newFixedThreadPool(
+                storageServiceConfigurationProperties.getPluginInfo().getThreadPool())),
+        objectKeyLoader,
+        storageServiceConfigurationProperties.getPluginInfo().getRefreshMs(),
+        storageServiceConfigurationProperties.getPluginInfo().getShouldWarmCache(),
+        registry);
+  }
+
+  @Bean
+  PluginVersionPinningRepository pluginVersionPinningRepository(
+      StorageService storageService,
+      StorageServiceConfigurationProperties storageServiceConfigurationProperties,
+      ObjectKeyLoader objectKeyLoader,
+      Registry registry) {
+    return new DefaultPluginVersionPinningRepository(
         storageService,
         Schedulers.from(
             Executors.newFixedThreadPool(

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/Front50CoreConfiguration.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/Front50CoreConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.front50.config;
 
+import com.netflix.spinnaker.moniker.Namer;
+import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -32,5 +34,11 @@ public class Front50CoreConfiguration {
   @ConditionalOnMissingBean(RestTemplate.class)
   public RestTemplate restTemplate() {
     return new RestTemplate();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(Namer.class)
+  public Namer<?> namer() {
+    return new FriggaReflectiveNamer();
   }
 }

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/PluginVersionCleanupProperties.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/PluginVersionCleanupProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Controls configuration for the plugin version pinning metadata storage cleanup. */
+@ConfigurationProperties("storage-service.plugin-version-pinning.cleanup")
+public class PluginVersionCleanupProperties {
+  /** The maximum number of pinned version records to keep by cluster (and location). */
+  public int maxVersionsPerCluster = 10;
+
+  /** The interval that the cleanup agent will run. */
+  public Duration interval = Duration.ofDays(1);
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/PluginVersioningConfiguration.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/config/PluginVersioningConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.config;
+
+import com.netflix.spinnaker.front50.model.plugins.PluginInfoRepository;
+import com.netflix.spinnaker.front50.model.plugins.PluginVersionCleanupAgent;
+import com.netflix.spinnaker.front50.model.plugins.PluginVersionPinningRepository;
+import com.netflix.spinnaker.front50.model.plugins.PluginVersionPinningService;
+import com.netflix.spinnaker.moniker.Namer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+
+@Configuration
+@EnableConfigurationProperties(PluginVersionCleanupProperties.class)
+public class PluginVersioningConfiguration {
+
+  @Bean
+  PluginVersionPinningService pluginVersionPinningService(
+      PluginVersionPinningRepository pluginVersionPinningRepository,
+      PluginInfoRepository pluginInfoRepository) {
+    return new PluginVersionPinningService(pluginVersionPinningRepository, pluginInfoRepository);
+  }
+
+  @Bean
+  PluginVersionCleanupAgent pluginVersionCleanupAgent(
+      PluginVersionPinningRepository repository,
+      PluginVersionCleanupProperties properties,
+      Namer<?> namer,
+      TaskScheduler taskScheduler) {
+    return new PluginVersionCleanupAgent(repository, properties, namer, taskScheduler);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/ObjectType.java
@@ -21,7 +21,8 @@ import com.netflix.spinnaker.front50.model.delivery.Delivery;
 import com.netflix.spinnaker.front50.model.notification.Notification;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.ServerGroupPluginVersions;
 import com.netflix.spinnaker.front50.model.project.Project;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
 import com.netflix.spinnaker.front50.model.snapshot.Snapshot;
@@ -43,7 +44,9 @@ public enum ObjectType {
   SNAPSHOT(Snapshot.class, "snapshots", "snapshot.json"),
   ENTITY_TAGS(EntityTags.class, "tags", "entity-tags-metadata.json"),
   DELIVERY(Delivery.class, "delivery", "delivery-metadata.json"),
-  PLUGIN_INFO(PluginInfo.class, "pluginInfo", "plugin-info-metadata.json");
+  PLUGIN_INFO(PluginInfo.class, "pluginInfo", "plugin-info-metadata.json"),
+  PLUGIN_VERSIONS(
+      ServerGroupPluginVersions.class, "pluginVersions", "plugin-versions-metadata.json");
 
   public final Class<? extends Timestamped> clazz;
   public final String group;

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/DefaultPluginInfoRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/DefaultPluginInfoRepository.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.plugininfo;
+package com.netflix.spinnaker.front50.model.plugins;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/DefaultPluginVersionPinningRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/DefaultPluginVersionPinningRepository.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.plugins;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.ObjectType;
+import com.netflix.spinnaker.front50.model.StorageService;
+import com.netflix.spinnaker.front50.model.StorageServiceSupport;
+import com.netflix.spinnaker.kork.exceptions.IntegrationException;
+import java.util.Objects;
+import rx.Scheduler;
+
+public class DefaultPluginVersionPinningRepository
+    extends StorageServiceSupport<ServerGroupPluginVersions>
+    implements PluginVersionPinningRepository {
+  public DefaultPluginVersionPinningRepository(
+      StorageService service,
+      Scheduler scheduler,
+      ObjectKeyLoader objectKeyLoader,
+      long refreshIntervalMs,
+      boolean shouldWarmCache,
+      Registry registry) {
+    super(
+        ObjectType.PLUGIN_VERSIONS,
+        service,
+        scheduler,
+        objectKeyLoader,
+        refreshIntervalMs,
+        shouldWarmCache,
+        registry);
+  }
+
+  @Override
+  public ServerGroupPluginVersions create(String id, ServerGroupPluginVersions item) {
+    Objects.requireNonNull(item.getId());
+    Objects.requireNonNull(item.getPluginVersions());
+    if (!item.getId().equals(id)) {
+      throw new IntegrationException("The provided id and body id do not match");
+    }
+
+    if (item.getCreateTs() == null) {
+      item.setCreateTs(System.currentTimeMillis());
+    }
+    item.setLastModified(System.currentTimeMillis());
+
+    update(id, item);
+    return findById(id);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfo.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfo.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.plugininfo;
+package com.netflix.spinnaker.front50.model.plugins;
 
 import com.netflix.spinnaker.front50.model.Timestamped;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -59,6 +60,10 @@ public class PluginInfo implements Timestamped {
   private String lastModifiedBy;
 
   public PluginInfo() {}
+
+  public Optional<Release> getReleaseByVersion(String version) {
+    return releases.stream().filter(it -> it.version.equals(version)).findFirst();
+  }
 
   /** A singular {@code PluginInfo} release. */
   @Data

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoRepository.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.plugininfo;
+package com.netflix.spinnaker.front50.model.plugins;
 
 import com.netflix.spinnaker.front50.model.ItemDAO;
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo.Release;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo.Release;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.plugininfo;
+package com.netflix.spinnaker.front50.model.plugins;
 
 import com.netflix.spinnaker.front50.exception.NotFoundException;
 import com.netflix.spinnaker.front50.validator.GenericValidationErrors;

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionCleanupAgent.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionCleanupAgent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.plugins;
+
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.front50.config.PluginVersionCleanupProperties;
+import com.netflix.spinnaker.moniker.Namer;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.TaskScheduler;
+
+/** Responsible for cleaning up old server group plugin version records. */
+public class PluginVersionCleanupAgent implements Runnable {
+
+  private static final Logger log = LoggerFactory.getLogger(PluginVersionCleanupAgent.class);
+
+  private final PluginVersionPinningRepository repository;
+  private final PluginVersionCleanupProperties properties;
+  private final Namer namer;
+  private final TaskScheduler taskScheduler;
+
+  public PluginVersionCleanupAgent(
+      PluginVersionPinningRepository repository,
+      PluginVersionCleanupProperties properties,
+      Namer namer,
+      TaskScheduler taskScheduler) {
+    this.repository = repository;
+    this.properties = properties;
+    this.namer = namer;
+    this.taskScheduler = taskScheduler;
+  }
+
+  @PostConstruct
+  public void schedule() {
+    taskScheduler.scheduleWithFixedDelay(this, properties.interval);
+  }
+
+  @Override
+  public void run() {
+    log.info("Starting cleanup");
+
+    Collection<ServerGroupPluginVersions> allVersions = repository.all();
+
+    // Group all versions by cluster & location (region), then reduce the list by groups that have
+    // more than maxVersionsPerCluster, deleting the oldest server group records by created
+    // timestamp.
+    allVersions.stream()
+        .collect(
+            Collectors.groupingBy(
+                it -> {
+                  String clusterName = namer.deriveMoniker(it.getServerGroupName()).getCluster();
+                  String group = format("%s-%s", clusterName, it.getLocation());
+                  return group;
+                }))
+        .entrySet()
+        .stream()
+        .filter(it -> it.getValue().size() > properties.maxVersionsPerCluster)
+        .forEach(
+            it -> {
+              List<String> candidates =
+                  it.getValue().stream()
+                      .sorted(Comparator.comparing(ServerGroupPluginVersions::getCreateTs))
+                      .sorted(Comparator.reverseOrder())
+                      .map(ServerGroupPluginVersions::getId)
+                      .collect(Collectors.toList());
+
+              List<String> ids =
+                  candidates.subList(properties.maxVersionsPerCluster, candidates.size());
+
+              log.debug("Deleting {} version records for '{}'", ids.size(), it.getKey());
+              repository.bulkDelete(ids);
+            });
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningRepository.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.validator;
+package com.netflix.spinnaker.front50.model.plugins;
 
-import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
-import org.springframework.validation.Errors;
+import com.netflix.spinnaker.front50.model.ItemDAO;
 
-/** A {@link PluginInfo} validator. */
-public interface PluginInfoValidator {
-  void validate(PluginInfo pluginInfo, Errors validationErrors);
-}
+public interface PluginVersionPinningRepository extends ItemDAO<ServerGroupPluginVersions> {}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.plugins;
+
+import static java.lang.String.format;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PluginVersionPinningService {
+
+  private final PluginVersionPinningRepository pluginVersionPinningRepository;
+  private final PluginInfoRepository pluginInfoRepository;
+
+  public PluginVersionPinningService(
+      PluginVersionPinningRepository pluginVersionPinningRepository,
+      PluginInfoRepository pluginInfoRepository) {
+    this.pluginVersionPinningRepository = pluginVersionPinningRepository;
+    this.pluginInfoRepository = pluginInfoRepository;
+  }
+
+  public Map<String, PluginInfo.Release> pinVersions(
+      String serviceName,
+      String location,
+      String serverGroupName,
+      Map<String, String> pluginVersions) {
+    String id = format("%s-%s-%s", serviceName, location, serverGroupName);
+
+    ServerGroupPluginVersions existing = pluginVersionPinningRepository.findById(id);
+    if (existing == null) {
+      pluginVersionPinningRepository.create(
+          id, new ServerGroupPluginVersions(id, serverGroupName, location, pluginVersions));
+      return getReleasesForIds(pluginVersions);
+    }
+    return getReleasesForIds(existing.pluginVersions);
+  }
+
+  private Map<String, PluginInfo.Release> getReleasesForIds(Map<String, String> versions) {
+    Map<String, PluginInfo.Release> releases = new HashMap<>();
+
+    versions.forEach(
+        (pluginId, version) ->
+            pluginInfoRepository
+                .findById(pluginId)
+                .getReleaseByVersion(version)
+                .ifPresent(it -> releases.put(pluginId, it)));
+
+    return releases;
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/ServerGroupPluginVersions.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/ServerGroupPluginVersions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.model.plugins;
+
+import com.netflix.spinnaker.front50.model.Timestamped;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.Data;
+
+@Data
+public class ServerGroupPluginVersions
+    implements Timestamped, Comparable<ServerGroupPluginVersions> {
+
+  @Nonnull private String id;
+
+  @Nonnull private String serverGroupName;
+
+  @Nonnull private String location;
+
+  @Nonnull Map<String, String> pluginVersions;
+
+  private Long createTs;
+
+  private Long lastModified;
+
+  private String lastModifiedBy;
+
+  @Override
+  public int compareTo(@Nonnull ServerGroupPluginVersions o) {
+    return createTs.compareTo(o.createTs);
+  }
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidator.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.front50.validator;
 
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
 import com.netflix.spinnaker.kork.plugins.CanonicalPluginId;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidator.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidator.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.front50.validator;
 
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
 import com.netflix.spinnaker.kork.plugins.VersionRequirementsParser;
 import com.netflix.spinnaker.kork.plugins.VersionRequirementsParser.IllegalVersionRequirementsOperator;
 import com.netflix.spinnaker.kork.plugins.VersionRequirementsParser.InvalidPluginVersionRequirementException;

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoServiceSpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.plugininfo
+package com.netflix.spinnaker.front50.model.plugins
 
 import com.netflix.spinnaker.front50.exception.NotFoundException
 import com.netflix.spinnaker.front50.validator.PluginInfoValidator

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoSpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.front50.model.plugininfo
+package com.netflix.spinnaker.front50.model.plugins
 
 
 import spock.lang.Specification

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionCleanupAgentSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionCleanupAgentSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.plugins
+
+import com.netflix.spinnaker.front50.config.PluginVersionCleanupProperties
+import com.netflix.spinnaker.moniker.Namer
+import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
+import org.springframework.scheduling.TaskScheduler
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class PluginVersionCleanupAgentSpec extends Specification {
+
+  PluginVersionPinningRepository repository = Mock()
+  PluginVersionCleanupProperties properties = new PluginVersionCleanupProperties()
+  Namer namer = new FriggaReflectiveNamer()
+  TaskScheduler scheduler = Mock()
+
+  def "schedules on creation"() {
+    given:
+    PluginVersionCleanupAgent subject = new PluginVersionCleanupAgent(repository, properties, namer, scheduler)
+
+    when:
+    subject.schedule()
+
+    then:
+    1 * scheduler.scheduleWithFixedDelay(subject, properties.interval)
+  }
+
+  def "cleans up old versions"() {
+    given:
+    PluginVersionCleanupAgent subject = new PluginVersionCleanupAgent(repository, properties, namer, scheduler)
+
+    when:
+    subject.run()
+
+    then:
+    1 * repository.all() >> [
+      serverGroupPluginVersions("orca-main", "us-west-2", 11),
+      serverGroupPluginVersions("clouddriver-main", "us-west-2", 3),
+      serverGroupPluginVersions("orca-main", "us-east-1", 5)
+    ].flatten()
+    1 * repository.bulkDelete(["orca-main-v000-us-west-2"])
+    0 * _
+  }
+
+  private List<ServerGroupPluginVersions> serverGroupPluginVersions(String cluster, String location, int count) {
+    Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+
+    (0..count - 1).collect {
+      String sequence = "$it".padLeft(3, "0")
+      String serverGroupName = "$cluster-v$sequence"
+      def versions = new ServerGroupPluginVersions("$serverGroupName-$location", serverGroupName, location, [:])
+      versions.createTs = clock.instant().plusMillis(it).toEpochMilli()
+      versions
+    }
+  }
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningServiceSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model.plugins
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PluginVersionPinningServiceSpec extends Specification {
+
+  PluginVersionPinningRepository versionRepository = Mock()
+  PluginInfoRepository infoRepository = Mock()
+
+  @Subject PluginVersionPinningService subject = new PluginVersionPinningService(versionRepository, infoRepository)
+
+  def "pins versions"() {
+    given:
+    def serviceName = "orca"
+    def serverGroupName = "orca-v000"
+    def location = "us-west-2"
+    def id = "$serviceName-$serverGroupName-$location"
+    def versions = [
+      "foo": "1.0.0",
+      "bar": "1.0.0"
+    ]
+
+    def result
+
+    when:
+    result = subject.pinVersions(serviceName, serverGroupName, "us-west-2", versions)
+
+    then:
+    result.foo.version == "1.0.0"
+    result.bar.version == "1.0.0"
+    1 * versionRepository.findById(id) >> null
+    1 * versionRepository.create(id, _)
+    1 * infoRepository.findById("foo") >> pluginInfo("foo", "1.0.0")
+    1 * infoRepository.findById("bar") >> pluginInfo("bar", "1.0.0")
+    0 * _
+
+    when:
+    versions.foo = "1.0.1"
+    result = subject.pinVersions(serviceName, serverGroupName, location, versions)
+
+    then:
+    result.foo.version == "1.0.0"
+    result.foo.version == "1.0.0"
+    1 * versionRepository.findById(id) >> new ServerGroupPluginVersions(
+      id,
+      serverGroupName,
+      location,
+      [
+        foo: "1.0.0",
+        bar: "1.0.0"
+      ]
+    )
+    1 * infoRepository.findById("foo") >> pluginInfo("foo", "1.0.0")
+    1 * infoRepository.findById("bar") >> pluginInfo("bar", "1.0.0")
+    0 * _
+  }
+
+  private static PluginInfo pluginInfo(String id, String version) {
+    new PluginInfo(id: id).tap {
+      releases.add(new PluginInfo.Release(version: version))
+    }
+  }
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasCanonicalPluginIdValidatorSpec.groovy
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.front50.validator
 
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo
 import org.springframework.validation.Errors
 import spock.lang.Specification
 import spock.lang.Subject

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/HasValidRequiresFieldsValidatorSpec.groovy
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.front50.validator
 
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.front50.model.ObjectType.NOTIFICATION
 import com.netflix.spinnaker.front50.model.ObjectType.PIPELINE
 import com.netflix.spinnaker.front50.model.ObjectType.PIPELINE_TEMPLATE
 import com.netflix.spinnaker.front50.model.ObjectType.PLUGIN_INFO
+import com.netflix.spinnaker.front50.model.ObjectType.PLUGIN_VERSIONS
 import com.netflix.spinnaker.front50.model.ObjectType.PROJECT
 import com.netflix.spinnaker.front50.model.ObjectType.SERVICE_ACCOUNT
 import com.netflix.spinnaker.front50.model.ObjectType.SNAPSHOT
@@ -76,7 +77,8 @@ class SqlStorageService(
       SNAPSHOT to DefaultTableDefinition(SNAPSHOT, "snapshots", false),
       ENTITY_TAGS to DefaultTableDefinition(ENTITY_TAGS, "entity_tags", false),
       DELIVERY to DeliveryTableDefinition(),
-      PLUGIN_INFO to DefaultTableDefinition(PLUGIN_INFO, "plugin_info", false)
+      PLUGIN_INFO to DefaultTableDefinition(PLUGIN_INFO, "plugin_info", false),
+      PLUGIN_VERSIONS to DefaultTableDefinition(PLUGIN_VERSIONS, "plugin_versions", false)
     )
   }
 

--- a/front50-sql/src/main/resources/db/changelog-master.yml
+++ b/front50-sql/src/main/resources/db/changelog-master.yml
@@ -47,3 +47,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200113-rename-plugin-artifacts-to-plugin-info.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200428-initial-plugin-versions-schema.yml
+      relativeToChangelogFile: true

--- a/front50-sql/src/main/resources/db/changelog/20200428-initial-plugin-versions-schema.yml
+++ b/front50-sql/src/main/resources/db/changelog/20200428-initial-plugin-versions-schema.yml
@@ -1,0 +1,69 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-plugin-versions-table
+      author: robzienert
+      changes:
+        - createTable:
+            tableName: plugin_versions
+            columns:
+              - column:
+                  name: id
+                  type: char(255)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: body
+                  type: longtext
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_modified_at
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_modified_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci"
+      rollback:
+        - dropTable:
+            tableName: plugin_versions
+  - changeSet:
+      id: plugin-versions-is-deleted-index
+      author: rzienert
+      changes:
+        - createIndex:
+            indexName: is_deleted_plugin_versions_idx
+            tableName: plugin_versions
+            columns:
+              - column:
+                  name: is_deleted
+  - changeSet:
+      preConditions:
+        onFail: CONTINUE
+        dbms:
+          type: postgresql
+      id: modify-plugin-versions-id-to-varchar
+      author: rzienert
+      changes:
+        - modifyDataType:
+            columnName: id
+            newDataType: varchar(255)
+            tableName: plugin_versions

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginInfoController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginInfoController.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.spinnaker.front50.controllers;
 
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfo;
-import com.netflix.spinnaker.front50.model.plugininfo.PluginInfoService;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfoService;
 import java.util.Collection;
 import java.util.Optional;
 import org.springframework.http.HttpStatus;

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginVersionController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginVersionController.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.controllers;
+
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.PluginVersionPinningService;
+import java.util.Map;
+import lombok.Value;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/pluginVersions")
+public class PluginVersionController {
+
+  private final PluginVersionPinningService pluginVersionPinningService;
+
+  public PluginVersionController(PluginVersionPinningService pluginVersionPinningService) {
+    this.pluginVersionPinningService = pluginVersionPinningService;
+  }
+
+  @PutMapping("/{serverGroupName}")
+  Map<String, PluginInfo.Release> pinVersions(
+      @PathVariable String serverGroupName,
+      @RequestParam String location,
+      @RequestParam String serviceName,
+      @RequestBody PinnedVersions pinnedVersions) {
+    return pluginVersionPinningService.pinVersions(
+        serviceName, location, serverGroupName, pinnedVersions.pluginVersions);
+  }
+
+  @Value
+  public static class PinnedVersions {
+    Map<String, String> pluginVersions;
+  }
+}


### PR DESCRIPTION
Adds new metadata store for pinning plugin versions to a server group. This
ensures a server group will continue to load the same plugins even through
instance replacement on long-lived server groups.

Metadata is regularly cleaned up, leaving the last N records for a particular
cluster, by default leaving the last 10 (which is likely excessive).