### PR TITLE
chore(dependencies): remove dependency on groovy-all where straightforward

### DIFF
--- a/front50-redis/front50-redis.gradle
+++ b/front50-redis/front50-redis.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation project(":front50-api")
   implementation "io.spinnaker.kork:kork-exceptions"
 
-  implementation("org.codehaus.groovy:groovy-all")
+  implementation("org.codehaus.groovy:groovy")
 
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/front50-test/front50-test.gradle
+++ b/front50-test/front50-test.gradle
@@ -21,7 +21,7 @@ dependencies {
   implementation project(":front50-core")
   implementation project(":front50-s3")
 
-  implementation "org.codehaus.groovy:groovy-all"
+  implementation "org.codehaus.groovy:groovy"
   implementation "org.spockframework:spock-core"
   implementation "com.amazonaws:aws-java-sdk-s3"
 }


### PR DESCRIPTION
with a specific goal to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.
