### PR TITLE
fix(pipelines): prevent from creating duplicated pipelines

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -143,7 +143,7 @@ public class PipelineController {
   @PreAuthorize(
       "@fiatPermissionEvaluator.storeWholePermission() and hasPermission(#pipeline.application, 'APPLICATION', 'WRITE') and @authorizationSupport.hasRunAsUserPermission(#pipeline)")
   @RequestMapping(value = "", method = RequestMethod.POST)
-  public Pipeline save(
+  public synchronized Pipeline save(
       @RequestBody Pipeline pipeline,
       @RequestParam(value = "staleCheck", required = false, defaultValue = "false")
           Boolean staleCheck) {


### PR DESCRIPTION
We've noticed that sometimes spinnaker users end up with duplicated pipelines when using pipelines as a code. In my opinion the logic in PipelineController that creates a pipeline is not safe in a multithreaded environment as we validate pipeline duplicates in line 151, but we actually persist it in line 165. It's likely that two threads running simultaneously will pass validation due to lack of duplicates and then they will persist it.

This simple fix prevents from aforementioned scenario. 