### PR TITLE
feat(s3): allow enabling payload signing

### DIFF
--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
@@ -29,6 +29,7 @@ public class S3BucketProperties {
   private String proxyHost;
   private String proxyPort;
   private String proxyProtocol;
+  private Boolean payloadSigning = false; // disabled by default
   private Boolean versioning = true; // enabled by default
   private Boolean pathStyleAccess = true; // enable by default
   private ServerSideEncryption serverSideEncryption; // options are "AWSKMS" and "AES256"
@@ -95,6 +96,14 @@ public class S3BucketProperties {
 
   public void setProxyProtocol(String proxyProtocol) {
     this.proxyProtocol = proxyProtocol;
+  }
+
+  public Boolean getPayloadSigning() {
+    return payloadSigning;
+  }
+
+  public void setPayloadSigning(Boolean payloadSigning) {
+    this.payloadSigning = payloadSigning;
   }
 
   public Boolean getVersioning() {

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
@@ -57,8 +57,10 @@ public class S3ClientFactory {
 
     AmazonS3Client client = new AmazonS3Client(awsCredentialsProvider, clientConfiguration);
 
-    S3ClientOptions.Builder clientOptionsBuilder = S3ClientOptions.builder()
-      .setPayloadSigningEnabled(s3Properties.getPayloadSigning());
+    S3ClientOptions.Builder clientOptionsBuilder = S3ClientOptions.builder();
+    if (s3Properties.getPayloadSigning() != null) {
+      clientOptionsBuilder.setPayloadSigningEnabled(s3Properties.getPayloadSigning());
+    }
 
     if (!StringUtils.isEmpty(s3Properties.getEndpoint())) {
       client.setEndpoint(s3Properties.getEndpoint());

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
@@ -37,22 +37,28 @@ public class S3ClientFactory {
   public static AmazonS3 create(
       AWSCredentialsProvider awsCredentialsProvider, S3Properties s3Properties) {
     ClientConfiguration clientConfiguration = new ClientConfiguration();
+
     if (s3Properties.getProxyProtocol() != null) {
       if (s3Properties.getProxyProtocol().equalsIgnoreCase("HTTPS")) {
         clientConfiguration.setProtocol(Protocol.HTTPS);
       } else {
         clientConfiguration.setProtocol(Protocol.HTTP);
       }
+
       Optional.ofNullable(s3Properties.getProxyHost()).ifPresent(clientConfiguration::setProxyHost);
       Optional.ofNullable(s3Properties.getProxyPort())
           .map(Integer::parseInt)
           .ifPresent(clientConfiguration::setProxyPort);
     }
+
     if (!StringUtils.isEmpty(s3Properties.getSignerOverride())) {
       clientConfiguration.setSignerOverride(s3Properties.getSignerOverride());
     }
 
     AmazonS3Client client = new AmazonS3Client(awsCredentialsProvider, clientConfiguration);
+
+    S3ClientOptions.Builder clientOptionsBuilder = S3ClientOptions.builder()
+      .setPayloadSigningEnabled(s3Properties.getPayloadSigning());
 
     if (!StringUtils.isEmpty(s3Properties.getEndpoint())) {
       client.setEndpoint(s3Properties.getEndpoint());
@@ -61,14 +67,15 @@ public class S3ClientFactory {
         client.setSignerRegionOverride(s3Properties.getRegionOverride());
       }
 
-      client.setS3ClientOptions(
-          S3ClientOptions.builder().setPathStyleAccess(s3Properties.getPathStyleAccess()).build());
+      clientOptionsBuilder.setPathStyleAccess(s3Properties.getPathStyleAccess());
     } else {
       Optional.ofNullable(s3Properties.getRegion())
           .map(Regions::fromName)
           .map(Region::getRegion)
           .ifPresent(client::setRegion);
     }
+
+    client.setS3ClientOptions(clientOptionsBuilder.build());
 
     return client;
   }


### PR DESCRIPTION
Adds option (disabled by default) to enable payload signing. This is required for Signature V4.

cc @ajordens @german-muzquiz 