### PR TITLE
fix(bug): Reject blank strings for pipeline name, application and als…

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -224,8 +225,7 @@ public class PipelineController {
    */
   private void validatePipeline(final Pipeline pipeline, Boolean staleCheck) {
     // Pipelines must have an application and a name
-    if (Strings.isNullOrEmpty(pipeline.getApplication())
-        || Strings.isNullOrEmpty(pipeline.getName())) {
+    if (StringUtils.isAnyBlank(pipeline.getApplication(), pipeline.getName())) {
       throw new InvalidEntityException("A pipeline requires name and application fields");
     }
 

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.netflix.spinnaker.front50.exception.BadRequestException;
 import com.netflix.spinnaker.front50.exceptions.DuplicateEntityException;
+import com.netflix.spinnaker.front50.exceptions.InvalidEntityException;
 import com.netflix.spinnaker.front50.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.front50.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
@@ -90,6 +91,10 @@ public class V2PipelineTemplateController {
       @RequestBody PipelineTemplate pipelineTemplate) {
     if (StringUtils.isNotEmpty(tag)) {
       validatePipelineTemplateTag(tag);
+    }
+
+    if (StringUtils.isBlank(pipelineTemplate.getId())) {
+      throw new InvalidEntityException("A pipeline template requires an id");
     }
 
     String templateId;

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -1,0 +1,89 @@
+package com.netflix.spinnaker.front50.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.mock.DetachedMockFactory
+
+import javax.servlet.http.HttpServletResponse
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = [PipelineController])
+@ContextConfiguration(classes = [TestConfiguration, PipelineController])
+class PipelineControllerSpec extends Specification {
+
+  @Autowired
+  private MockMvc mockMvc
+
+  @Unroll
+  def "should fail to save if application is missing, empty or blank"() {
+    given:
+    Map pipelineData = [
+      name: "some pipeline with no application",
+      application: application
+    ]
+
+    when:
+    HttpServletResponse response = mockMvc
+      .perform(
+        post("/pipelines")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(new ObjectMapper().writeValueAsString(pipelineData))
+      )
+      .andReturn()
+      .response
+
+    then:
+    response.status == HttpStatus.UNPROCESSABLE_ENTITY.value()
+
+    where:
+    application << [ null, "", "      "]
+  }
+
+  @Unroll
+  def "should fail to save if pipeline name is missing, empty or blank"() {
+    given:
+    Map pipelineData = [
+      name: name,
+      application: "some application"
+    ]
+
+    when:
+    HttpServletResponse response = mockMvc
+      .perform(
+        post("/pipelines")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(new ObjectMapper().writeValueAsString(pipelineData))
+      )
+      .andReturn()
+      .response
+
+    then:
+    response.status == HttpStatus.UNPROCESSABLE_ENTITY.value()
+
+    where:
+    name << [ null, "", "      "]
+  }
+
+  @Configuration
+  private static class TestConfiguration {
+      DetachedMockFactory detachedMockFactory = new DetachedMockFactory()
+      @Bean
+      PipelineDAO pipelineDAO() {
+        detachedMockFactory.Stub(PipelineDAO)
+      }
+  }
+
+}

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateControllerSpec.groovy
@@ -18,11 +18,13 @@
 package com.netflix.spinnaker.front50.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.exceptions.InvalidEntityException
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 class V2PipelineTemplateControllerSpec extends Specification {
   def pipelineDAO = Mock(PipelineDAO)
@@ -152,6 +154,18 @@ class V2PipelineTemplateControllerSpec extends Specification {
 
     then:
     hash1 == hash2
+  }
+
+  @Unroll
+  def 'should fail with InvalidEntityException if Id(#id) is not provided or empty'() {
+    when:
+    controller.save('latest', new PipelineTemplate(id: id))
+
+    then:
+    thrown(InvalidEntityException)
+
+    where:
+    id << [null, "", "    "]
   }
 }
 


### PR DESCRIPTION
- During create operations we are allowing `blank` strings for required attrs like (id, name and application) and the fix here is to reject null, empty and blank values for any of the required attrs.