### PR TITLE
feat(plugins): make Front50 pluggable

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/config/Front50WebConfig.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/config/Front50WebConfig.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.config;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig;
 import com.netflix.spinnaker.fiat.shared.FiatAccessDeniedExceptionHandler;
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties;
@@ -43,6 +44,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -54,6 +56,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @ComponentScan
 @EnableFiatAutoConfig
 @EnableScheduling
+@Import({PluginsAutoConfiguration.class})
 @EnableConfigurationProperties(StorageServiceConfigurationProperties.class)
 public class Front50WebConfig extends WebMvcConfigurerAdapter {
 


### PR DESCRIPTION
Based on @jonsie's comment in https://github.com/spinnaker/front50/pull/949, I thought "of course Front50 is pluggable, we've written Front50 plugins!". 

It's true that Armory has written Front50 plugins and that they work for some range of Spinnaker versions, but it's also true that Front50 doesn't import `PluginsAutoConfiguration`, which is pretty confusing. 

It turns out that since `kork-plugins` ends up on the [classpath](https://github.com/spinnaker/front50/blob/master/front50-core/front50-core.gradle#L31) and since Front50 `Main` does a component scan of `com.netflix.spinnaker.config`, we used to get `PluginsAutoConfiguration` for free. I think we lost that behavior when the `@Configuration` annotation on `PluginsAutoConfiguration` [got dropped here](https://github.com/spinnaker/kork/pull/752/files#diff-abed1df5ae8a77ddedc0f40f1c6399acL77). Whoops.