### PR TITLE
fix(pipeline): include updated timestamp

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -36,7 +36,7 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private List<Trigger> triggers = new ArrayList<>();
   @Getter @Setter private Integer index;
 
-  private String updateTs;
+  @Getter private String updateTs;
   private String createTs;
   private String lastModifiedBy;
   private String lastModified;


### PR DESCRIPTION
Add back the last modified timestamp property `updateTs` to pipelines, which is expected by things like deck to provide revision history.