### PR TITLE
feat(pipeline executions/front50) : Added code to save multiple pipelines at once to sql database.

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AuthorizationSupport.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AuthorizationSupport.java
@@ -87,4 +87,11 @@ public class AuthorizationSupport {
 
     return permissionEvaluator.hasPermission(auth, application, "APPLICATION", "EXECUTE");
   }
+
+  public boolean hasRunAsUserPermission(final List<Pipeline> pipelineList) {
+    for (Pipeline pipeline : pipelineList) {
+      return hasRunAsUserPermission(pipeline);
+    }
+    return true;
+  }
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.front50.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -84,6 +85,10 @@ class PipelineControllerSpec extends Specification {
       PipelineDAO pipelineDAO() {
         detachedMockFactory.Stub(PipelineDAO)
       }
+      @Bean
+      FiatPermissionEvaluator fiatPermissionEvaluator() {
+      detachedMockFactory.Stub(FiatPermissionEvaluator)
+    }
   }
 
 }

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.controllers
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.front50.ServiceAccountsService
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
@@ -55,10 +56,12 @@ abstract class PipelineControllerTck extends Specification {
   @Subject
   PipelineDAO pipelineDAO
   def serviceAccountsService
+  def fiatPermissionEvaluator
 
   void setup() {
     this.pipelineDAO = createPipelineDAO()
     this.serviceAccountsService = Mock(ServiceAccountsService)
+    this.fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
 
     mockMvc = MockMvcBuilders
       .standaloneSetup(
@@ -67,7 +70,8 @@ abstract class PipelineControllerTck extends Specification {
           new ObjectMapper(),
           Optional.of(serviceAccountsService),
           Collections.emptyList(),
-          Optional.empty()
+          Optional.empty(),
+          fiatPermissionEvaluator
         )
       )
       .setControllerAdvice(


### PR DESCRIPTION
feat(pipeline executions/front50) : Added code to save multiple pipelines at once to sql database.

This is part of: spinnaker/spinnaker#6147.

Enhanced PipelineController.java to

Added new rest api method bulksave(List<Map> pipelineList, Boolean staleCheck)
This method accepts a list of pipelines json.
This method checks each and every pipeline for authorization.
If the pipeline has valid authorization, then it will be saved to a savedPipelineList.
If the pipeline do not have a valid authorization, then it will be saved to a errorPipelineList
 and an error message is also populated.
All the savedPipelinesList will be saved to sql database using bulk insert.
This method returns a Map object having the below data:
{
  “Successful”: <count>,
  “Failed”: <cound>,
  “Failed_list”: [<array of failed pipelines - (application, pipeline name, etc) and the error message]
}

Enhanced AuthorizationSupport.java to

Added code to accept the pipeline list and authorize the pipelines.

Enhanced PipelineControllerSpec.java to

Added bean of FiatPermissionEvalutor.java as it is used in the PipelineController constructor.

Enhanced PipelineControllerTck.groovy to

Added bean of FiatPermissionEvalutor.java as it is used in the PipelineController constructor.

