### PR TITLE
chore(tests): Cleanup of useJUnitPlatform() from sub-modules and introducing junit-vintage-engine in front50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects { project ->
       testLogging {
         exceptionFormat = 'full'
       }
+      useJUnitPlatform()
     }
 
     tasks.withType(JavaExec) {
@@ -70,6 +71,7 @@ subprojects { project ->
       testImplementation("org.springframework:spring-test")
       testImplementation("org.hamcrest:hamcrest-core")
       testRuntimeOnly("cglib:cglib-nodep")
+      testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
       testRuntimeOnly("org.objenesis:objenesis")
     }
   }

--- a/front50-api-tck/front50-api-tck.gradle
+++ b/front50-api-tck/front50-api-tck.gradle
@@ -14,9 +14,3 @@ dependencies {
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines "junit-jupiter"
-  }
-}

--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -49,9 +49,3 @@ dependencies {
   testImplementation "io.mockk:mockk"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines "junit-jupiter"
-  }
-}

--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -30,9 +30,3 @@ dependencies {
   // Only used for Initializing Datasource. For actual CRUD, test containers preferred.
   testImplementation "com.h2database:h2"
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
-}


### PR DESCRIPTION
Cleaning up the call for test engines using `useJUnitPlatform()` from individual sub-modules, and placing it in build.gradle at root. As per the gradle docs, all test engines on the test runtime classpath will be used by sub modules. 
https://docs.gradle.org/6.8.1/userguide/java_testing.html#filtering_test_engine

Spring boot 2.4.x removed JUnit5 vintage engine from spring-boot-starter-test.
[https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test]
It is required for executing junit4 based test cases in front50.
So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

Total test cases executed are 281.