### PR TITLE
fix(fiat): only attempt to sync permissions when fiat is enabled

### DIFF
--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/config/Front50WebConfig.groovy
@@ -20,6 +20,8 @@ import com.netflix.hystrix.exception.HystrixRuntimeException
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig
 import com.netflix.spinnaker.fiat.shared.FiatAccessDeniedExceptionHandler
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO
@@ -29,6 +31,7 @@ import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
 import com.netflix.spinnaker.front50.model.project.ProjectDAO
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
 import com.netflix.spinnaker.kork.web.context.RequestContextProvider
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
@@ -142,6 +145,13 @@ public class Front50WebConfig extends WebMvcConfigurerAdapter {
   @Bean
   RequestContextProvider requestContextProvider() {
     return new AuthenticatedRequestContextProvider()
+  }
+
+  @Bean
+  FiatStatus fiatStatus(DynamicConfigService dynamicConfigService,
+                        Registry registry,
+                        FiatClientConfigurationProperties fiatClientConfigurationProperties) {
+    return new FiatStatus(registry, dynamicConfigService, fiatClientConfigurationProperties)
   }
 
   @ControllerAdvice

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -1,7 +1,9 @@
 package com.netflix.spinnaker.front50.controllers.v2
 
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.front50.ServiceAccountsService
+import com.netflix.spinnaker.front50.config.FiatConfigurationProperties
 import com.netflix.spinnaker.front50.controllers.exception.InvalidApplicationRequestException
 import com.netflix.spinnaker.front50.events.ApplicationEventListener
 import com.netflix.spinnaker.front50.exception.NotFoundException
@@ -67,6 +69,12 @@ public class ApplicationsController {
   @Autowired
   Optional<ServiceAccountsService> serviceAccountsService;
 
+  @Autowired
+  FiatClientConfigurationProperties fiatClientConfigurationProperties;
+
+  @Autowired
+  FiatConfigurationProperties fiatConfigurationProperties;
+
   @PreAuthorize("#restricted ? @fiatPermissionEvaluator.storeWholePermission() : true")
   @PostFilter("#restricted ? hasPermission(filterObject.name, 'APPLICATION', 'READ') : true")
   @ApiOperation(value = "", notes = """Fetch all applications.
@@ -107,10 +115,12 @@ public class ApplicationsController {
   @RequestMapping(method = RequestMethod.POST)
   Application create(@RequestBody final Application app) {
     Application createdApplication = getApplication().initialize(app).withName(app.getName()).save()
-    try {
-      fiatService.ifPresent { it.sync() }
-    } catch (Exception ignored) {
-      log.warn("failed to trigger fiat permission sync", ignored)
+    if (fiatClientConfigurationProperties.isEnabled() && fiatConfigurationProperties.getRoleSync().isEnabled() && fiatService.isPresent()) {
+      try {
+        fiatService.get().sync()
+      } catch (Exception ignored) {
+        log.warn("failed to trigger fiat permission sync", ignored)
+      }
     }
     return createdApplication
   }

--- a/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
+++ b/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.groovy
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.front50.controllers.v2
 
-import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatService
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.front50.ServiceAccountsService
 import com.netflix.spinnaker.front50.config.FiatConfigurationProperties
 import com.netflix.spinnaker.front50.controllers.exception.InvalidApplicationRequestException
@@ -70,10 +70,10 @@ public class ApplicationsController {
   Optional<ServiceAccountsService> serviceAccountsService;
 
   @Autowired
-  FiatClientConfigurationProperties fiatClientConfigurationProperties;
+  FiatConfigurationProperties fiatConfigurationProperties;
 
   @Autowired
-  FiatConfigurationProperties fiatConfigurationProperties;
+  FiatStatus fiatStatus;
 
   @PreAuthorize("#restricted ? @fiatPermissionEvaluator.storeWholePermission() : true")
   @PostFilter("#restricted ? hasPermission(filterObject.name, 'APPLICATION', 'READ') : true")
@@ -115,7 +115,7 @@ public class ApplicationsController {
   @RequestMapping(method = RequestMethod.POST)
   Application create(@RequestBody final Application app) {
     Application createdApplication = getApplication().initialize(app).withName(app.getName()).save()
-    if (fiatClientConfigurationProperties.isEnabled() && fiatConfigurationProperties.getRoleSync().isEnabled() && fiatService.isPresent()) {
+    if (fiatStatus.isEnabled() && fiatConfigurationProperties.getRoleSync().isEnabled() && fiatService.isPresent()) {
       try {
         fiatService.get().sync()
       } catch (Exception ignored) {


### PR DESCRIPTION
In [this PR](https://github.com/spinnaker/front50/pull/619), we added logic to sync roles after an application is created. Let's only attempt to sync roles if the Fiat client is actually enabled. Elsewhere in Front50, such as in ApplicationPermissionsService.syncUsers, we only attempt to call Fiat to sync these roles if FiatClientConfigurationProperties is enabled, if FiatService is present, and if FiatConfigurationProperties.roleSync is enabled. Let's mirror this logic in the ApplicationsController.

cc @AbdulRahmanAlHamali 