### PR TITLE
fix(api): remove JsonIgnore annotations to fix Pipeline deserialization regression

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -18,21 +18,8 @@ package com.netflix.spinnaker.front50.jackson.mixins;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Map;
 
-@JsonIgnoreProperties(
-    value = {
-      "application",
-      "name",
-      "email",
-      "id",
-      "updateTs",
-      "config",
-      "type",
-      "schema",
-      "index",
-    })
 public abstract class PipelineMixins {
   @JsonAnySetter
   abstract void setAny(String key, Object value);

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -13,26 +13,6 @@ class PipelineSpec extends Specification {
     objectMapper.addMixIn(Pipeline.class, PipelineMixins.class)
   }
 
-  def 'should ignore correct pipeline properties when serializing Pipeline to JSON'() {
-    given:
-    Pipeline pipeline = new Pipeline()
-    pipeline.setId("1")
-    String pipelineJSON = objectMapper.writeValueAsString(pipeline)
-
-    expect:
-    pipelineJSON == '{"disabled":null,"triggers":[],"lastModifiedBy":null,"template":null,"roles":null,"serviceAccount":null,"executionEngine":null,"stageCounter":null,"stages":null,"constraints":null,"payloadConstraints":null,"keepWaitingPipelines":null,"limitConcurrent":null,"parameterConfig":null,"spelEvaluator":null,"lastModified":null,"createdAt":null}'
-  }
-
-  def 'should ignore correct pipeline properties from deserializing JSON to Pipeline'() {
-    given:
-    String pipelineJSON = '{"foo": "bar"}'
-
-    Pipeline pipeline = objectMapper.readValue(pipelineJSON, Pipeline.class)
-
-    expect:
-    pipeline.getType() == null
-  }
-
   def 'should set any additional pipeline properties when deserializing JSON to Pipeline'() {
     given:
     String pipelineJSON = '{"foo": "bar"}'
@@ -45,7 +25,8 @@ class PipelineSpec extends Specification {
 
   def 'roundtrip (JSON -> Pipeline -> JSON) retains arbitrary values'() {
     given:
-    String pipelineJSON = '{"disabled":null,"triggers":[],"lastModifiedBy":"anonymous","template":null,"roles":null,"serviceAccount":null,"executionEngine":null,"stageCounter":null,"stages":null,"constraints":null,"payloadConstraints":null,"keepWaitingPipelines":null,"limitConcurrent":null,"parameterConfig":null,"spelEvaluator":null,"lastModified":null,"createdAt":null,"foo":"bar"}'
+    String pipelineJSON = '{"id":null,"name":null,"application":null,"disabled":null,"email":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","template":null,"roles":null,"serviceAccount":null,"executionEngine":null,"stageCounter":null,"stages":null,"constraints":null,"payloadConstraints":null,"keepWaitingPipelines":null,"limitConcurrent":null,"parameterConfig":null,"spelEvaluator":null,"lastModified":null,"createdAt":null,"foo":"bar"}'
+
 
     String pipeline = objectMapper.writeValueAsString(objectMapper.readValue(pipelineJSON, Pipeline.class))
 


### PR DESCRIPTION
This deserialization regression was introduced when I migrated the the `@jsonIgnore` annotations for the getter/setters in the `front50-core` Pipeline class to `@JsonIgnoreProperties` on the PipelineMixin class here: spinnaker/front50#1035. 

I got reports that pipelines were still producing errors due to missing fields and that the fields that we were supposed to ignore actually needed to be serialized/deserialized (ie name, application, etc).  I checked out the previous code prior to the `front50-api` package creation PR and noticed that the `@jsonIgnore` field was masking behavior and wasn't actually ignoring those fields for serialization/deserialization. 

Introducing `@JsonIgnoreProperties` to the PipelineMixin class enforced the behavior of ignoring these fields, so I need to revert this back to the old behavior.

Unfortunately I wasn't able to determine why `@JsonIgnore` wasn't working prior to that PR with the time I had.