### PR TITLE
fix(dependency): Forcing google-api-services-storage and google-auth-library-oauth2-http version for desired conflict resolution

### DIFF
--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -21,8 +21,12 @@ dependencies {
   implementation project(":front50-api")
 
   implementation "com.fasterxml.jackson.core:jackson-databind"
-  implementation "com.google.apis:google-api-services-storage"
-  implementation "com.google.auth:google-auth-library-oauth2-http"
+  implementation ("com.google.apis:google-api-services-storage:v1-rev20200326-1.30.9") {
+       force=true
+  }
+  implementation ("com.google.auth:google-auth-library-oauth2-http:0.20.0") {
+       force=true
+  }
   // TODO(plumpy): remove version once added to kork
   implementation "com.google.cloud:google-cloud-storage:1.108.0"
   implementation "com.google.guava:guava"


### PR DESCRIPTION
While enforcing the direct and transitive dependencies strictly from kork-bom using "enforcedPlatform" in build.gradle as:

implementation(enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion"))

google-api-services-storage:v1-rev141-1.25.0 and google-auth-library-oauth2-http:0.18.0 is overriding the google-api-services-storage:v1-rev20200326-1.30.9 and google-auth-library-oauth2-http:0.20.0 version, which is an older version coming from kork-bom mentioned in spinnaker-dependencies.gradle.
It is causing following errors in front50-gcs module as given below:

```
> Task :front50-gcs:compileTestKotlin FAILED
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (23, 46): Unresolved reference: HmacKey
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (24, 46): Unresolved reference: HmacKeyMetadata
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (187, 80): Unresolved reference: HmacKeyMetadata
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (206, 47): Unresolved reference: HmacKeyMetadata
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (206, 99): Unresolved reference: HmacKeyMetadata
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (222, 47): Unresolved reference: HmacKeyMetadata
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (279, 93): Unresolved reference: HmacKeyMetadata
e: /home/ubuntu/spinnaker-comp/sb-upgrade-2-3-12/front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/FakeStorageRpc.kt: (323, 94): Unresolved reference: HmacKey
```
---------------------
```
> Task :front50-gcs:test

GcsIntegrationTest > startupTest(GcsStorageService) FAILED
    java.lang.IllegalStateException: Failed to load ApplicationContext
        at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:132)
        at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:123)
        Caused by:
        org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'googleCloudStorage' defined in com.netflix.spinnaker.front50.config.GcsConfig: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.google.cloud.storage.Storage]: Factory method 'googleCloudStorage' threw exception; nested exception is java.lang.NoClassDefFoundError: com/google/auth/oauth2/QuotaProjectIdProvider
            Caused by:
            org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.google.cloud.storage.Storage]: Factory method 'googleCloudStorage' threw exception; nested exception is java.lang.NoClassDefFoundError: com/google/auth/oauth2/QuotaProjectIdProvider
                at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:185)
                Caused by:
                java.lang.NoClassDefFoundError: com/google/auth/oauth2/QuotaProjectIdProvider
                    at com.google.cloud.ServiceOptions$Builder.setCredentials(ServiceOptions.java:220)
                    at com.netflix.spinnaker.front50.config.GcsConfig.googleCloudStorage(GcsConfig.java:130)
                    at com.netflix.spinnaker.front50.config.GcsConfig$$EnhancerBySpringCGLIB$$ea6e0ac7.CGLIB$googleCloudStorage$1(<generated>)
```
In order to fix, we require google-api-services-storage:v1-rev20200326-1.30.9 and google-auth-library-oauth2-http:0.20.0 to force restore.
Forcing the specified version will take precedence during conflict resolution and provide desired version.