### PR TITLE
fix: Revision history is not showing the timestamp of the revision

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -59,7 +59,9 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private String spelEvaluator;
 
   public String getUpdateTs() {
-    return getLastModified().toString();
+    var lastModified = getLastModified();
+
+    return lastModified != null ? lastModified.toString() : null;
   }
 
   public void setAny(String key, Object value) {

--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -36,7 +36,7 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private List<Trigger> triggers = new ArrayList<>();
   @Getter @Setter private Integer index;
 
-  @Getter private String updateTs;
+  @Getter @Setter private String updateTs;
   private String createTs;
   private String lastModifiedBy;
   private String lastModified;

--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -16,6 +16,7 @@
  */
 package com.netflix.spinnaker.front50.api.model.pipeline;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
 import java.util.*;
 import lombok.Getter;
@@ -36,10 +37,10 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private List<Trigger> triggers = new ArrayList<>();
   @Getter @Setter private Integer index;
 
-  @Getter @Setter private String updateTs;
   private String createTs;
+  @JsonIgnore private String updateTs;
   private String lastModifiedBy;
-  private String lastModified;
+  @Getter @Setter private Long lastModified;
 
   @Getter @Setter private String email;
   @Getter @Setter private Boolean disabled;
@@ -57,6 +58,10 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private List<Map<String, Object>> parameterConfig;
   @Getter @Setter private String spelEvaluator;
 
+  public String getUpdateTs() {
+    return getLastModified().toString();
+  }
+
   public void setAny(String key, Object value) {
     anyMap.put(key, value);
   }
@@ -68,22 +73,6 @@ public class Pipeline implements Timestamped {
   @Override
   public String getId() {
     return this.id;
-  }
-
-  @Override
-  public Long getLastModified() {
-    String updateTs = this.updateTs;
-    if (updateTs == null || updateTs == "") {
-      return null;
-    }
-    return Long.valueOf(updateTs);
-  }
-
-  @Override
-  public void setLastModified(Long lastModified) {
-    if (lastModified != null) {
-      this.updateTs = lastModified.toString();
-    }
   }
 
   @Override


### PR DESCRIPTION
**Observed Behavior**

<img width="729" alt="image" src="https://user-images.githubusercontent.com/106548537/181593333-0d0abc7b-faa6-4025-963b-133e4fddf4b0.png">

**Expected Behavior**

<img width="288" alt="image" src="https://user-images.githubusercontent.com/106548537/181593422-7a052759-b014-4f78-8048-9b6a4f37c2a3.png">

**Issue reason**

Desk uses this request to update pipeline.

POST http://{host}:8084/pipelines?staleCheck=true

```
payload {
  "id": string,
  "name": string,
  "application": string,
  "schema": string,
  "triggers": [],
  "index": number,
  "updateTs": "1659026349611",
  "lastModifiedBy": string,
  "stages": object[],
  "keepWaitingPipelines": bolean,
  "limitConcurrent": bolean,
  "spelEvaluator": string
}
```

As you can see, it has `updateTs` field inside the payload, so we need to have setter function to deserialize this DTO correctly.
