### PR TITLE
feat(pipeline/kubernetes): Migrate existing K8s deploy manifest traffic management from redblack to bluegreen

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
@@ -17,8 +17,6 @@ package com.netflix.spinnaker.front50.migrations;
 
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
-import java.time.Clock;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +29,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class RedBlackToBlueGreenK8sPipelinesMigration implements Migration {
 
-  private static final LocalDate VALID_UNTIL = LocalDate.of(2023, 6, 1);
-
   private final PipelineDAO pipelineDAO;
 
   public RedBlackToBlueGreenK8sPipelinesMigration(PipelineDAO pipelineDAO) {
@@ -41,7 +37,7 @@ public class RedBlackToBlueGreenK8sPipelinesMigration implements Migration {
 
   @Override
   public boolean isValid() {
-    return LocalDate.now(Clock.systemDefaultZone()).isBefore(VALID_UNTIL);
+    return true;
   }
 
   @Override
@@ -60,6 +56,7 @@ public class RedBlackToBlueGreenK8sPipelinesMigration implements Migration {
         .filter(RedBlackToBlueGreenK8sPipelinesMigration::kubernetesProvider)
         .filter(RedBlackToBlueGreenK8sPipelinesMigration::deployManifestStage)
         .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagement)
+        .filter(Objects::nonNull)
         .filter(RedBlackToBlueGreenK8sPipelinesMigration::trafficManagementEnabled)
         .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagementOptions)
         .forEach(

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -83,6 +84,7 @@ public class RedBlackToBlueGreenK8sPipelinesMigration implements Migration {
             .filter(RedBlackToBlueGreenK8sPipelinesMigration::kubernetesProvider)
             .filter(RedBlackToBlueGreenK8sPipelinesMigration::deployManifestStage)
             .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagement)
+            .filter(Objects::nonNull)
             .filter(RedBlackToBlueGreenK8sPipelinesMigration::trafficManagementEnabled)
             .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagementOptions)
             .anyMatch(RedBlackToBlueGreenK8sPipelinesMigration::redBlackStrategy);

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.front50.migrations;
+
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class RedBlackToBlueGreenK8sPipelinesMigration implements Migration {
+
+  private static final LocalDate VALID_UNTIL = LocalDate.of(2023, 6, 1);
+
+  private final PipelineDAO pipelineDAO;
+
+  public RedBlackToBlueGreenK8sPipelinesMigration(PipelineDAO pipelineDAO) {
+    this.pipelineDAO = pipelineDAO;
+  }
+
+  @Override
+  public boolean isValid() {
+    return LocalDate.now(Clock.systemDefaultZone()).isBefore(VALID_UNTIL);
+  }
+
+  @Override
+  public void run() {
+    log.info(
+        "Starting the migration of K8s pipelines using RED/BLACK traffic management strategy to BLUE/GREEN");
+    pipelineDAO.all().stream()
+        .filter(RedBlackToBlueGreenK8sPipelinesMigration.pipelineWithRedBlackStrategyPredicate())
+        .forEach(this::migrate);
+  }
+
+  private void migrate(Pipeline pipeline) {
+    List<Map<String, Object>> stages = new ArrayList<>(pipeline.getStages());
+
+    stages.stream()
+        .filter(RedBlackToBlueGreenK8sPipelinesMigration::kubernetesProvider)
+        .filter(RedBlackToBlueGreenK8sPipelinesMigration::deployManifestStage)
+        .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagement)
+        .filter(RedBlackToBlueGreenK8sPipelinesMigration::trafficManagementEnabled)
+        .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagementOptions)
+        .forEach(
+            trafficManagementOptions -> {
+              Object strategy = trafficManagementOptions.get("strategy");
+              if ("redblack".equals(strategy)) {
+                trafficManagementOptions.put("strategy", "bluegreen");
+              }
+            });
+
+    this.pipelineDAO.update(pipeline.getId(), pipeline);
+    log.info(
+        "Migrated pipeline (application: {}, pipelineId: {}, name: {})",
+        pipeline.getApplication(),
+        pipeline.getId(),
+        pipeline.getName());
+  }
+
+  private static Predicate<Pipeline> pipelineWithRedBlackStrategyPredicate() {
+    return pipeline ->
+        pipeline.getStages().stream()
+            .filter(RedBlackToBlueGreenK8sPipelinesMigration::kubernetesProvider)
+            .filter(RedBlackToBlueGreenK8sPipelinesMigration::deployManifestStage)
+            .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagement)
+            .filter(RedBlackToBlueGreenK8sPipelinesMigration::trafficManagementEnabled)
+            .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagementOptions)
+            .anyMatch(RedBlackToBlueGreenK8sPipelinesMigration::redBlackStrategy);
+  }
+
+  private static Map<String, Object> getTrafficManagementOptions(
+      Map<String, Object> trafficManagement) {
+    return (Map<String, Object>) trafficManagement.get("options");
+  }
+
+  private static boolean trafficManagementEnabled(Map<String, Object> trafficManagement) {
+    return Boolean.TRUE.equals(trafficManagement.get("enabled"));
+  }
+
+  private static Map<String, Object> getTrafficManagement(Map<String, Object> stage) {
+    return (Map<String, Object>) stage.get("trafficManagement");
+  }
+
+  private static boolean kubernetesProvider(Map<String, Object> stage) {
+    return "kubernetes".equals(stage.get("cloudProvider"));
+  }
+
+  private static boolean deployManifestStage(Map<String, Object> stage) {
+    return "deployManifest".equals(stage.get("type"));
+  }
+
+  private static boolean redBlackStrategy(Map<String, Object> stage) {
+    return "redblack".equals(stage.get("strategy"));
+  }
+}

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigrationSpec.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.migrations
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.front50.api.model.Timestamped
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins
+import com.netflix.spinnaker.front50.jackson.mixins.TimestampedMixins
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import spock.lang.Specification
+import spock.lang.Subject
+
+class RedBlackToBlueGreenK8sPipelinesMigrationSpec extends Specification {
+
+
+  def pipelineWithHighlanderStrategy = "{\"id\":\"pipeline-1\",\"name\":null,\"application\":\"application1\",\"type\":null,\"schema\":\"1\",\"config\":null,\"triggers\":[],\"index\":null,\"updateTs\":null,\"lastModifiedBy\":null,\"lastModified\":null,\"email\":null,\"disabled\":null,\"template\":null,\"roles\":null,\"serviceAccount\":null,\"executionEngine\":null,\"stageCounter\":null,\"stages\":[{\"cloudProvider\":\"kubernetes\",\"trafficManagement\":{\"options\":{\"strategy\":\"highlander\"},\"enabled\":true},\"type\":\"deployManifest\"}],\"constraints\":null,\"payloadConstraints\":null,\"keepWaitingPipelines\":null,\"limitConcurrent\":null,\"maxConcurrentExecutions\":null,\"parameterConfig\":null,\"spelEvaluator\":null,\"any\":{},\"createdAt\":null}"
+
+  def pipelineDAO = Mock(PipelineDAO)
+  def objectMapper = new ObjectMapper().addMixIn(Timestamped.class, TimestampedMixins.class)
+    .addMixIn(Pipeline.class, PipelineMixins.class)
+
+  @Subject
+  def migration = new RedBlackToBlueGreenK8sPipelinesMigration(pipelineDAO)
+
+  def "should not migrate K8s pipeline that is not using redblack strategy"() {
+    given:
+    def pipeline = this.objectMapper.readValue(pipelineWithHighlanderStrategy, Pipeline.class)
+
+    when:
+    migration.run()
+
+    then:
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update("pipeline-1", _)
+    0 * _
+  }
+
+
+  def "should migrate K8s pipeline that is using redblack strategy"() {
+    given:
+    def pipelineWithRedBlackStrategy = "{\"id\":\"pipeline-2\",\"name\":null,\"application\":\"application2\",\"type\":null,\"schema\":\"1\",\"config\":null,\"triggers\":[],\"index\":null,\"updateTs\":null,\"lastModifiedBy\":null,\"lastModified\":null,\"email\":null,\"disabled\":null,\"template\":null,\"roles\":null,\"serviceAccount\":null,\"executionEngine\":null,\"stageCounter\":null,\"stages\":[{\"cloudProvider\":\"kubernetes\",\"trafficManagement\":{\"options\":{\"strategy\":\"redblack\"},\"enabled\":true},\"type\":\"deployManifest\"}],\"constraints\":null,\"payloadConstraints\":null,\"keepWaitingPipelines\":null,\"limitConcurrent\":null,\"maxConcurrentExecutions\":null,\"parameterConfig\":null,\"spelEvaluator\":null,\"any\":{},\"createdAt\":null}"
+    def expectedPipelineBlueGreenStrategy = "{\"id\":\"pipeline-2\",\"application\":\"application2\",\"schema\":\"1\",\"triggers\":[],\"stages\":[{\"cloudProvider\":\"kubernetes\",\"trafficManagement\":{\"options\":{\"strategy\":\"bluegreen\"},\"enabled\":true},\"type\":\"deployManifest\"}],\"lastModified\":null,\"any\":{}}"
+    def pipeline = this.objectMapper.readValue(pipelineWithRedBlackStrategy, Pipeline.class)
+    def inputPipeline
+
+    when:
+    migration.run()
+
+    then:
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    1 * pipelineDAO.update("pipeline-2", _) >> { arguments -> inputPipeline = arguments[1] }
+    0 * _
+    inputPipeline instanceof Pipeline
+    this.objectMapper.writeValueAsString(inputPipeline) == expectedPipelineBlueGreenStrategy
+  }
+}
+
+

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigrationSpec.groovy
@@ -50,6 +50,33 @@ class RedBlackToBlueGreenK8sPipelinesMigrationSpec extends Specification {
     0 * _
   }
 
+  def "should not migrate K8s pipeline when traffic management is not defined"() {
+    given:
+    def pipelineWithNoTrafficManagement = "{\"id\":\"pipeline-1\",\"name\":null,\"application\":\"application1\",\"type\":null,\"schema\":\"1\",\"config\":null,\"triggers\":[],\"index\":null,\"updateTs\":null,\"lastModifiedBy\":null,\"lastModified\":null,\"email\":null,\"disabled\":null,\"template\":null,\"roles\":null,\"serviceAccount\":null,\"executionEngine\":null,\"stageCounter\":null,\"stages\":[{\"cloudProvider\":\"kubernetes\",\"type\":\"deployManifest\"}],\"constraints\":null,\"payloadConstraints\":null,\"keepWaitingPipelines\":null,\"limitConcurrent\":null,\"maxConcurrentExecutions\":null,\"parameterConfig\":null,\"spelEvaluator\":null,\"any\":{},\"createdAt\":null}"
+    def pipeline = this.objectMapper.readValue(pipelineWithNoTrafficManagement, Pipeline.class)
+
+    when:
+    migration.run()
+
+    then:
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update("pipeline-1", _)
+    0 * _
+  }
+
+  def "should not migrate K8s pipeline that doesn't have a deploy manifest stage"() {
+    given:
+    def pipelineWithBakeManifestStage = "{\"id\":\"pipeline-1\",\"name\":null,\"application\":\"application1\",\"type\":null,\"schema\":\"1\",\"config\":null,\"triggers\":[],\"index\":null,\"updateTs\":null,\"lastModifiedBy\":null,\"lastModified\":null,\"email\":null,\"disabled\":null,\"template\":null,\"roles\":null,\"serviceAccount\":null,\"executionEngine\":null,\"stageCounter\":null,\"stages\":[{\"cloudProvider\":\"kubernetes\",\"type\":\"bakeManifest\"}],\"constraints\":null,\"payloadConstraints\":null,\"keepWaitingPipelines\":null,\"limitConcurrent\":null,\"maxConcurrentExecutions\":null,\"parameterConfig\":null,\"spelEvaluator\":null,\"any\":{},\"createdAt\":null}"
+    def pipeline = this.objectMapper.readValue(pipelineWithBakeManifestStage, Pipeline.class)
+
+    when:
+    migration.run()
+
+    then:
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update("pipeline-1", _)
+    0 * _
+  }
 
   def "should migrate K8s pipeline that is using redblack strategy"() {
     given:


### PR DESCRIPTION
Migrate existing K8s deploy manifest traffic management from redblack to bluegreen

The migration loads all the k8s pipelines that are currently using red/black traffic management, and it is updating all pipelines to the new terminology blue/green

Pipeline inserted in MySQL using **redblack** strategy
![image](https://user-images.githubusercontent.com/105648914/211801979-ae1c8acf-9131-4191-aff2-4bf247d25d3d.png)

After the migration, the strategy will be **bluegreen**
![image](https://user-images.githubusercontent.com/105648914/211802865-95269664-1e1d-4036-821d-3460301d917d.png)

![image](https://user-images.githubusercontent.com/105648914/211802429-53699112-8131-427f-b1ec-e11547c9c340.png)
