### PR TITLE
fix(vulnerability): Remove fixed version of postgres dependency to accommodate safer version from kork.

### DIFF
--- a/front50-sql-postgres/front50-sql-postgres.gradle
+++ b/front50-sql-postgres/front50-sql-postgres.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  runtimeOnly "org.postgresql:postgresql" // fix CVE-2020-13692 by upgraded version in kork
+  runtimeOnly "org.postgresql:postgresql"
 }

--- a/front50-sql-postgres/front50-sql-postgres.gradle
+++ b/front50-sql-postgres/front50-sql-postgres.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  runtimeOnly "org.postgresql:postgresql:42.2.8"
+  runtimeOnly "org.postgresql:postgresql" // fix CVE-2020-13692 by upgraded version in kork
 }


### PR DESCRIPTION
[CVE-2020-13692](https://nvd.nist.gov/vuln/detail/CVE-2020-13692)