### PR TITLE
fix(api): Fix type mismatch with Pipeline boolean properties

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -42,7 +42,7 @@ public class Pipeline implements Timestamped {
   private String lastModified;
 
   @Getter @Setter private String email;
-  @Getter @Setter private Boolean disabled;
+  @Getter @Setter private String disabled;
   @Getter @Setter private Map<String, Object> template;
   @Getter @Setter private List<String> roles;
   @Getter @Setter private String serviceAccount;
@@ -51,8 +51,8 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private List<Map<String, Object>> stages;
   @Getter @Setter private Map<String, Object> constraints;
   @Getter @Setter private Map<String, Object> payloadConstraints;
-  @Getter @Setter private Boolean keepWaitingPipelines;
-  @Getter @Setter private Boolean limitConcurrent;
+  @Getter @Setter private String keepWaitingPipelines;
+  @Getter @Setter private String limitConcurrent;
   @Getter @Setter private List<Map<String, Object>> parameterConfig;
   @Getter @Setter private String spelEvaluator;
 

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -87,7 +87,7 @@ public abstract class PipelineMixins {
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
-  private Boolean disabled;
+  private String disabled;
 
   @JsonInclude(Include.NON_NULL)
   @Getter
@@ -137,12 +137,12 @@ public abstract class PipelineMixins {
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
-  private Boolean keepWaitingPipelines;
+  private String keepWaitingPipelines;
 
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
-  private Boolean limitConcurrent;
+  private String limitConcurrent;
 
   @JsonInclude(Include.NON_NULL)
   @Getter

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -49,6 +49,16 @@ class PipelineSpec extends Specification {
     pipeline == pipelineJSON
   }
 
+  def 'boolean properties should be strings'() {
+    given:
+    String pipelineJSON = '{"id":"1","schema":"1","triggers":[],"disabled":"true","keepWaitingPipelines":"true","limitConcurrent":"true"}'
+    Pipeline pipelineObj = objectMapper.readValue(pipelineJSON, Pipeline.class)
+    String pipeline = objectMapper.writeValueAsString(pipelineObj)
+
+    expect:
+    pipeline == pipelineJSON
+  }
+
   def 'should grab triggers after deserializing JSON into Pipeline'() {
     given:
     String pipelineJSON = '{"triggers": [{"type": "cron", "id": "a"}, {"type": "cron", "id": "b"}]}'


### PR DESCRIPTION
Pipeline properties that were migrated to the front50-api package as booleans should actually be strings, since this was the previous behavior (ie true -> "true", false -> "false). This PR reverts these properties back.