### PR TITLE
fix(sql): Fix bulk store objects JOOQ api to support both MySQL and P…

### DIFF
--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -184,7 +184,8 @@ class SqlStorageService(
                     *insertPairs.keys.map { DSL.field(it) }.toTypedArray()
                   )
                     .values(insertPairs.values)
-                    .onDuplicateKeyUpdate()
+                    .onConflict(DSL.field("id", String::class.java))
+                    .doUpdate()
                     .set(updatePairs.mapKeys { DSL.field(it.key) })
                 }
               ).execute()

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -245,6 +245,36 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
           expectThrows<NotFoundException> {
             sqlStorageService.loadObject<EntityTags>(ObjectType.ENTITY_TAGS, "id-entitytags001")
           }
+
+          // Verify we can store more than object
+          sqlStorageService.storeObjects(
+            ObjectType.ENTITY_TAGS,
+            listOf(
+              EntityTags().apply {
+                id = "id-entitytags1of1"
+                lastModified = 100
+                lastModifiedBy = "anonymous"
+                entityRef = EntityTags.EntityRef().apply {
+                  entityId = "application001"
+                }
+              },
+              EntityTags().apply {
+                id = "id-entitytags1of2"
+                lastModified = 100
+                lastModifiedBy = "anonymous"
+                entityRef = EntityTags.EntityRef().apply {
+                  entityId = "application001"
+                }
+              }
+
+            )
+          )
+          // Retrieve tags saved above
+          entityTags = sqlStorageService.loadObject<EntityTags>(ObjectType.ENTITY_TAGS, "id-entitytags1of1")
+          expectThat(entityTags.id).isEqualTo("id-entitytags1of1")
+
+          entityTags = sqlStorageService.loadObject<EntityTags>(ObjectType.ENTITY_TAGS, "id-entitytags1of2")
+          expectThat(entityTags.id).isEqualTo("id-entitytags1of2")
         }
       }
     }


### PR DESCRIPTION
- Fixed JOOQ api to store more than one object for both MySQL and Postgres.
- Test goes against MySQL and Postgres test container and validates JOOQ generates the correct SQL that works for both the Dialects.