### PR TITLE
feat(pipeline executions/front50): Add support for max concurrent pipeline executions

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -53,6 +53,7 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private Map<String, Object> payloadConstraints;
   @Getter @Setter private Boolean keepWaitingPipelines;
   @Getter @Setter private Boolean limitConcurrent;
+  @Getter @Setter private Integer maxConcurrentExecutions;
   @Getter @Setter private List<Map<String, Object>> parameterConfig;
   @Getter @Setter private String spelEvaluator;
 

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/jackson/mixins/PipelineMixins.java
@@ -147,6 +147,11 @@ public abstract class PipelineMixins {
   @JsonInclude(Include.NON_NULL)
   @Getter
   @Setter
+  private Integer maxConcurrentExecutions;
+
+  @JsonInclude(Include.NON_NULL)
+  @Getter
+  @Setter
   private List<Map<String, Object>> parameterConfig;
 
   @JsonInclude(Include.NON_NULL)

--- a/front50-web/src/main/resources/graphql/pipelineConfig.graphqls
+++ b/front50-web/src/main/resources/graphql/pipelineConfig.graphqls
@@ -20,7 +20,7 @@ type Pipeline {
   keepWaitingPipelines: Boolean!
   lastModifiedBy: String!
   limitConcurrent: Boolean!
-  maxConcurrentExecutions: Int!
+  maxConcurrentExecutions: Int
   parameterConfig: [ParameterConfig]!
   spelEvaluator: String!
   stageCounter: Int

--- a/front50-web/src/main/resources/graphql/pipelineConfig.graphqls
+++ b/front50-web/src/main/resources/graphql/pipelineConfig.graphqls
@@ -20,6 +20,7 @@ type Pipeline {
   keepWaitingPipelines: Boolean!
   lastModifiedBy: String!
   limitConcurrent: Boolean!
+  maxConcurrentExecutions: Int!
   parameterConfig: [ParameterConfig]!
   spelEvaluator: String!
   stageCounter: Int


### PR DESCRIPTION
It adds support for max concurrent pipeline executions. If concurrent pipeline execution is enabled, pipelines will queue when the max concurrent pipeline executions is reached. Any queued pipelines will be allowed to run once the number of running pipeline executions drops below the max. If the max is set to 0, then pipelines will not queue.

This is the proposed change for spinnaker/spinnaker#6558.

Changes to orca, deck and echo are also needed in order to expose max concurrent pipeline executions as a pipeline configuration to Spinnaker users.

(Orca pull request: https://github.com/spinnaker/orca/pull/4193)
(Echo pull request: https://github.com/spinnaker/echo/pull/1134)
(Deck pull request: https://github.com/spinnaker/deck/pull/9777)