### PR TITLE
fix(build): Remove extra repository

### DIFF
--- a/front50-azure/front50-azure.gradle
+++ b/front50-azure/front50-azure.gradle
@@ -13,13 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-repositories {
-  maven { url "https://adxsnapshots.azurewebsites.net" }
-}
-
-repositories {
-  maven { url "https://adxsnapshots.azurewebsites.net" }
-}
 
 dependencies {
   implementation project(":front50-core")


### PR DESCRIPTION
This change removes the addition of the Azure snapshot repo, that was also
duplicated.

All of the dependencies used are hosted at Maven Central, so there's really
no need to have this extra repo defined.
