### PR TITLE
fix(core): remove stale read warning

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -405,20 +405,6 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
                               String key = entry.getKey();
                               T object = (T) service.loadObject(objectType, key);
 
-                              Long expectedLastModifiedTime = keyUpdateTime.get(key);
-                              Long currentLastModifiedTime = object.getLastModified();
-
-                              if (expectedLastModifiedTime != null
-                                  && currentLastModifiedTime != null) {
-                                if (currentLastModifiedTime < expectedLastModifiedTime) {
-                                  log.warn(
-                                      "Unexpected stale read for {} (current: {}, expected: {})",
-                                      key,
-                                      new Date(currentLastModifiedTime),
-                                      new Date(expectedLastModifiedTime));
-                                }
-                              }
-
                               if (!key.equals(buildObjectKey(object))) {
                                 mismatchedIdCounter.increment();
                                 log.warn(


### PR DESCRIPTION
Removes the unexpected stale read warning. This isn't really useful and doesn't play nicely with providers that don't have millisecond precision - using S3 and this log is being generated millions of times an hour.

resolves spinnaker/spinnaker#4093

cc @ajordens @dogonthehorizon @german-muzquiz 