### PR TITLE
chore(s3): Add deafult rootFolder name

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.front50.config;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public abstract class S3Properties extends S3BucketProperties {
-  String rootFolder;
+  String rootFolder = "front50";
 
   @NestedConfigurationProperty S3FailoverProperties failover = new S3FailoverProperties();
 


### PR DESCRIPTION
This was being defaulted by Halyard, but will no longer be defaulted by kleat; add this default to front50 so that users using kleat get the same default as Halyard users. This doesn't affect users who explicitly specify it (or Halyard users as Halyard always explicitly defaults the field).
