### PR TITLE
chore(gcs): Add deafult rootFolder name

### DIFF
--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsProperties.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsProperties.java
@@ -24,7 +24,7 @@ public class GcsProperties {
 
   private String bucketLocation;
 
-  private String rootFolder;
+  private String rootFolder = "front50";
 
   private String jsonPath = "";
 


### PR DESCRIPTION
This was being defaulted by Halyard, but will no longer be defaulted by kleat; add this default to front50 so that users using kleat get the same default as Halyard users. This doesn't affect users who explicitly specify it (or Halyard users as Halyard always explicitly defaults the field).