### PR TITLE
fix(misc): Recover application permission also when we undo delete op…

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/AdminOperations.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/AdminOperations.java
@@ -16,12 +16,16 @@
 
 package com.netflix.spinnaker.front50.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 public interface AdminOperations {
   void recover(Recover operation);
 
   @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
   class Recover {
     String objectType;
     String objectId;

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AdminController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AdminController.java
@@ -43,8 +43,7 @@ public class AdminController {
   @RequestMapping(value = "/recover", method = RequestMethod.POST)
   void recover(@RequestBody AdminOperations.Recover operation) {
     adminOperations.forEach(o -> o.recover(operation));
-    // If we are recovering application , recover application permission also. Without that
-    // subsequent CRUD operations on application will fail.
+    // Application permissions need to be recovered alongside the application itself.
     if (operation.getObjectType().equalsIgnoreCase(ObjectType.APPLICATION.clazz.getSimpleName())) {
       adminOperations.forEach(
           o ->

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AdminController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AdminController.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.controllers;
 
 import com.netflix.spinnaker.front50.model.AdminOperations;
+import com.netflix.spinnaker.front50.model.ObjectType;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.Collection;
@@ -42,5 +43,16 @@ public class AdminController {
   @RequestMapping(value = "/recover", method = RequestMethod.POST)
   void recover(@RequestBody AdminOperations.Recover operation) {
     adminOperations.forEach(o -> o.recover(operation));
+    // If we are recovering application , recover application permission also. Without that
+    // subsequent CRUD
+    // operations on application will fail.
+    if (operation.getObjectType().equalsIgnoreCase(ObjectType.APPLICATION.clazz.getSimpleName())) {
+      adminOperations.forEach(
+          o ->
+              o.recover(
+                  new AdminOperations.Recover(
+                      ObjectType.APPLICATION_PERMISSION.clazz.getSimpleName(),
+                      operation.getObjectId())));
+    }
   }
 }

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AdminController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AdminController.java
@@ -44,8 +44,7 @@ public class AdminController {
   void recover(@RequestBody AdminOperations.Recover operation) {
     adminOperations.forEach(o -> o.recover(operation));
     // If we are recovering application , recover application permission also. Without that
-    // subsequent CRUD
-    // operations on application will fail.
+    // subsequent CRUD operations on application will fail.
     if (operation.getObjectType().equalsIgnoreCase(ObjectType.APPLICATION.clazz.getSimpleName())) {
       adminOperations.forEach(
           o ->

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/AdminControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/AdminControllerSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.front50.controllers
+
+import com.netflix.spinnaker.front50.model.AdminOperations
+import com.netflix.spinnaker.front50.model.ObjectType
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AdminControllerSpec extends Specification {
+
+  AdminOperations adminOperations = Mock(AdminOperations)
+
+  @Subject
+  AdminController controller = new AdminController([adminOperations])
+
+
+  def 'should recover application and permission record'() {
+    given:
+    AdminOperations.Recover operation = new AdminOperations.Recover('application', 'test-app')
+
+    when:
+    controller.recover(operation)
+
+    then:
+    noExceptionThrown()
+    2 * adminOperations.recover(_) >> { AdminOperations.Recover op ->
+      assert op.objectId == 'test-app'
+      assert op.objectType.toLowerCase() in [ObjectType.APPLICATION.clazz.simpleName.toLowerCase(), ObjectType.APPLICATION_PERMISSION.clazz.simpleName.toLowerCase()]
+    }
+    0 * _
+  }
+
+}


### PR DESCRIPTION
- Currently for recovering a deleted application we need to call `/recover` endpoint for application and application permission separately and if missed to call for permission, we won't be able to perform any write operation on the application.  With this change, we recover permission record also along with application record.