### PR TITLE
perf(sql): Support for bulk sql imports

### DIFF
--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/BulkStorageService.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/BulkStorageService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.model;
+
+import java.util.Collection;
+
+public interface BulkStorageService {
+  <T extends Timestamped> void storeObjects(ObjectType objectType, Collection<T> items);
+}

--- a/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -244,6 +244,20 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
     User authenticatedUser = new User();
     authenticatedUser.setUsername(AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
 
+    if (service instanceof BulkStorageService) {
+      String lastModifiedBy = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous");
+      Long lastModified = System.currentTimeMillis();
+
+      items.forEach(
+          item -> {
+            item.setLastModifiedBy(lastModifiedBy);
+            item.setLastModified(lastModified);
+          });
+
+      ((BulkStorageService) service).storeObjects(objectType, items);
+      return;
+    }
+
     Observable.from(items)
         .buffer(10)
         .flatMap(

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/EntityTagsController.groovy
@@ -87,7 +87,7 @@ class EntityTagsController {
     }
 
     taggedEntityDAO.bulkImport(tags)
-    return findAllByIds(tags.findResults { it.id })
+    return tags;
   }
 
   @RequestMapping(value = "/batchDelete", method = RequestMethod.POST)
@@ -106,13 +106,5 @@ class EntityTagsController {
 
     taggedEntityDAO.delete(tagId)
     response.setStatus(HttpStatus.NO_CONTENT.value())
-  }
-
-  private Set<EntityTags> findAllByIds(Collection<String> ids) {
-    return ids.findResults {
-      try {
-        taggedEntityDAO.findById(it)
-      } catch (ignored) {}
-    }
   }
 }


### PR DESCRIPTION
This PR also adjusts the bulk import behavior for entity
tags to avoid a one-by-one fetch after the import succeeds.

Given our use-cases, I believe this unnecessarily adds to the
import time.
