### PR TITLE
fix(redis): Issue with front50-redis module while upgrading the spring boot 2.5.x

### DIFF
--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineTemplateDAO.java
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineTemplateDAO.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Spliterators;
@@ -60,8 +59,6 @@ public class RedisPipelineTemplateDAO implements PipelineTemplateDAO {
       return StreamSupport.stream(Spliterators.spliteratorUnknownSize(c, 0), false)
           .map(e -> (PipelineTemplate) e.getValue())
           .collect(Collectors.toList());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
During upgrade of spring boot from 2.4.x to 2.5.x, encountered the below build error in front50

```
> Task :front50-redis:compileGroovy
/front50/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineTemplateDAO.java:63: error: exception IOException is never thrown in body of corresponding try statement
    } catch (IOException e) {
      ^
1 error
startup failed:
Compilation failed; see the compiler error output for details.

1 error

> Task :front50-redis:compileGroovy FAILED
```

The root cause of this issue is the change of extended interface `java.io.Closeable` for `org.springframework.data.redis.core.Cursor`. With spring boot 2.4.13, spring-data-redis 2.4.15 is used and [Cursor](https://docs.spring.io/spring-data/redis/docs/2.4.15/api/) interface inherits `java.io.Closeable` [interface](https://docs.oracle.com/javase/8/docs/api/java/io/Closeable.html?is-external=true), that contains Closeable.close() method which throws IOException. Whereas spring boot 2.5.x, uses spring-data-redis 2.5.11 and [Cursor](https://docs.spring.io/spring-data/redis/docs/2.5.11/api/org/springframework/data/redis/core/Cursor.html) interface does not inherits Closeable interface. The fix is removal of catch block. But this fix will break front50 with spring boot 2.4.x (present master) and it will pass with spring boot 2.5.x. So, it must be merged after performing the upgrade autobump commit.