### PR TITLE
fix(api): fix regression for ignoring specific pipeline fields with null values

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -26,11 +26,10 @@ public class Pipeline implements Timestamped {
   public static final String TYPE_TEMPLATED = "templatedPipeline";
 
   private Map<String, Object> anyMap = new HashMap<>();
+
   @Setter private String id;
   @Getter @Setter private String name;
   @Getter @Setter private String application;
-  @Getter @Setter private Boolean disabled;
-  @Getter @Setter private String email;
   @Getter @Setter private String type;
   @Setter private String schema;
   @Getter @Setter private Object config;
@@ -41,6 +40,9 @@ public class Pipeline implements Timestamped {
   private String createTs;
   private String lastModifiedBy;
 
+  // Excluded fields with null value: see PipelineMixins in front50-core
+  @Getter @Setter private String email;
+  @Getter @Setter private Boolean disabled;
   @Getter @Setter private Map<String, Object> template;
   @Getter @Setter private List<String> roles;
   @Getter @Setter private String serviceAccount;

--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -39,6 +39,7 @@ public class Pipeline implements Timestamped {
   private String updateTs;
   private String createTs;
   private String lastModifiedBy;
+  private String lastModified;
 
   // Excluded fields with null value: see PipelineMixins in front50-core
   @Getter @Setter private String email;

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.jackson.mixins;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
@@ -31,6 +32,8 @@ public abstract class PipelineMixins {
 
   @JsonAnyGetter
   abstract Map<String, Object> getAny();
+
+  @JsonIgnore private String lastModified;
 
   @JsonInclude(Include.NON_NULL)
   @Getter

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -18,7 +18,12 @@ package com.netflix.spinnaker.front50.jackson.mixins;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.List;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 
 public abstract class PipelineMixins {
   @JsonAnySetter
@@ -26,4 +31,74 @@ public abstract class PipelineMixins {
 
   @JsonAnyGetter
   abstract Map<String, Object> getAny();
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Boolean disabled;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String email;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Map<String, Object> template;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private List<String> roles;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String serviceAccount;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String executionEngine;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Integer stageCounter;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private List<Map<String, Object>> stages;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Map<String, Object> constraints;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Map<String, Object> payloadConstraints;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Boolean keepWaitingPipelines;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Boolean limitConcurrent;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private List<Map<String, Object>> parameterConfig;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String spelEvaluator;
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationModelSpec.groovy
@@ -57,11 +57,12 @@ class ApplicationModelSpec extends Specification {
     def application = new Application()
     application.setCreatedAt(new Long(1))
     application.setLastModifiedBy("foo")
+    application.setLastModified(new Long(1))
 
     ObjectMapper mapper = new ObjectMapper().addMixIn(Timestamped.class, TimestampedMixins.class)
     String appJSON = mapper.writeValueAsString(application)
 
     expect:
-    appJSON == '{"name":null,"description":null,"email":null,"updateTs":null,"createTs":"1","lastModifiedBy":"foo","cloudProviders":null,"trafficGuards":[]}'
+    appJSON == '{"name":null,"description":null,"email":null,"updateTs":"1","createTs":"1","lastModifiedBy":"foo","cloudProviders":null,"trafficGuards":[]}'
   }
 }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -2,8 +2,10 @@ package com.netflix.spinnaker.front50.model.pipeline
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.api.model.Timestamped
 import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
 import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins
 import spock.lang.Specification
 
 class PipelineSpec extends Specification {
@@ -11,6 +13,7 @@ class PipelineSpec extends Specification {
 
   void setup() {
     objectMapper.addMixIn(Pipeline.class, PipelineMixins.class)
+    objectMapper.addMixIn(Timestamped.class, TimestampedMixins.class)
   }
 
   def 'should set any additional pipeline properties when deserializing JSON to Pipeline'() {
@@ -25,10 +28,22 @@ class PipelineSpec extends Specification {
 
   def 'roundtrip (JSON -> Pipeline -> JSON) retains arbitrary values'() {
     given:
-    String pipelineJSON = '{"id":null,"name":null,"application":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","lastModified":null,"createdAt":null,"foo":"bar"}'
+    String pipelineJSON = '{"id":null,"name":null,"application":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","foo":"bar","updateTs":null}'
 
 
     String pipeline = objectMapper.writeValueAsString(objectMapper.readValue(pipelineJSON, Pipeline.class))
+
+    expect:
+    pipeline == pipelineJSON
+  }
+
+  def 'setting lastModified on pipeline sets updateTs'() {
+    given:
+    String pipelineJSON = '{"id":null,"name":null,"application":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","updateTs":null}'
+    Pipeline pipelineObj = objectMapper.readValue(pipelineJSON, Pipeline.class)
+
+    pipelineObj.setLastModified(new Long(1))
+    String pipeline = objectMapper.writeValueAsString(pipelineObj)
 
     expect:
     pipeline == pipelineJSON

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -25,7 +25,7 @@ class PipelineSpec extends Specification {
 
   def 'roundtrip (JSON -> Pipeline -> JSON) retains arbitrary values'() {
     given:
-    String pipelineJSON = '{"id":null,"name":null,"application":null,"disabled":null,"email":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","template":null,"roles":null,"serviceAccount":null,"executionEngine":null,"stageCounter":null,"stages":null,"constraints":null,"payloadConstraints":null,"keepWaitingPipelines":null,"limitConcurrent":null,"parameterConfig":null,"spelEvaluator":null,"lastModified":null,"createdAt":null,"foo":"bar"}'
+    String pipelineJSON = '{"id":null,"name":null,"application":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","lastModified":null,"createdAt":null,"foo":"bar"}'
 
 
     String pipeline = objectMapper.writeValueAsString(objectMapper.readValue(pipelineJSON, Pipeline.class))


### PR DESCRIPTION
This is a regression from refactoring the Pipeline class that was moved to the `front50-api` package in #1035. This PR reverts the Pipeline object to previous behavior where null values for some properties are ignored during serialization. Also, this removes the `lastModified` property from serialization since that was the previous behavior and it is a duplicate of `updateTs`.