### PR TITLE
fix(plugins): Serde and API simplication, handling checked exceptions

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/ServerGroupPluginVersions.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/plugins/ServerGroupPluginVersions.java
@@ -38,6 +38,21 @@ public class ServerGroupPluginVersions
 
   private String lastModifiedBy;
 
+  public ServerGroupPluginVersions() {
+    // Jackson
+  }
+
+  public ServerGroupPluginVersions(
+      @Nonnull String id,
+      @Nonnull String serverGroupName,
+      @Nonnull String location,
+      @Nonnull Map<String, String> pluginVersions) {
+    this.id = id;
+    this.serverGroupName = serverGroupName;
+    this.location = location;
+    this.pluginVersions = pluginVersions;
+  }
+
   @Override
   public int compareTo(@Nonnull ServerGroupPluginVersions o) {
     return createTs.compareTo(o.createTs);

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginVersionPinningServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.front50.model.plugins
 
+import com.netflix.spinnaker.front50.exception.NotFoundException
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -45,7 +46,7 @@ class PluginVersionPinningServiceSpec extends Specification {
     then:
     result.foo.version == "1.0.0"
     result.bar.version == "1.0.0"
-    1 * versionRepository.findById(id) >> null
+    1 * versionRepository.findById(id) >> { throw new NotFoundException("booo") }
     1 * versionRepository.create(id, _)
     1 * infoRepository.findById("foo") >> pluginInfo("foo", "1.0.0")
     1 * infoRepository.findById("bar") >> pluginInfo("bar", "1.0.0")

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginVersionController.java
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PluginVersionController.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.front50.controllers;
 import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
 import com.netflix.spinnaker.front50.model.plugins.PluginVersionPinningService;
 import java.util.Map;
-import lombok.Value;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -36,13 +35,8 @@ public class PluginVersionController {
       @PathVariable String serverGroupName,
       @RequestParam String location,
       @RequestParam String serviceName,
-      @RequestBody PinnedVersions pinnedVersions) {
+      @RequestBody Map<String, String> pinnedVersions) {
     return pluginVersionPinningService.pinVersions(
-        serviceName, location, serverGroupName, pinnedVersions.pluginVersions);
-  }
-
-  @Value
-  public static class PinnedVersions {
-    Map<String, String> pluginVersions;
+        serviceName, location, serverGroupName, pinnedVersions);
   }
 }


### PR DESCRIPTION
Fixes some Jackson issues and handles those stupid `NotFoundException` checked exceptions that Front50 is so fond of using.