### PR TITLE
feat(s3): add signerOverride config option

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
@@ -24,6 +24,7 @@ public class S3BucketProperties {
   // regionOverride allows the aws client to override the region in s3 request signatures
   // some s3 compatible solutions allow non-aws region identifiers to be used
   private String regionOverride;
+  private String signerOverride;
   private String endpoint;
   private String proxyHost;
   private String proxyPort;
@@ -54,6 +55,14 @@ public class S3BucketProperties {
 
   public void setRegionOverride(String regionOverride) {
     this.regionOverride = regionOverride;
+  }
+
+  public String getSignerOverride() {
+    return signerOverride;
+  }
+
+  public void setSignerOverride(String signerOverride) {
+    this.signerOverride = signerOverride;
   }
 
   public String getEndpoint() {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
@@ -48,6 +48,9 @@ public class S3ClientFactory {
           .map(Integer::parseInt)
           .ifPresent(clientConfiguration::setProxyPort);
     }
+    if (!StringUtils.isEmpty(s3Properties.getSignerOverride())) {
+      clientConfiguration.setSignerOverride(s3Properties.getSignerOverride());
+    }
 
     AmazonS3Client client = new AmazonS3Client(awsCredentialsProvider, clientConfiguration);
 


### PR DESCRIPTION
Allow users to override the S3 signer algorithm if they can't use the default. They can set the AWS client to use a different algorithm in their profile yaml:
```
  s3:
    bucket: my-bucket
    rootFolder: front50
    region: us-west-2
    enabled: true
    signerOverride: S3SignerType
```

The AWS SDK validates the algorithm passed in and will throw an exception if the user tries to configure one that doesn't exist:
```
Caused by: java.lang.IllegalArgumentException: unknown signer type: blahblah
        at com.amazonaws.auth.SignerFactory.createSigner(SignerFactory.java:131) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.auth.SignerFactory.getSignerByTypeAndService(SignerFactory.java:104) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.AmazonWebServiceClient.computeSignerByServiceRegion(AmazonWebServiceClient.java:459) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.AmazonWebServiceClient.computeSignerByURI(AmazonWebServiceClient.java:430) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.AmazonWebServiceClient.setEndpoint(AmazonWebServiceClient.java:318) ~[aws-java-sdk-core-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.setEndpoint(AmazonS3Client.java:750) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.init(AmazonS3Client.java:731) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:653) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:629) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.amazonaws.services.s3.AmazonS3Client.<init>(AmazonS3Client.java:607) ~[aws-java-sdk-s3-1.11.934.jar:na]
        at com.netflix.spinnaker.front50.config.S3ClientFactory.create(S3ClientFactory.java:55) ~[front50-s3.jar:na]
        at com.netflix.spinnaker.front50.config.S3Config.awsS3MetadataClient(S3Config.java:37) ~[front50-s3.jar:na]
...
```