### PR TITLE
feat(test): add front50 test fixture

### DIFF
--- a/front50-api-tck/README.md
+++ b/front50-api-tck/README.md
@@ -1,0 +1,3 @@
+# front50-api-tck
+
+Test harnesses and utilities for Front50 plugin developers.

--- a/front50-api-tck/front50-api-tck.gradle
+++ b/front50-api-tck/front50-api-tck.gradle
@@ -1,0 +1,29 @@
+apply from: "${project.rootDir}/gradle/kotlin.gradle"
+
+dependencies {
+  implementation(project(":front50-web"))
+  implementation("com.h2database:h2")
+
+  api("org.springframework.boot:spring-boot-starter-test")
+  api("dev.minutest:minutest")
+
+  testImplementation(project(":front50-core"))
+  testImplementation(project(":front50-sql"))
+  testImplementation("io.strikt:strikt-core")
+
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines "junit-jupiter"
+  }
+}
+
+compileTestKotlin {
+  kotlinOptions {
+    languageVersion = "1.4"
+    jvmTarget = "1.8"
+  }
+}

--- a/front50-api-tck/src/main/kotlin/com/netflix/spinnaker/front50/api/test/Front50Fixture.kt
+++ b/front50-api-tck/src/main/kotlin/com/netflix/spinnaker/front50/api/test/Front50Fixture.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.front50.api.test
+
+import com.netflix.spinnaker.front50.Main
+import dev.minutest.TestContextBuilder
+import dev.minutest.TestDescriptor
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestContextManager
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Front50Fixture is the base configuration for a Front50 integration test.
+ *
+ * The fixture uses an embedded SQL instance as a backing store.
+ */
+@SpringBootTest(classes = [Main::class])
+@TestPropertySource(properties = ["spring.config.location=classpath:front50-test-app.yml"])
+@AutoConfigureTestDatabase
+abstract class Front50Fixture
+
+/**
+ * DSL for constructing a Front50Fixture within a Minutest suite.
+ */
+inline fun <PF, reified F> TestContextBuilder<PF, F>.front50Fixture(
+  crossinline factory: (Unit).(testDescriptor: TestDescriptor) -> F
+) {
+  fixture { testDescriptor ->
+    factory(testDescriptor).also {
+      TestContextManager(F::class.java).prepareTestInstance(it)
+    }
+  }
+}

--- a/front50-api-tck/src/main/resources/front50-test-app.yml
+++ b/front50-api-tck/src/main/resources/front50-test-app.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: front50
+  test:
+    database:
+      replace: none
+
+services:
+  fiat:
+    enabled: false
+    baseUrl: http://localhost:7003
+
+sql:
+  enabled: true
+  connectionPools:
+    default:
+      default: true
+      jdbcUrl: jdbc:h2:mem:testdb
+      user: sa
+  migration:
+    user: sa
+    jdbcUrl: jdbc:h2:mem:testdb

--- a/front50-api-tck/src/test/kotlin/com/netflix/spinnaker/front50/api/test/Front50FixtureTest.kt
+++ b/front50-api-tck/src/test/kotlin/com/netflix/spinnaker/front50/api/test/Front50FixtureTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.front50.api.test
+
+import com.netflix.spinnaker.front50.model.SqlStorageService
+import com.netflix.spinnaker.front50.model.StorageService
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.springframework.beans.factory.annotation.Autowired
+import strikt.api.expectThat
+import strikt.assertions.isA
+
+class Front50FixtureTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    context("a front50 integration test environment") {
+      front50Fixture {
+        Fixture()
+      }
+
+      test("service starts with SQL storage service") {
+        expectThat(storageService).isA<SqlStorageService>()
+      }
+    }
+  }
+
+  private inner class Fixture : Front50Fixture() {
+
+    @Autowired
+    lateinit var storageService: StorageService
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ enableFeaturePreview("VERSION_ORDERING_V2")
 rootProject.name = "front50"
 
 include 'front50-web',
+    'front50-api-tck',
     'front50-core',
     'front50-gcs',
     'front50-redis',


### PR DESCRIPTION
This is modeled after https://github.com/spinnaker/orca/tree/master/orca-api-tck and has the same purpose (letting plugin developers write Front50 integration tests).

I named the project `front50-api-tck`, following the pattern in Orca (and I'm opening PRs for test fixtures in the other projects). There's no corresponding `front50-api` subproject, which makes the name seem a little strange.  
