### PR TITLE
fix(core/dao): case insensitive search details

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/ApplicationDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/ApplicationDAO.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.front50.model.SearchUtils;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 public interface ApplicationDAO extends ItemDAO<Application> {
   Application findByName(String name) throws NotFoundException;
@@ -44,15 +45,19 @@ public interface ApplicationDAO extends ItemDAO<Application> {
                   if (Strings.isNullOrEmpty(e.getValue())) {
                     continue;
                   }
+
+                  Map<String, Object> details = new LinkedCaseInsensitiveMap<>();
+                  details.putAll(it.details());
+
                   if (!UntypedUtils.hasProperty(it, e.getKey())
-                      && !it.details().containsKey(e.getKey())) {
+                      && !details.containsKey(e.getKey())) {
                     return false;
                   }
 
                   Object appVal =
                       UntypedUtils.hasProperty(it, e.getKey())
                           ? UntypedUtils.getProperty(it, e.getKey())
-                          : it.details().get(e.getKey());
+                          : details.get(e.getKey());
                   if (appVal == null) {
                     appVal = "";
                   }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAOSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAOSpec.groovy
@@ -82,4 +82,18 @@ class ApplicationDAOSpec extends Specification {
     ["name": "Netflix", description: "Spinnaker"] | ["name": "flix", description: "ker"]  || 93
     ["name": "Netflix", description: "Spinnaker"] | ["name": "flix", owner: "netflix"]    || 59
   }
+
+  @Unroll
+  def "search applications by details"() {
+    given:
+    def applications = [
+      new Application(name: "SOMEAPP", details: [repoSlug: "someapp"]),
+      new Application(name: "ANOTHERAPP", details: [repoSlug: "anotherapp"]),
+    ]
+
+    expect:
+    ApplicationDAO.Searcher.search(applications, ["repoSlug": "someapp"])*.name == [
+      "SOMEAPP"
+    ]
+  }
 }


### PR DESCRIPTION
Ignore case when searching application.details, currently searching properties in details (such as repoSlug) will never match as the search param is always lowercased.