### PR TITLE
fixed issues 6218(public access enforcement) & 6221 (special chars support in dinghy file)

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URLDecoder;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.joda.time.DateTime;
@@ -58,11 +59,14 @@ public class AzureStorageService implements StorageService {
       try {
         blobContainer = getBlobClient().getContainerReference(this.containerName);
         blobContainer.createIfNotExists();
-        BlobContainerPermissions permissions = new BlobContainerPermissions();
+        // removing the public access enforcement, so that we can leverage private and public AZ
+        // https://github.com/spinnaker/spinnaker/issues/6218
+        /*BlobContainerPermissions permissions = new BlobContainerPermissions()
         permissions.setPublicAccess(BlobContainerPublicAccessType.CONTAINER);
-        blobContainer.uploadPermissions(permissions);
+        blobContainer.uploadPermissions(permissions);*/
       } catch (Exception e) {
-        // log exception
+        // log exception is missed
+        log.error(e.getMessage() + e.getCause() + e.getStackTrace());
         blobContainer = null;
       }
     }
@@ -88,6 +92,11 @@ public class AzureStorageService implements StorageService {
   public <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey) {
     String key = buildKeyPath(objectType.group, objectKey, objectType.defaultMetadataFilename);
     try {
+      /* Issue with special character(space)handling in dinghy file.
+       * https://github.com/spinnaker/spinnaker/issues/6221
+       * Container Blob Reference key generation has the logic of double encode of special chars
+       * Decode the key to avoid/fix double encode of special characters.*/
+      key = URLDecoder.decode(key, "ISO-8859-1");
       CloudBlockBlob blob = getBlobContainer().getBlockBlobReference(key);
       if (blob.exists()) {
         return deserialize(blob, (Class<T>) objectType.clazz);


### PR DESCRIPTION
Issue: https://github.com/spinnaker/spinnaker/issues/6218
Issue Summary: Private Azure Storage is not supported by Armory Spinnaker
Cloud Provider(s): AZS
Environment: DEV and Prod
Feature Area:
Description: When we convert the Azure Storage container access to private from public access, Spinnker front50 service unable to retrieve the pipelines from Azure Storage.
Steps to Reproduce: Configure Azure Storage container access to private from public access and try to pull the pipelines of any application with in Spinnaker UI.
Additional Details:
Observed that Spinnaker front50 container is expecting Azure blob storage container with public access enabled always. Application code is trying to set the permission to public access and getting exception “com.microsoft.azure.storage.StorageException: Public access is not permitted on this storage account.” as we disabled public access.
Mitigation / Fix: Removed the code snippet which is enforcing public access of expecting Azure blob storage container. Able to build & run the spinnaker front50 in local environment and getting the pipeline details from storage as expected.
Code snippet(actual exception was not getting logged due this it took more time for us to understand the cause) 

Issue: https://github.com/spinnaker/spinnaker/issues/6221
Issue Summary: Issues with special character(space)handling in dinghy file during the new application & pipeline creation. Once we have space in one specific pipeline, it is breaking complete spinnaker pipelines which was integrated with AZS.
Cloud Provider(s):AZS(Azure)
Environment: DEV and Prod
Feature Area: Front50 get pipelines is returning empty set, even we have 50+ pipeline which does not have any special characters in it.
Description: Issues with special character(space)handling in dinghy file during the new application & pipeline creation. Once we have space in one specific pipeline, it is breaking complete spinnaker pipelines which was integrated with AZS.
Front50 get pipelines is returning empty set, even we have 50+ pipeline which does not have any special characters in it.

Steps to Reproduce:
Issues with special character(space)handling in dinghy file during the new application & pipeline creation. Once we have space in one specific pipeline, it is breaking complete spinnaker pipelines which was integrated with AZS.
Front50 get pipelines is returning empty set, even we have 50+ pipeline which does not have any special characters in it.

Additional Details:
As per analysis front50 service code is performing double encoding of special characters during cache refresh and load. Due to double encode, it is unable to locate the actual resource in Azure Storage Container.
Example Name: test spinnkerpipeline
Actual URL generated from code : test%2520spinnkerpipeline
Expected URL generated from code : test%20spinnkerpipeline

Proposed Fix: During the Container Blob Reference key generation, we have to decode the key to avoid double encode of special characters.
class: com.netflix.spinnaker.front50.model.AzureStorageService.java