### PR TITLE
fix(core): do not lowercase search params

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/ApplicationDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/ApplicationDAO.java
@@ -32,15 +32,13 @@ public interface ApplicationDAO extends ItemDAO<Application> {
   class Searcher {
     public static Collection<Application> search(
         Collection<Application> searchableApplications, Map<String, String> attributes) {
-      Map<String, String> normalizedAttributes = new HashMap<>();
-      attributes.forEach((key, value) -> normalizedAttributes.put(key.toLowerCase(), value));
 
       // filtering vs. querying to achieve case-insensitivity without using an additional column
       // (small data set)
       return searchableApplications.stream()
           .filter(
               it -> {
-                for (Map.Entry<String, String> e : normalizedAttributes.entrySet()) {
+                for (Map.Entry<String, String> e : attributes.entrySet()) {
                   if (Strings.isNullOrEmpty(e.getValue())) {
                     continue;
                   }
@@ -63,10 +61,7 @@ public interface ApplicationDAO extends ItemDAO<Application> {
                 return true;
               })
           .distinct()
-          .sorted(
-              (a, b) ->
-                  SearchUtils.score(b, normalizedAttributes)
-                      - SearchUtils.score(a, normalizedAttributes))
+          .sorted((a, b) -> SearchUtils.score(b, attributes) - SearchUtils.score(a, attributes))
           .collect(Collectors.toList());
     }
   }

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAOSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/model/application/ApplicationDAOSpec.groovy
@@ -82,4 +82,24 @@ class ApplicationDAOSpec extends Specification {
     ["name": "Netflix", description: "Spinnaker"] | ["name": "flix", description: "ker"]  || 93
     ["name": "Netflix", description: "Spinnaker"] | ["name": "flix", owner: "netflix"]    || 59
   }
+
+
+  @Unroll
+  def "should be able to search applications"() {
+    given:
+    def apps = applications
+
+    expect:
+    ApplicationDAO.Searcher.search(apps, search)*.name == app
+
+    where:
+    applications                                                                                | search                                    | app
+    [new Application(name: "APP1", details: [repoSlug: "app1"]), new Application(name: "APP2")] | [repoSlug: "app1"]                        | ["APP1"]
+    [new Application(name: "APP1", details: [repoSlug: "app1"]), new Application(name: "APP2")] | [repoSlug: "APP1"]                        | ["APP1"]
+    [new Application(name: "APP1", details: [repoSlug: "app1"]), new Application(name: "APP2")] | [repoSlug: "app2"]                        | []
+    [new Application(name: "APP1", details: [repoSlug: "app1"]), new Application(name: "APP2")] | [name: "app2"]                            | ["APP2"]
+    [new Application(name: "APP1", details: [repoSlug: "app1"]), new Application(name: "APP2")] | [:]                                       | ["APP1", "APP2"]
+    [new Application(name: "APP1", details: [repoSlug: "app1", repoProjectKey: "org"])]         | [repoSlug: "app1", repoProjectKey: "org"] | ["APP1"]
+    [new Application(name: "APP1", details: [repoSlug: "app1"])]                                | [reposlug: "app1"]                        | []
+  }
 }


### PR DESCRIPTION
Fixes searching for applications by keys with caps in the dataset, such as `repoSlug`.