### PR TITLE
fix(authz): Activate the RunAsUserToPermissionsMigration again

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigration.java
@@ -11,9 +11,6 @@ import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
 import com.netflix.spinnaker.front50.model.pipeline.Trigger;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount;
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO;
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.Month;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -32,16 +29,12 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty("migrations.migrate-to-managed-service-accounts")
 public class RunAsUserToPermissionsMigration implements Migration {
 
-  // Only valid until April 1, 2020
-  private static final LocalDate VALID_UNTIL = LocalDate.of(2020, Month.APRIL, 1);
-
   private static final String SERVICE_ACCOUNT_SUFFIX = "@managed-service-account";
   private static final String RUN_AS_USER = "runAsUser";
   private static final String ROLES = "roles";
 
   private final PipelineDAO pipelineDAO;
   private final ServiceAccountDAO serviceAccountDAO;
-  private Clock clock = Clock.systemDefaultZone();
 
   @Autowired
   public RunAsUserToPermissionsMigration(
@@ -52,7 +45,7 @@ public class RunAsUserToPermissionsMigration implements Migration {
 
   @Override
   public boolean isValid() {
-    return LocalDate.now(clock).isBefore(VALID_UNTIL);
+    return true;
   }
 
   @Override
@@ -137,9 +130,5 @@ public class RunAsUserToPermissionsMigration implements Migration {
     }
     String pipelineName = pipeline.getId();
     return pipelineName.toLowerCase() + SERVICE_ACCOUNT_SUFFIX;
-  }
-
-  void setClock(Clock clock) {
-    this.clock = clock;
   }
 }

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RunAsUserToPermissionsMigrationSpec.groovy
@@ -10,11 +10,6 @@ import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccount
 import com.netflix.spinnaker.front50.model.serviceaccount.ServiceAccountDAO
 import spock.lang.Specification
 import spock.lang.Subject
-import spock.lang.Unroll
-
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
 
 class RunAsUserToPermissionsMigrationSpec extends Specification {
   PipelineDAO pipelineDAO = Mock()
@@ -22,31 +17,6 @@ class RunAsUserToPermissionsMigrationSpec extends Specification {
 
   @Subject
   def migration = new RunAsUserToPermissionsMigration(pipelineDAO, serviceAccountDAO)
-
-  def setup() {
-    migration.setClock(Clock.fixed(Instant.parse("2019-04-01T10:15:30.00Z"), ZoneId.of("Z")))
-  }
-
-  @Unroll
-  def "should #shouldRun migration if time is #date"() {
-    given:
-    migration.setClock(Clock.fixed(Instant.parse(date), ZoneId.of("Z")))
-
-    when:
-    def valid = migration.isValid()
-
-    then:
-    valid == expectedValid
-
-    where:
-    date                      || expectedValid
-    "2019-04-01T10:15:30.00Z" || true
-    "2020-03-31T23:59:59.99Z" || true
-    "2020-04-01T00:00:00.00Z" || false
-    "2020-04-02T10:15:30.00Z" || false
-    shouldRun = "${expectedValid ? '' : 'not '}run"
-
-  }
 
   def "should migrate pipeline if one trigger is missing automatic service user"() {
     given:


### PR DESCRIPTION
Because the migration is already feature flagged, I think there is no need to expire this migration by using a hard coded date.