### PR TITLE
fix(core): Support partial application model updates

### DIFF
--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationServiceSpec.groovy
@@ -64,6 +64,19 @@ class ApplicationServiceSpec extends Specification {
     1 * applicationDAO.update("OK", _)
   }
 
+  def "save should merge properties from existing record"() {
+    when:
+    Application result = subject.save(new Application(name: "foo"))
+
+    then:
+    1 * applicationDAO.findByName("FOO") >> new Application(
+      name: "foo",
+      email: "foo@example.com"
+    )
+    1 * applicationDAO.update("FOO", _)
+    result.email == "foo@example.com"
+  }
+
   def "save should merge details from existing record"() {
     when:
     Application result = subject.save(new Application(name: "foo", details: [one: "new"]))


### PR DESCRIPTION
I removed this behavior as part of removing the weird in-memory copy behavior
that Applications used thinking it was unnecessary. Turns out front50 allows
patch updates across the entire application model, but there were no tests
covering this feature.