### PR TITLE
feat(plugins): Add remote extensions field to a plugin info release

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/PluginInfo.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/PluginInfo.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.plugins;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Splitter;
 import com.netflix.spinnaker.front50.model.Timestamped;
+import com.netflix.spinnaker.front50.model.plugins.remote.RemoteExtension;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -181,6 +182,9 @@ public class PluginInfo implements Timestamped {
     public boolean supportsService(@Nonnull String service) {
       return getParsedRequires().stream().anyMatch(it -> it.getService().equalsIgnoreCase(service));
     }
+
+    /** Remote extensions associated with this plugin release. */
+    @Nonnull private List<RemoteExtension> remoteExtensions = new ArrayList<>();
   }
 
   @Data

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/remote/RemoteExtension.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/remote/RemoteExtension.java
@@ -10,12 +10,17 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
 
 /**
  * A Spinnaker plugin's remote extension configuration.
  *
  * <p>This model is used by Spinnaker to determine which extension points and services require
  * remote extension point configuration.
+ *
+ * <p>The plugin release {@link PluginInfo.Release#requires} field is used to inform Spinnaker which
+ * service to use in configuring the extension point {@link #type} and additionally if the remote
+ * extension is compatible with the running version of the Spinnaker service.
  */
 @Data
 @NoArgsConstructor
@@ -23,13 +28,11 @@ public class RemoteExtension {
 
   /**
    * The remote extension type. The remote extension is configured in the service that implements
-   * this extension type. The plugin release {@link PluginInfo.Release#requires} field is used to
-   * inform Spinnaker which service to use in configuring the remote extension type and if the
-   * remote extension is compatible with the running version of the Spinnaker service.
+   * this extension type.
    */
   @Nonnull private String type;
 
-  /** Identifier of the remote extension. Used for observability. */
+  /** Identifier of the remote extension. Used for tracing. */
   @Nonnull private String id;
 
   /**
@@ -61,7 +64,7 @@ public class RemoteExtension {
     public static class Http {
 
       /** URL for remote extension invocation. */
-      @Nonnull private String url;
+      @URL @Nonnull private String url;
 
       /** A placeholder for misc. configuration for the underlying HTTP client. */
       @Nonnull private Map<String, Object> config = new HashMap<>();

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/remote/RemoteExtension.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/remote/RemoteExtension.java
@@ -1,0 +1,70 @@
+package com.netflix.spinnaker.front50.model.plugins.remote;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.netflix.spinnaker.front50.model.plugins.PluginInfo;
+import com.netflix.spinnaker.front50.model.plugins.remote.stage.StageRemoteExtensionConfig;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A Spinnaker plugin's remote extension configuration.
+ *
+ * <p>This model is used by Spinnaker to determine which extension points and services require
+ * remote extension point configuration.
+ */
+@Data
+@NoArgsConstructor
+public class RemoteExtension {
+
+  /**
+   * The remote extension type. The remote extension is configured in the service that implements
+   * this extension type. The plugin release {@link PluginInfo.Release#requires} field is used to
+   * inform Spinnaker which service to use in configuring the remote extension type and if the
+   * remote extension is compatible with the running version of the Spinnaker service.
+   */
+  @Nonnull private String type;
+
+  /** Identifier of the remote extension. Used for observability. */
+  @Nonnull private String id;
+
+  /**
+   * Outbound transport configuration for the remote extension point; the protocol to address it
+   * with and the necessary configuration.
+   */
+  @Nonnull private RemoteExtensionTransport transport = new RemoteExtensionTransport();
+
+  /** Configures the remote extension point. */
+  @JsonTypeInfo(
+      use = JsonTypeInfo.Id.NAME,
+      include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+      property = "type")
+  @JsonSubTypes({@JsonSubTypes.Type(value = StageRemoteExtensionConfig.class, name = "stage")})
+  @Nullable
+  public RemoteExtensionConfig config;
+
+  /** Root remote extension configuration type. */
+  public interface RemoteExtensionConfig {}
+
+  @Data
+  @NoArgsConstructor
+  public static class RemoteExtensionTransport {
+
+    @Nonnull private Http http = new Http();
+
+    @Data
+    @NoArgsConstructor
+    public static class Http {
+
+      /** URL for remote extension invocation. */
+      @Nonnull private String url;
+
+      /** A placeholder for misc. configuration for the underlying HTTP client. */
+      @Nonnull private Map<String, Object> config = new HashMap<>();
+    }
+  }
+}

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/remote/stage/StageRemoteExtensionConfig.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/remote/stage/StageRemoteExtensionConfig.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.front50.model.plugins.remote.stage;
+
+import com.netflix.spinnaker.front50.model.plugins.remote.RemoteExtension.RemoteExtensionConfig;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class StageRemoteExtensionConfig implements RemoteExtensionConfig {
+
+  /** Represents stage type. */
+  @Nonnull private String type;
+
+  /** Label to use on the Spinnaker UI while configuring pipeline stages. */
+  @Nonnull private String label;
+
+  /** Description to use on the Spinnaker UI while configuring pipeline stages. */
+  @Nonnull private String description;
+
+  /** Map of stage parameter names and default values. */
+  @Nonnull private Map<String, Object> parameters = new HashMap<>();
+}

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/plugins/PluginInfoServiceSpec.groovy
@@ -17,6 +17,8 @@ package com.netflix.spinnaker.front50.model.plugins
 
 import com.netflix.spinnaker.front50.echo.EchoService
 import com.netflix.spinnaker.front50.exception.NotFoundException
+import com.netflix.spinnaker.front50.model.plugins.remote.RemoteExtension
+import com.netflix.spinnaker.front50.model.plugins.remote.stage.StageRemoteExtensionConfig
 import com.netflix.spinnaker.front50.plugins.PluginBinaryStorageService
 import com.netflix.spinnaker.front50.validator.PluginInfoValidator
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
@@ -58,7 +60,7 @@ class PluginInfoServiceSpec extends Specification {
     0 * repository.create(_, _)
   }
 
-  def "upsert with a new release for an existing plugin"() {
+  def "upsert with a new release for an existing plugin, new release contains remote extension configuration"() {
     given:
     PluginInfo currentPluginInfo = new PluginInfo(id: "foo.bar")
     currentPluginInfo.releases.add(new PluginInfo.Release(version: "1.0.0"))
@@ -66,6 +68,22 @@ class PluginInfoServiceSpec extends Specification {
     and:
     PluginInfo newPluginInfo = new PluginInfo(id: "foo.bar")
     newPluginInfo.releases.add(new PluginInfo.Release(version: "2.0.0"))
+    newPluginInfo.releases.get(0).remoteExtensions.add(
+      new RemoteExtension(
+        type: "stage",
+        id: "netflix.remote.remoteWait",
+        transport: new RemoteExtension.RemoteExtensionTransport(
+          http: new RemoteExtension.RemoteExtensionTransport.Http(
+            url: "http://example.com"
+          )
+        ),
+        config: new StageRemoteExtensionConfig(
+          type: "remoteWait",
+          label: "Wait on a remote service",
+          description: "A stage that waits on a remote service",
+          parameters: ["waitTime": 30, "message": "Done"]
+        )
+      ))
 
     when:
     PluginInfo persistedPluginInfo = subject.upsert(newPluginInfo)


### PR DESCRIPTION
In https://github.com/spinnaker/orca/pull/3840 I realized I had the cart before the horse on a few items, specifically the basic remote extension point configuration.  This will not only allow me to get away from abusing the PreconfiguredJob stuff even more (by allowing for specific remote stage configuration), but also lay some of the ground work for other types of remote extension points.

Adds a `remoteExtensions` field to a plugin info `release`.  A plugin that is just a remote extension look like this:

```
{
  "id": "netflix.remote",
  "description": "A remote plugin",
  "provider": "csmalley",
  "releases": [
    {
      "version": "0.0.1",
      "date": "2020-06-16T02:20:14.889Z",
      "requires": "orca>=1.0.0",
      "url": null,
      "sha512sum": null,
      "preferred": false,
      "lastModified": "2020-06-18T23:08:48.899Z",
      "lastModifiedBy": "csmalley",
      "remoteExtensions": [
        {
          "type": "stage",
          "id": "netflix.remote.remoteWait",
          "transport": {
            "http": {
              "url": "http://service.com/remoteWait",
              "config": {}
            }
          },
          "config": {
            "type": "remoteWait",
            "label": "Wait on a remote service",
            "description": "A stage that waits on a remote service",
            "parameters": {
              "waitTime": 30,
              "message": "done!"
            }
          }
        }
      ]
    }
  ]
}
```

The idea here is that we use the `requires` field in-conjunction with the remote extension `type` to determine which service to configure with the specific remote extension and corresponding remote extension configuration.