### PR TITLE
feat(migration): ability to disable deleting orphaned objects

### DIFF
--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfiguration.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfiguration.kt
@@ -84,5 +84,6 @@ data class StorageServiceMigratorConfigurationProperties(
   var previousClass: String? = null,
   var primaryName: String? = null,
   var previousName: String? = null,
-  var writeOnly: Boolean = false
+  var writeOnly: Boolean = false,
+  var deleteOrphans: Boolean = true
 )

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
@@ -60,33 +60,38 @@ class StorageServiceMigrator(
 
     val targetObjectKeys = target.listObjectKeys(objectType)
 
-    val deletableObjectKeys = targetObjectKeys.filter { e ->
-      // only cleanup "orphans" if they don't exist in source _AND_ they are at least five minutes old
-      // (accounts for edge cases around eventual consistency reads in s3)9
-      !sourceObjectKeys.containsKey(e.key) && (e.value + TimeUnit.MINUTES.toMillis(5)) < System.currentTimeMillis()
-    }
-
-    if (!deletableObjectKeys.isEmpty()) {
-      /*
-       * Handle a situation where deletes can still happen directly against the source/previous storage service.
-       *
-       * In these cases, the delete should also be reflected in the primary/target storage service.
-       */
-      log.info(
-        "Found orphaned objects in {} (keys: {})",
-        source.javaClass.simpleName,
-        deletableObjectKeys.keys.joinToString(", ")
-      )
-
-      deletableObjectKeys.keys.forEach {
-        target.deleteObject(objectType, it)
+    if (dynamicConfigService.isEnabled("spinnaker.migration.compositeStorageService.writeOnly", false)) {
+      log.info("Checking for orphaned objects in {}", target.javaClass.simpleName)
+      val deletableObjectKeys = targetObjectKeys.filter { e ->
+        // only cleanup "orphans" if they don't exist in source _AND_ they are at least five minutes old
+        // (accounts for edge cases around eventual consistency reads in s3)9
+        !sourceObjectKeys.containsKey(e.key) && (e.value + TimeUnit.MINUTES.toMillis(5)) < System.currentTimeMillis()
       }
 
-      log.info(
-        "Deleted orphaned objects from {} (keys: {})",
-        target.javaClass.simpleName,
-        deletableObjectKeys.keys.joinToString(", ")
-      )
+      if (deletableObjectKeys.isNotEmpty()) {
+        /*
+         * Handle a situation where deletes can still happen directly against the source/previous storage service.
+         *
+         * In these cases, the delete should also be reflected in the primary/target storage service.
+         */
+        log.info(
+          "Found orphaned objects in {} (keys: {})",
+          source.javaClass.simpleName,
+          deletableObjectKeys.keys.joinToString(", ")
+        )
+
+        deletableObjectKeys.keys.forEach {
+          target.deleteObject(objectType, it)
+        }
+
+        log.info(
+          "Deleted orphaned objects from {} (keys: {})",
+          target.javaClass.simpleName,
+          deletableObjectKeys.keys.joinToString(", ")
+        )
+      }
+    } else {
+      log.info("Not deleting orphaned objects in the primary datasource as writeOnly mode is enabled")
     }
 
     val migratableObjectKeys = sourceObjectKeys.filter { e ->

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
@@ -60,7 +60,7 @@ class StorageServiceMigrator(
 
     val targetObjectKeys = target.listObjectKeys(objectType)
 
-    if (dynamicConfigService.isEnabled("spinnaker.migration.compositeStorageService.writeOnly", false)) {
+    if (dynamicConfigService.getConfig(Boolean::class.java, "spinnaker.migration.compositeStorageService.writeOnly", false)) {
       log.info("Checking for orphaned objects in {}", target.javaClass.simpleName)
       val deletableObjectKeys = targetObjectKeys.filter { e ->
         // only cleanup "orphans" if they don't exist in source _AND_ they are at least five minutes old

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigrator.kt
@@ -60,7 +60,7 @@ class StorageServiceMigrator(
 
     val targetObjectKeys = target.listObjectKeys(objectType)
 
-    if (dynamicConfigService.getConfig(Boolean::class.java, "spinnaker.migration.compositeStorageService.writeOnly", false)) {
+    if (dynamicConfigService.getConfig(Boolean::class.java, "spinnaker.migration.compositeStorageService.deleteOrphans", true)) {
       log.info("Checking for orphaned objects in {}", target.javaClass.simpleName)
       val deletableObjectKeys = targetObjectKeys.filter { e ->
         // only cleanup "orphans" if they don't exist in source _AND_ they are at least five minutes old
@@ -91,7 +91,7 @@ class StorageServiceMigrator(
         )
       }
     } else {
-      log.info("Not deleting orphaned objects in the primary datasource as writeOnly mode is enabled")
+      log.info("Not deleting orphaned objects in {} as deleteOrphans is disabled", source.javaClass.simpleName)
     }
 
     val migratableObjectKeys = sourceObjectKeys.filter { e ->

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigratorTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/migrations/StorageServiceMigratorTests.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 JPMorgan Chase & Co.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.migrations
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.front50.model.ObjectType
+import com.netflix.spinnaker.front50.model.SqlStorageService
+import com.netflix.spinnaker.front50.model.tag.EntityTagsDAO
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.web.context.RequestContextProvider
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.*
+import java.util.concurrent.TimeUnit
+
+class StorageServiceMigratorTests : JUnit5Minutests {
+  private val dynamicConfigService: DynamicConfigService = mockk(relaxUnitFun = true)
+  private val target: SqlStorageService = mockk(relaxUnitFun = true)
+  private val source: SqlStorageService = mockk(relaxUnitFun = true)
+  private val entityTagsDAO: EntityTagsDAO = mockk(relaxUnitFun = true)
+  private val contextProvider: RequestContextProvider = mockk(relaxUnitFun = true)
+
+  private val subject = StorageServiceMigrator(dynamicConfigService, NoopRegistry(), target, source, entityTagsDAO, contextProvider)
+
+  fun tests() = rootContext {
+    after {
+      clearMocks(dynamicConfigService, target, source, entityTagsDAO, contextProvider)
+    }
+
+    context("migrate()") {
+      test("should not delete orphaned objects less than 5 minutes old") {
+        every {
+          source.listObjectKeys(ObjectType.APPLICATION)
+        } returns mapOf()
+
+        every {
+          target.listObjectKeys(ObjectType.APPLICATION)
+        } returns mapOf("id-application-0" to System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(3))
+
+        every {
+          dynamicConfigService.getConfig(
+            Boolean::class.java,
+            "spinnaker.migration.compositeStorageService.deleteOrphans",
+            any()
+          )
+        } returns true
+
+        subject.migrate(ObjectType.APPLICATION)
+
+        verify(exactly = 0) {
+          target.deleteObject(ObjectType.APPLICATION, "id-application-0")
+        }
+      }
+
+      test("should delete orphaned objects in primary when deleteOrphans is true") {
+        every {
+          source.listObjectKeys(ObjectType.APPLICATION)
+        } returns mapOf()
+
+        every {
+          target.listObjectKeys(ObjectType.APPLICATION)
+        } returns mapOf("id-application-0" to System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(6))
+
+        every {
+          dynamicConfigService.getConfig(
+            Boolean::class.java,
+            "spinnaker.migration.compositeStorageService.deleteOrphans",
+            any()
+          )
+        } returns true
+
+        subject.migrate(ObjectType.APPLICATION)
+
+        verify(exactly = 1) {
+          target.deleteObject(ObjectType.APPLICATION, "id-application-0")
+        }
+      }
+
+      test("should not delete orphaned objects in primary when deleteOrphans is false") {
+        every {
+          source.listObjectKeys(ObjectType.APPLICATION)
+        } returns mapOf()
+
+        every {
+          target.listObjectKeys(ObjectType.APPLICATION)
+        } returns mapOf("id-application-0" to System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(6))
+
+        every {
+          dynamicConfigService.getConfig(
+            Boolean::class.java,
+            "spinnaker.migration.compositeStorageService.deleteOrphans",
+            any()
+          )
+        } returns false
+
+        subject.migrate(ObjectType.APPLICATION)
+
+        verify(exactly = 0) {
+          target.deleteObject(ObjectType.APPLICATION, "id-application-0")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `writeOnly` flag is currently unused, so repurposing it to toggle disabling deletion of "orphaned" objects in the target datasource.

Useful when "merging" two disparate instances of Spinnaker together.