### PR TITLE
fix(dependencies): depend on only swagger-annotations for compile

### DIFF
--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -39,8 +39,8 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-web"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
-  implementation "com.netflix.spinnaker.kork:kork-swagger"
   implementation "com.squareup.retrofit:converter-jackson"
+  implementation "io.swagger:swagger-annotations"
   implementation "commons-codec:commons-codec"
 
   runtimeOnly "com.netflix.spinnaker.kork:kork-runtime"


### PR DESCRIPTION
kork-runtime brings in kork-swagger for the runtime component configuration