### PR TITLE
fix(auth): cleanup AuthenticatedRequest call, remove unnecessary parameter.

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -257,7 +257,6 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
                                       update(item.getId(), item);
                                       return Observable.just(item);
                                     },
-                                    true,
                                     authenticatedUser)
                                 .call();
                           } catch (Exception e) {


### PR DESCRIPTION
Restoring the context is the default behavior