### PR TITLE
fix(provider/Oracle):Cache issue related to Oracle Object Storage

### DIFF
--- a/front50-oracle/front50-oracle.gradle
+++ b/front50-oracle/front50-oracle.gradle
@@ -3,7 +3,7 @@ dependencies {
 
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.oracle.oci.sdk:oci-java-sdk-objectstorage:1.5.2"
+  implementation "com.oracle.oci.sdk:oci-java-sdk-objectstorage:1.19.1"
   implementation "com.sun.jersey:jersey-client"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
+++ b/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
@@ -6,8 +6,6 @@
  * If a copy of the Apache License Version 2.0 was not distributed with this file,
  * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
  */
-// changed timeCreated() to timeModified() in code below to fix pipeline issue
-
 package com.netflix.spinnaker.front50.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
+++ b/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
@@ -215,7 +215,7 @@ public class OracleStorageService implements StorageService {
         client.resource(
             UriBuilder.fromPath(endpoint + "/n/{arg1}/b/{arg2}/o")
                 .queryParam("prefix", objectType.group)
-                .queryParam("fields", "name,timeCreated")
+                .queryParam("fields", "name,timeModified")
                 .build(region, namespace, bucketName));
     wr.accept(MediaType.APPLICATION_JSON_TYPE);
     ListObjects listObjects = wr.get(ListObjects.class);
@@ -223,7 +223,7 @@ public class OracleStorageService implements StorageService {
     for (ObjectSummary summary : listObjects.getObjects()) {
       if (summary.getName().endsWith(objectType.defaultMetadataFilename)) {
         results.put(
-            buildObjectKey(objectType, summary.getName()), summary.getTimeCreated().getTime());
+            buildObjectKey(objectType, summary.getName()), summary.getTimeModified().getTime());
       }
     }
     return results;
@@ -258,6 +258,9 @@ public class OracleStorageService implements StorageService {
     wr.accept(MediaType.APPLICATION_JSON_TYPE);
     try {
       byte[] bytes = objectMapper.writeValueAsBytes(new LastModified());
+      // convert byte array to string
+      // print out the output
+
       wr.put(new String(bytes, StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
+++ b/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
@@ -6,6 +6,8 @@
  * If a copy of the Apache License Version 2.0 was not distributed with this file,
  * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
  */
+// changed timeCreated() to timeModified() in code below to fix pipeline issue
+
 package com.netflix.spinnaker.front50.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -258,9 +260,6 @@ public class OracleStorageService implements StorageService {
     wr.accept(MediaType.APPLICATION_JSON_TYPE);
     try {
       byte[] bytes = objectMapper.writeValueAsBytes(new LastModified());
-      // convert byte array to string
-      // print out the output
-
       wr.put(new String(bytes, StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Related tickets: spinnaker/spinnaker#5035
This pull request is to introduce changes made that fix an issue related to Oracle Object Storage and the Spinnaker pipeline. Prior to these changes any edits made to the deployment pipeline would not be persisted using Oracle Object Storage. The changes introduced in this PR resolved those issues such that the previous caching issues seem to be gone. The difference can be observed below in the code.