### PR TITLE
refactor(spring config): simplify the DAO config

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @ConditionalOnExpression("${spinnaker.azs.enabled:false}")
 @EnableConfigurationProperties(AzureStorageProperties.class)
-public class AzureStorageConfig extends CommonStorageServiceDAOConfig {
+public class AzureStorageConfig {
   @Bean
   @ConditionalOnMissingBean(RestTemplate.class)
   public RestTemplate restTemplate() {

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -50,8 +50,10 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import java.util.concurrent.Executors;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import rx.schedulers.Schedulers;
 
+@Configuration
 public class CommonStorageServiceDAOConfig {
   @Bean
   @ConditionalOnMissingBean(ObjectKeyLoader.class)
@@ -79,6 +81,7 @@ public class CommonStorageServiceDAOConfig {
   }
 
   @Bean
+  @ConditionalOnMissingBean // GcsConfig overrides this
   ApplicationPermissionDAO applicationPermissionDAO(
       StorageService storageService,
       StorageServiceConfigurationProperties storageServiceConfigurationProperties,

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.front50.config;
 import static net.logstash.logback.argument.StructuredArguments.value;
 
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.front50.model.*;
+import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader;
+import com.netflix.spinnaker.front50.model.GcsStorageService;
+import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
 import com.netflix.spinnaker.front50.model.application.DefaultApplicationPermissionDAO;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -41,7 +43,8 @@ import rx.schedulers.Schedulers;
 @Configuration
 @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
 @EnableConfigurationProperties(GcsProperties.class)
-public class GcsConfig extends CommonStorageServiceDAOConfig {
+public class GcsConfig {
+
   @Value("${spinnaker.gcs.safe-retry.max-wait-interval-ms:60000}")
   int maxWaitInterval;
 
@@ -142,11 +145,9 @@ public class GcsConfig extends CommonStorageServiceDAOConfig {
     return new RestTemplate();
   }
 
-  @Override
+  @Bean
   public ApplicationPermissionDAO applicationPermissionDAO(
-      StorageService storageService,
       StorageServiceConfigurationProperties storageServiceConfigurationProperties,
-      ObjectKeyLoader objectKeyLoader,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     GcsStorageService service =

--- a/front50-oracle/src/main/java/com/netflix/spinnaker/front50/config/OracleConfig.java
+++ b/front50-oracle/src/main/java/com/netflix/spinnaker/front50/config/OracleConfig.java
@@ -20,7 +20,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @ConditionalOnExpression("${spinnaker.oracle.enabled:false}")
 @EnableConfigurationProperties(OracleProperties.class)
-public class OracleConfig extends CommonStorageServiceDAOConfig {
+public class OracleConfig {
 
   @Bean
   public OracleStorageService oracleStorageService(OracleProperties oracleProperties)

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnProperty("spinnaker.s3.enabled")
 @Import(BastionConfig.class)
 @EnableConfigurationProperties({S3MetadataStorageProperties.class, S3PluginStorageProperties.class})
-public class S3Config extends CommonStorageServiceDAOConfig {
+public class S3Config {
 
   @Bean
   @ConditionalOnProperty(value = "spinnaker.s3.storage-service.enabled", matchIfMissing = true)

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.model.SqlStorageService
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
 import com.netflix.spinnaker.kork.sql.config.SqlProperties
@@ -34,7 +33,7 @@ import org.springframework.context.annotation.Import
 @Configuration
 @ConditionalOnProperty("sql.enabled")
 @Import(DefaultSqlConfiguration::class)
-class SqlConfiguration : CommonStorageServiceDAOConfig() {
+class SqlConfiguration {
 
   @Bean
   fun sqlStorageService(

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.migrations.StorageServiceMigrator
 import com.netflix.spinnaker.front50.model.CompositeStorageService
@@ -64,7 +65,7 @@ internal class CompositeStorageServiceConfigurationTests {
 }
 
 @SpringBootApplication
-@Import(CompositeStorageServiceConfiguration::class, SqlConfiguration::class)
+@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class)
 @EnableConfigurationProperties(StorageServiceConfigurationProperties::class)
 internal class CompositeStorageServiceConfigurationTestApp {
   @Bean

--- a/front50-swift/src/main/java/com/netflix/spinnaker/front50/config/SwiftConfig.java
+++ b/front50-swift/src/main/java/com/netflix/spinnaker/front50/config/SwiftConfig.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @ConditionalOnExpression("${spinnaker.swift.enabled:false}")
 @EnableConfigurationProperties(SwiftProperties.class)
-public class SwiftConfig extends CommonStorageServiceDAOConfig {
+public class SwiftConfig {
 
   @Autowired Registry registry;
 


### PR DESCRIPTION
There's no reason for everyone to subclass this. It just binds a bunch of beans, it doesn't provide any functionality other than that, so just make it a `@Configuration` of its own.