### PR TITLE
fix(dependencies): update resteasy to remove CVE

### DIFF
--- a/front50-swift/front50-swift.gradle
+++ b/front50-swift/front50-swift.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-core"
   implementation "org.springframework:spring-web"
   implementation 'org.pacesys:openstack4j:3.2.0'
+  implementation 'org.jboss.resteasy:resteasy-jaxrs:3.12.1.Final'
 
   testImplementation project(":front50-test")
 }


### PR DESCRIPTION
An old version of resteasy is resolved transitively through org.pacesys:openstack4j in front50-swift. Updating this removes CVE-2020-1695.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1695

At Armory, we have been running this config for over a year, so this is a pretty safe change. We are just moving our own overrides to open source to fix CVE's for everyone.
|    |    |    \--- org.pacesys:openstack4j:3.2.0
|    |    |         +--- org.pacesys.openstack4j.connectors:openstack4j-resteasy:3.2.0
|    |    |         |    +--- org.jboss.resteasy:resteasy-client:3.1.4.Final
|    |    |         |    |    +--- org.jboss.resteasy:resteasy-jaxrs:3.1.4.Final -> 3.12.1.Final
