### PR TITLE
fix(migrations): SpelLoadBalancersMigration runs on every migration

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/SpelLoadBalancersMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/SpelLoadBalancersMigration.java
@@ -2,10 +2,8 @@ package com.netflix.spinnaker.front50.migrations;
 
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.time.Clock;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,14 +11,19 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class SpelLoadBalancersMigration implements Migration {
+  // Only valid until October 13th, 2021
+  private static final Date VALID_UNTIL = new GregorianCalendar(2021, 10, 13).getTime();
+  private Clock clock = Clock.systemDefaultZone();
+
   private final PipelineDAO pipelineDAO;
 
   public SpelLoadBalancersMigration(PipelineDAO pipelineDAO) {
     this.pipelineDAO = pipelineDAO;
   }
 
+  @Override
   public boolean isValid() {
-    return true;
+    return clock.instant().toEpochMilli() < VALID_UNTIL.getTime();
   }
 
   public void run() {


### PR DESCRIPTION
`isValid` returns true for `SpelLoadBalancersMigration` and there is no `VALID_UNTIL` set. Because of this, this migration runs regardless of the migration that were planning to run. I imagine the intent was originally to run this once, but in its current configuration, that is not true.
