### PR TITLE
feat(pipeline_template): Add support of semver for template tags

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Hex;
@@ -61,6 +63,9 @@ public class V2PipelineTemplateController {
   // TODO(jacobkiefer): (PLACEHOLDER) Decide on the final set of supported tags.
   private static final List<String> VALID_TEMPLATE_TAGS =
       Arrays.asList("latest", "stable", "unstable", "experimental", "test", "canary");
+
+  public static final Pattern VALID_TEMPLATE_TAG_PATTERN =
+      Pattern.compile("^v?[0-9]\\d*\\.\\d+\\.\\d+(?:-[a-zA-Z0-9]+)?$");
 
   @Autowired(required = false)
   PipelineTemplateDAO pipelineTemplateDAO = null;
@@ -257,10 +262,12 @@ public class V2PipelineTemplateController {
   }
 
   private void validatePipelineTemplateTag(String tag) {
-    if (!VALID_TEMPLATE_TAGS.contains(tag)) {
+    Matcher m = VALID_TEMPLATE_TAG_PATTERN.matcher(tag);
+    if (!VALID_TEMPLATE_TAGS.contains(tag) && !m.matches()) {
       throw new InvalidRequestException(
           String.format(
-              "The provided tag %s is not supported." + " Pipeline template must tag be one of %s",
+              "The provided tag %s is not supported."
+                  + " Pipeline template must tag be one of %s or semantic versioning",
               tag, VALID_TEMPLATE_TAGS));
     }
   }


### PR DESCRIPTION
Resolves https://github.com/spinnaker/spinnaker/issues/5569

This PR would add support of semver for pipeline template tags. Seems many users want such a option in the above issue.

The regex pattern is the almost same as: https://github.com/spinnaker/front50/blob/28206e1d8fae2cc071ad168d9b43e7551de0a808/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/PluginInfo.java#L95 and also supports `v` prefix as an option.