### PR TITLE
fix(api): ignore all Pipeline properties with null value for serialization

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -41,7 +41,6 @@ public class Pipeline implements Timestamped {
   private String lastModifiedBy;
   private String lastModified;
 
-  // Excluded fields with null value: see PipelineMixins in front50-core
   @Getter @Setter private String email;
   @Getter @Setter private Boolean disabled;
   @Getter @Setter private Map<String, Object> template;

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.netflix.spinnaker.front50.api.model.pipeline.Trigger;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
@@ -32,6 +34,53 @@ public abstract class PipelineMixins {
 
   @JsonAnyGetter
   abstract Map<String, Object> getAny();
+
+  @JsonInclude(Include.NON_NULL)
+  @Setter
+  private String id;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String name;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String application;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private String type;
+
+  @JsonInclude(Include.NON_NULL)
+  @Setter
+  private String schema;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Object config;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private List<Trigger> triggers = new ArrayList<>();
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
+  private Integer index;
+
+  @JsonInclude(Include.NON_NULL)
+  private String updateTs;
+
+  @JsonInclude(Include.NON_NULL)
+  private String createTs;
+
+  @JsonInclude(Include.NON_NULL)
+  private String lastModifiedBy;
 
   @JsonIgnore private String lastModified;
 

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -28,7 +28,7 @@ class PipelineSpec extends Specification {
 
   def 'roundtrip (JSON -> Pipeline -> JSON) retains arbitrary values'() {
     given:
-    String pipelineJSON = '{"id":null,"name":null,"application":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","foo":"bar","updateTs":null}'
+    String pipelineJSON = '{"id":"1","name":"sky","application":"almond","schema":"1","triggers":[],"lastModifiedBy":"anonymous","foo":"bar"}'
 
 
     String pipeline = objectMapper.writeValueAsString(objectMapper.readValue(pipelineJSON, Pipeline.class))
@@ -39,7 +39,7 @@ class PipelineSpec extends Specification {
 
   def 'setting lastModified on pipeline sets updateTs'() {
     given:
-    String pipelineJSON = '{"id":null,"name":null,"application":null,"type":null,"schema":"1","config":null,"triggers":[],"index":null,"lastModifiedBy":"anonymous","updateTs":null}'
+    String pipelineJSON = '{"id":"1","name":"sky","application":"almond","schema":"1","triggers":[],"updateTs":"1"}'
     Pipeline pipelineObj = objectMapper.readValue(pipelineJSON, Pipeline.class)
 
     pipelineObj.setLastModified(new Long(1))


### PR DESCRIPTION
#1043 annotated some properties that needed to be excluded if they were null, but we are finding that all of these properties need to be excluded if they are null or there will be null pointer exceptions in Orca. 