### PR TITLE
fix(authZ): Invert service account authz logic

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AuthorizationSupport.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/AuthorizationSupport.java
@@ -55,24 +55,10 @@ public class AuthorizationSupport {
 
     final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-    return runAsUsers.stream()
+    return !runAsUsers.stream()
         .noneMatch(
             runAsUser -> {
-              if (!userCanAccessServiceAccount(auth, runAsUser)) {
-                log.error(
-                    "User {} does not have access to service account {}",
-                    Optional.ofNullable(auth).map(Authentication::getPrincipal).orElse("unknown"),
-                    runAsUser);
-                return true;
-              }
-              if (!serviceAccountCanAccessApplication(runAsUser, pipeline.getApplication())) {
-                log.error(
-                    "Service account {} does not have access to application {}",
-                    runAsUser,
-                    pipeline.getApplication());
-                return true;
-              }
-              return false;
+              userCanAccessServiceAccount(auth, runAsUser) && serviceAccountCanAccessApplication(runAsUser, pipeline.getApplication()
             });
   }
 


### PR DESCRIPTION
hasRunAsUserPermission() has two ways it can grant permission:

1. If there are *no* service accounts. According to @sh4sh this is probably because spinnaker fails open: if there's no permissions set up then everyone has every permission by default)
2. If there are some service accounts then it goes through them and decides if any of them are correct

But I believe case 2 is implemented incorrectly. If it's not, then I hope someone will explain to me in this PR what is going on because I am very confused 😵.

The line used to read, from https://github.com/spinnaker/front50/pull/155/files,

```
    return runAsUsers.findAll { runAsUser ->
      !userCanAccessServiceAccount(auth, runAsUser) ||
          !serviceAccountCanAccessApplication(runAsUser, pipeline.application as String)
    }.isEmpty()
```

and from my reading, that logic was maintained through the addition of logging and the translation to Java. It now says `.stream().noneMatch()` instead of `.isEmpty()` but the same predicate is in use.

I'm going to break the predicate down to make it a bit easier to read in English:

By De Morgan's law the predicate is the same as

```
      !(userCanAccessServiceAccount(auth, runAsUser) && serviceAccountCanAccessApplication(runAsUser, pipeline.application as String))
```

In English, means "the current user can NOT use the service account `runAsUser` to access the application".

And `.findAll { ... }.isEmpty()` is saying "there are none of ....".

So the complete line in English reads "NONE of the service accounts can NOT be used by the current user to access the application".

You can write this as the quantified-logic statement

```latex
! \exists runAsUser : ! ( userCanAccessServiceAccount(auth, runAsUser) && serviceAccountCanAccessApplication(runAsUser, pipeline.application) )
```

By https://en.wikipedia.org/wiki/Existential_quantification#Negation this is the same as

```latex
\forall runAsUser : ( userCanAccessServiceAccount(auth, runAsUser) && serviceAccountCanAccessApplication(runAsUser, pipeline.application) )
```

Or in English: "the current user can use **every** service account to access the application". That can't possible be right can it? "The current user can use *some* service account to access the application" would make much more sense.

In math that is

```latex
\exists runAsUser : ( userCanAccessServiceAccount(auth, runAsUser) && serviceAccountCanAccessApplication(runAsUser, pipeline.application) )
```

and that's what this PR implements.

It drops the logging to make the logic clear but I can put that back if you want, but I have to think it was mostly unhelpful because it would just repeat the same list of all the service accounts and applications someone *doesn't* have access to over and over again, and would never tell you what service account it eventually chose to use in the end.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
