### PR TITLE
fix(docs): update broken markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,20 @@ The following storage backends are supported:
 
 `SQL` is a cloud agnostic storage backend that offers strong read-after-write consistency and metadata versioning.
 
-
 ### Metadata
 
 The following types are represented in Front50 ([data models](https://github.com/spinnaker/front50/tree/master/front50-core/src/main/groovy/com/netflix/spinnaker/front50/model)):
 
-| *Type* | *Description* |
-| ------ | ------------- |
-| Application | Defines a set of commonly named resources managed by Spinnaker (metadata includes name, ownership, description, source code repository, etc.). |
-| Application Permission | Defines the group memberships required to read/write any application resource. |
-| Entity Tags | Provides a general purpose and cloud agnostic tagging mechanism. |
-| Notification | Defines application-wide notification schemes (email, slack and sms). |
-| Pipeline | Defines a reusable delivery workflow (exists within the context of a specific application). |
-| Pipeline Strategy | Defines a custom deployment strategy (exists within the context of a specific application). |
-| Project | Provides a (many-to-many) grouping mechanism for multiple applications. |
-| Service Account | Defines a system identity (with group memberships) that can be associated with one or more pipeline triggers. |
-
+|         *Type*         |                                                                 *Description*                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Application            | Defines a set of commonly named resources managed by Spinnaker (metadata includes name, ownership, description, source code repository, etc.). |
+| Application Permission | Defines the group memberships required to read/write any application resource.                                                                 |
+| Entity Tags            | Provides a general purpose and cloud agnostic tagging mechanism.                                                                               |
+| Notification           | Defines application-wide notification schemes (email, slack and sms).                                                                          |
+| Pipeline               | Defines a reusable delivery workflow (exists within the context of a specific application).                                                    |
+| Pipeline Strategy      | Defines a custom deployment strategy (exists within the context of a specific application).                                                    |
+| Project                | Provides a (many-to-many) grouping mechanism for multiple applications.                                                                        |
+| Service Account        | Defines a system identity (with group memberships) that can be associated with one or more pipeline triggers.                                  |
 
 ### Domain
 
@@ -44,15 +42,15 @@ Migrators for non-trivial attribute changes are supported via implementations of
 
 The `StorageServiceSupport` class maintains an in-memory cache for each metadata type and delegates read/write operations to a storage backend-specific `StorageService` implementation.
 
-
 ### Relevant Metrics
 
 The following metrics are relevant to overall `Front50` health:
 
-| *Metric* | *Description* | *Grouping* |
-| `controller.invocations` (count) | Invocation counts. | `controller` |
-| `controller.invocations` (average) | Invocation times. | `controller`, `statusCode` and `method` |
-| `controller.invocations` (count) | All 5xx responses. | `controller`, `statusCode` and `status` = `5xx` |
+|              *Metric*              |   *Description*    |                   *Grouping*                    |
+| ---------------------------------- | ------------------ | ----------------------------------------------- |
+| `controller.invocations` (count)   | Invocation counts. | `controller`                                    |
+| `controller.invocations` (average) | Invocation times.  | `controller`, `statusCode` and `method`         |
+| `controller.invocations` (count)   | All 5xx responses. | `controller`, `statusCode` and `status` = `5xx` |
 
 ## Debugging
 
@@ -66,7 +64,6 @@ the debugger to be attached before starting Front50; the relevant JVM arguments 
 modified as needed in `build.gradle`.
 
 [0]:http://projects.spring.io/spring-boot/
-
 
 ### Modular builds
 


### PR DESCRIPTION
This PR fixes the broken markdown tables in README.md.

*Before*:

![Screenshot 2020-07-28 at 22 36 35](https://user-images.githubusercontent.com/21333876/88672821-df14d880-d122-11ea-96dc-e6c0a0ba6aee.png)

*After*:

![Screenshot 2020-07-28 at 22 36 51](https://user-images.githubusercontent.com/21333876/88672823-e0460580-d122-11ea-9201-4ff3bde50a20.png)