### PR TITLE
feat(plugins): Upsert plugin info release endpoint

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PluginInfoController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PluginInfoController.java
@@ -76,6 +76,13 @@ public class PluginInfoController {
   }
 
   @PreAuthorize("@fiatPermissionEvaluator.isAdmin()")
+  @RequestMapping(value = "/{id}/releases", method = RequestMethod.PUT)
+  PluginInfo upsertRelease(
+      @PathVariable String id, @Valid @RequestBody PluginInfo.Release release) {
+    return pluginInfoService.upsertRelease(id, release);
+  }
+
+  @PreAuthorize("@fiatPermissionEvaluator.isAdmin()")
   @RequestMapping(value = "/{id}/releases/{releaseVersion}", method = RequestMethod.PUT)
   PluginInfo.Release preferReleaseVersion(
       @PathVariable String id,


### PR DESCRIPTION
This endpoint shouldn't be used much if things are working well, but it can be useful here and there to modify an existing release.  

Admin required.