### PR TITLE
fix(api): revert fix type mismatch regression with Pipeline boolean properties (#1046)

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -42,7 +42,7 @@ public class Pipeline implements Timestamped {
   private String lastModified;
 
   @Getter @Setter private String email;
-  @Getter @Setter private String disabled;
+  @Getter @Setter private Boolean disabled;
   @Getter @Setter private Map<String, Object> template;
   @Getter @Setter private List<String> roles;
   @Getter @Setter private String serviceAccount;
@@ -51,8 +51,8 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private List<Map<String, Object>> stages;
   @Getter @Setter private Map<String, Object> constraints;
   @Getter @Setter private Map<String, Object> payloadConstraints;
-  @Getter @Setter private String keepWaitingPipelines;
-  @Getter @Setter private String limitConcurrent;
+  @Getter @Setter private Boolean keepWaitingPipelines;
+  @Getter @Setter private Boolean limitConcurrent;
   @Getter @Setter private List<Map<String, Object>> parameterConfig;
   @Getter @Setter private String spelEvaluator;
 

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -87,7 +87,7 @@ public abstract class PipelineMixins {
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
-  private String disabled;
+  private Boolean disabled;
 
   @JsonInclude(Include.NON_NULL)
   @Getter
@@ -137,12 +137,12 @@ public abstract class PipelineMixins {
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
-  private String keepWaitingPipelines;
+  private Boolean keepWaitingPipelines;
 
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
-  private String limitConcurrent;
+  private Boolean limitConcurrent;
 
   @JsonInclude(Include.NON_NULL)
   @Getter

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/pipeline/PipelineSpec.groovy
@@ -49,16 +49,6 @@ class PipelineSpec extends Specification {
     pipeline == pipelineJSON
   }
 
-  def 'boolean properties should be strings'() {
-    given:
-    String pipelineJSON = '{"id":"1","schema":"1","triggers":[],"disabled":"true","keepWaitingPipelines":"true","limitConcurrent":"true"}'
-    Pipeline pipelineObj = objectMapper.readValue(pipelineJSON, Pipeline.class)
-    String pipeline = objectMapper.writeValueAsString(pipelineObj)
-
-    expect:
-    pipeline == pipelineJSON
-  }
-
   def 'should grab triggers after deserializing JSON into Pipeline'() {
     given:
     String pipelineJSON = '{"triggers": [{"type": "cron", "id": "a"}, {"type": "cron", "id": "b"}]}'


### PR DESCRIPTION
The original type for these properties on deck is defined as boolean so we should keep it as is.

![Image 2021-09-29 at 3 01 35 PM](https://user-images.githubusercontent.com/16300174/135340153-1e2c8df9-14d6-43a1-b490-9f3594ec8b50.jpg)
