### PR TITLE
fix(updateTs): missing updateTs field in the get pipeline history's response.

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -16,9 +16,11 @@
  */
 package com.netflix.spinnaker.front50.api.model.pipeline;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -38,7 +40,7 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private Integer index;
 
   private String createTs;
-  @JsonIgnore private String updateTs;
+  private String updateTs;
   private String lastModifiedBy;
   @Getter @Setter private Long lastModified;
 


### PR DESCRIPTION
**What?**

`updateTs` field is missing in the response of `GET {host}/pipelines/{pipelineId}/history` endpoint. As a result, the pipeline revision history is not showing the timestamp of the revision.

![image](https://user-images.githubusercontent.com/106548537/189147265-946d279a-f02e-4e10-9300-eaf1c4a8858e.png)


