### PR TITLE
fix(sql): Ensure that `Application.createTs` is reliably returned when sql is used

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/Timestamped.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/Timestamped.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.front50.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public interface Timestamped {
   /**
    * TODO(rz): Move this method into new Identifiable interface. Has nothing to do with timestamps.
@@ -31,4 +33,13 @@ public interface Timestamped {
   String getLastModifiedBy();
 
   void setLastModifiedBy(String lastModifiedBy);
+
+  default void setCreatedAt(Long createdAt) {
+    // do nothing
+  }
+
+  @JsonIgnore
+  default Long getCreatedAt() {
+    return null;
+  }
 }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/Application.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/Application.java
@@ -91,6 +91,18 @@ public class Application implements Timestamped {
   }
 
   @Override
+  public void setCreatedAt(Long createdAt) {
+    if (createdAt != null) {
+      this.createTs = createdAt.toString();
+    }
+  }
+
+  @Override
+  public Long getCreatedAt() {
+    return Strings.isNullOrEmpty(createTs) ? null : Long.valueOf(createTs);
+  }
+
+  @Override
   public String toString() {
     return "Application{"
         + "name='"

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -32,6 +32,8 @@ import org.jooq.impl.DSL
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
+import strikt.assertions.isNotNull
 
 internal object SqlStorageServiceTests : JUnit5Minutests {
 
@@ -74,6 +76,7 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
 
           var application = sqlStorageService.loadObject<Application>(ObjectType.APPLICATION, "application001")
           expectThat(application.description).isEqualTo("my first application!")
+          expectThat(application.createdAt).isNotNull()
 
           // verify that an application can be updated
           sqlStorageService.storeObject(
@@ -114,6 +117,15 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
 
           application = sqlStorageService.loadObject(ObjectType.APPLICATION, "application001")
           expectThat(application.description).isEqualTo("my updated application!")
+
+          val allApplications = sqlStorageService.loadObjects<Application>(
+            ObjectType.APPLICATION,
+            sqlStorageService.listObjectKeys(ObjectType.APPLICATION).keys.toList()
+          )
+          expectThat(allApplications).isNotEmpty()
+          allApplications.forEach {
+            expectThat(it.createdAt).isNotNull()
+          }
         }
       }
 


### PR DESCRIPTION
For historical reasons, the original `createTs` value on the Application object itself
is not reliably stored.

When sql backends are used, the `created_at` column is the most accurate representation
of the time at which an Application was created.

This PR will override any `createTs` value that happens to exist in the Application
json blob with the value of the db column.
