### PR TITLE
fix(storage): Fix deserialization regression for storage services

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -29,6 +29,7 @@ public class Pipeline implements Timestamped {
   @Setter private String id;
   @Getter @Setter private String name;
   @Getter @Setter private String application;
+  @Getter @Setter private Boolean disabled;
   @Getter @Setter private String email;
   @Getter @Setter private String type;
   @Setter private String schema;
@@ -43,9 +44,15 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private Map<String, Object> template;
   @Getter @Setter private List<String> roles;
   @Getter @Setter private String serviceAccount;
+  @Getter @Setter private String executionEngine;
+  @Getter @Setter private Integer stageCounter;
   @Getter @Setter private List<Map<String, Object>> stages;
   @Getter @Setter private Map<String, Object> constraints;
   @Getter @Setter private Map<String, Object> payloadConstraints;
+  @Getter @Setter private Boolean keepWaitingPipelines;
+  @Getter @Setter private Boolean limitConcurrent;
+  @Getter @Setter private List<Map<String, Object>> parameterConfig;
+  @Getter @Setter private String spelEvaluator;
 
   public void setAny(String key, Object value) {
     anyMap.put(key, value);

--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
@@ -25,6 +25,9 @@ import com.microsoft.azure.storage.ResultSegment;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.*;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.io.IOException;
@@ -41,7 +44,10 @@ public class AzureStorageService implements StorageService {
   private CloudStorageAccount storageAccount = null;
   private CloudBlobClient blobClient = null;
   private CloudBlobContainer blobContainer = null;
-  private ObjectMapper objectMapper = new ObjectMapper();
+  private ObjectMapper objectMapper =
+      new ObjectMapper()
+          .addMixIn(Timestamped.class, TimestampedMixins.class)
+          .addMixIn(Pipeline.class, PipelineMixins.class);
 
   private static final String LAST_MODIFIED_FILENAME = "last_modified";
   private static final String LAST_MODIFIED_METADATA_NAME = "lastmodifydate";
@@ -91,6 +97,7 @@ public class AzureStorageService implements StorageService {
     try {
       CloudBlockBlob blob = getBlobContainer().getBlockBlobReference(key);
       if (blob.exists()) {
+        // TODO Fix
         return deserialize(blob, (Class<T>) objectType.clazz);
       }
       throw new NotFoundException(

--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
@@ -97,7 +97,6 @@ public class AzureStorageService implements StorageService {
     try {
       CloudBlockBlob blob = getBlobContainer().getBlockBlobReference(key);
       if (blob.exists()) {
-        // TODO Fix
         return deserialize(blob, (Class<T>) objectType.clazz);
       }
       throw new NotFoundException(

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -20,7 +20,7 @@ class PipelineSpec extends Specification {
     String pipelineJSON = objectMapper.writeValueAsString(pipeline)
 
     expect:
-    pipelineJSON == '{"triggers":[],"lastModifiedBy":null,"template":null,"roles":null,"serviceAccount":null,"stages":null,"constraints":null,"payloadConstraints":null,"lastModified":null,"createdAt":null}'
+    pipelineJSON == '{"disabled":null,"triggers":[],"lastModifiedBy":null,"template":null,"roles":null,"serviceAccount":null,"executionEngine":null,"stageCounter":null,"stages":null,"constraints":null,"payloadConstraints":null,"keepWaitingPipelines":null,"limitConcurrent":null,"parameterConfig":null,"spelEvaluator":null,"lastModified":null,"createdAt":null}'
   }
 
   def 'should ignore correct pipeline properties from deserializing JSON to Pipeline'() {
@@ -45,7 +45,7 @@ class PipelineSpec extends Specification {
 
   def 'roundtrip (JSON -> Pipeline -> JSON) retains arbitrary values'() {
     given:
-    String pipelineJSON = '{"triggers":[],"lastModifiedBy":"anonymous","template":null,"roles":null,"serviceAccount":null,"stages":null,"constraints":null,"payloadConstraints":null,"lastModified":null,"createdAt":null,"foo":"bar"}'
+    String pipelineJSON = '{"disabled":null,"triggers":[],"lastModifiedBy":"anonymous","template":null,"roles":null,"serviceAccount":null,"executionEngine":null,"stageCounter":null,"stages":null,"constraints":null,"payloadConstraints":null,"keepWaitingPipelines":null,"limitConcurrent":null,"parameterConfig":null,"spelEvaluator":null,"lastModified":null,"createdAt":null,"foo":"bar"}'
 
     String pipeline = objectMapper.writeValueAsString(objectMapper.readValue(pipelineJSON, Pipeline.class))
 

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -26,6 +26,10 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.api.model.Timestamped;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.GcsStorageService;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
@@ -77,7 +81,9 @@ public class GcsConfig {
             gcsProperties.getBucketLocation(),
             gcsProperties.getRootFolder(),
             dataFilename,
-            new ObjectMapper(),
+            new ObjectMapper()
+                .addMixIn(Timestamped.class, TimestampedMixins.class)
+                .addMixIn(Pipeline.class, PipelineMixins.class),
             executor);
     log.info(
         "Using Google Cloud Storage bucket={} in project={}",

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/V2PipelineTemplateSourceToArtifactMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/V2PipelineTemplateSourceToArtifactMigration.java
@@ -18,7 +18,10 @@
 package com.netflix.spinnaker.front50.migrations;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.api.model.Timestamped;
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.front50.model.ItemDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
 import com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration.TemplateSource;
@@ -49,7 +52,10 @@ public class V2PipelineTemplateSourceToArtifactMigration implements Migration {
   public V2PipelineTemplateSourceToArtifactMigration(
       PipelineDAO pipelineDAO, ObjectMapper objectMapper) {
     this.pipelineDAO = pipelineDAO;
-    this.objectMapper = objectMapper;
+    this.objectMapper =
+        new ObjectMapper()
+            .addMixIn(Timestamped.class, TimestampedMixins.class)
+            .addMixIn(Pipeline.class, PipelineMixins.class);
   }
 
   @Override

--- a/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
+++ b/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
@@ -13,7 +13,10 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.google.common.base.Supplier;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.config.OracleProperties;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
@@ -55,7 +58,10 @@ public class OracleStorageService implements StorageService {
   private final String compartmentId;
   private final String bucketName;
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .addMixIn(Timestamped.class, TimestampedMixins.class)
+          .addMixIn(Pipeline.class, PipelineMixins.class);
 
   private class RequestSigningFilter extends ClientFilter {
     private final RequestSigner signer;

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -10,6 +10,10 @@ import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.api.model.Timestamped;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.front50.model.*;
 import com.netflix.spinnaker.front50.plugins.PluginBinaryStorageService;
 import com.netflix.spinnaker.front50.plugins.S3PluginBinaryStorageService;
@@ -41,7 +45,10 @@ public class S3Config {
   @ConditionalOnProperty(value = "spinnaker.s3.storage-service.enabled", matchIfMissing = true)
   public S3StorageService s3StorageService(
       AmazonS3 awsS3MetadataClient, S3MetadataStorageProperties s3Properties) {
-    ObjectMapper awsObjectMapper = new ObjectMapper();
+    ObjectMapper awsObjectMapper =
+        new ObjectMapper()
+            .addMixIn(Timestamped.class, TimestampedMixins.class)
+            .addMixIn(Pipeline.class, PipelineMixins.class);
 
     S3StorageService service =
         new S3StorageService(

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -26,6 +26,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -59,7 +62,10 @@ public class S3StorageService implements StorageService {
       Boolean versioning,
       Integer maxKeys,
       ServerSideEncryption serverSideEncryption) {
-    this.objectMapper = objectMapper;
+    this.objectMapper =
+        new ObjectMapper()
+            .addMixIn(Timestamped.class, TimestampedMixins.class)
+            .addMixIn(Pipeline.class, PipelineMixins.class);
     this.amazonS3 = amazonS3;
     this.bucket = bucket;
     this.rootFolder = rootFolder;

--- a/front50-swift/src/main/java/com/netflix/spinnaker/front50/model/SwiftStorageService.java
+++ b/front50-swift/src/main/java/com/netflix/spinnaker/front50/model/SwiftStorageService.java
@@ -20,6 +20,9 @@ import static net.logstash.logback.argument.StructuredArguments.value;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -51,7 +54,10 @@ public class SwiftStorageService implements StorageService {
   private static final Logger log = LoggerFactory.getLogger(SwiftStorageService.class);
 
   private final ObjectStorageService swift;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .addMixIn(Timestamped.class, TimestampedMixins.class)
+          .addMixIn(Pipeline.class, PipelineMixins.class);
   private final String containerName;
 
   private Token token = null;
@@ -138,7 +144,7 @@ public class SwiftStorageService implements StorageService {
   @Override
   public <T extends Timestamped> void storeObject(ObjectType objectType, String objectKey, T item) {
     try {
-      byte[] bytes = new ObjectMapper().writeValueAsBytes(item);
+      byte[] bytes = objectMapper.writeValueAsBytes(item);
       InputStream is = new ByteArrayInputStream(bytes);
 
       getSwift()


### PR DESCRIPTION
This PR resolves this issue: https://github.com/spinnaker/spinnaker/issues/6468

This was introduced when I migrated Pipeline and Timestamped to a new front50-api package here: spinnaker/front50#1035

I needed to add the new Pipeline and Timestamped mixins to the other object mappers used for deserialization in the storage service classes.

There were also a few pipeline properties that were missing that needed to be added: https://github.com/spinnaker/front50/blob/9ed6b52419a4d154d7d86b5cbf54b9a2d3104f53/front50-web/src/main/resources/graphql/pipelineConfig.graphqls#L12