### PR TITLE
feat(core + sql): Optimize cache refresh

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -75,7 +75,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getApplication().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getApplication().getRefreshMs(),
-        storageServiceConfigurationProperties.getApplication().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getApplication().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -95,7 +95,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
-        storageServiceConfigurationProperties.getApplicationPermission().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getApplicationPermission().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -114,7 +114,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getServiceAccount().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getServiceAccount().getRefreshMs(),
-        storageServiceConfigurationProperties.getServiceAccount().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getServiceAccount().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -133,7 +133,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getProject().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getProject().getRefreshMs(),
-        storageServiceConfigurationProperties.getProject().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getProject().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -152,7 +152,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getNotification().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getNotification().getRefreshMs(),
-        storageServiceConfigurationProperties.getNotification().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getNotification().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -171,7 +171,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getPipelineStrategy().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getPipelineStrategy().getRefreshMs(),
-        storageServiceConfigurationProperties.getPipelineStrategy().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getPipelineStrategy().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -190,7 +190,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getPipeline().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getPipeline().getRefreshMs(),
-        storageServiceConfigurationProperties.getPipeline().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getPipeline().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -209,7 +209,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getPipelineTemplate().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getPipelineTemplate().getRefreshMs(),
-        storageServiceConfigurationProperties.getPipelineTemplate().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getPipelineTemplate().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -228,7 +228,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getSnapshot().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getSnapshot().getRefreshMs(),
-        storageServiceConfigurationProperties.getSnapshot().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getSnapshot().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -247,7 +247,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getEntityTags().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getEntityTags().getRefreshMs(),
-        storageServiceConfigurationProperties.getEntityTags().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getEntityTags().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -266,7 +266,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getDeliveryConfig().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getDeliveryConfig().getRefreshMs(),
-        storageServiceConfigurationProperties.getDeliveryConfig().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getDeliveryConfig().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -285,7 +285,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getPluginInfo().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getPluginInfo().getRefreshMs(),
-        storageServiceConfigurationProperties.getPluginInfo().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getPluginInfo().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }
@@ -304,7 +304,7 @@ public class CommonStorageServiceDAOConfig {
                 storageServiceConfigurationProperties.getPluginInfo().getThreadPool())),
         objectKeyLoader,
         storageServiceConfigurationProperties.getPluginInfo().getRefreshMs(),
-        storageServiceConfigurationProperties.getPluginInfo().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getPluginInfo().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/CommonStorageServiceDAOConfig.java
@@ -74,8 +74,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getApplication().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getApplication().getRefreshMs(),
-        storageServiceConfigurationProperties.getApplication().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getApplication(),
         registry,
         circuitBreakerRegistry);
   }
@@ -94,8 +93,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
-        storageServiceConfigurationProperties.getApplicationPermission().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getApplicationPermission(),
         registry,
         circuitBreakerRegistry);
   }
@@ -113,8 +111,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getServiceAccount().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getServiceAccount().getRefreshMs(),
-        storageServiceConfigurationProperties.getServiceAccount().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getServiceAccount(),
         registry,
         circuitBreakerRegistry);
   }
@@ -132,8 +129,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getProject().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getProject().getRefreshMs(),
-        storageServiceConfigurationProperties.getProject().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getProject(),
         registry,
         circuitBreakerRegistry);
   }
@@ -151,8 +147,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getNotification().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getNotification().getRefreshMs(),
-        storageServiceConfigurationProperties.getNotification().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getNotification(),
         registry,
         circuitBreakerRegistry);
   }
@@ -170,8 +165,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getPipelineStrategy().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getPipelineStrategy().getRefreshMs(),
-        storageServiceConfigurationProperties.getPipelineStrategy().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getPipelineStrategy(),
         registry,
         circuitBreakerRegistry);
   }
@@ -189,8 +183,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getPipeline().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getPipeline().getRefreshMs(),
-        storageServiceConfigurationProperties.getPipeline().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getPipeline(),
         registry,
         circuitBreakerRegistry);
   }
@@ -208,8 +201,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getPipelineTemplate().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getPipelineTemplate().getRefreshMs(),
-        storageServiceConfigurationProperties.getPipelineTemplate().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getPipelineTemplate(),
         registry,
         circuitBreakerRegistry);
   }
@@ -227,8 +219,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getSnapshot().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getSnapshot().getRefreshMs(),
-        storageServiceConfigurationProperties.getSnapshot().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getSnapshot(),
         registry,
         circuitBreakerRegistry);
   }
@@ -246,8 +237,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getEntityTags().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getEntityTags().getRefreshMs(),
-        storageServiceConfigurationProperties.getEntityTags().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getEntityTags(),
         registry,
         circuitBreakerRegistry);
   }
@@ -265,8 +255,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getDeliveryConfig().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getDeliveryConfig().getRefreshMs(),
-        storageServiceConfigurationProperties.getDeliveryConfig().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getDeliveryConfig(),
         registry,
         circuitBreakerRegistry);
   }
@@ -284,8 +273,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getPluginInfo().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getPluginInfo().getRefreshMs(),
-        storageServiceConfigurationProperties.getPluginInfo().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getPluginInfo(),
         registry,
         circuitBreakerRegistry);
   }
@@ -303,8 +291,7 @@ public class CommonStorageServiceDAOConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getPluginInfo().getThreadPool())),
         objectKeyLoader,
-        storageServiceConfigurationProperties.getPluginInfo().getRefreshMs(),
-        storageServiceConfigurationProperties.getPluginInfo().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getPluginInfo(),
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
@@ -82,6 +82,12 @@ public class StorageServiceConfigurationProperties {
      */
     private boolean synchronizeCacheRefresh;
 
+    /**
+     * When true, for objects that support versioning, cache refreshes only query the data store for
+     * objects modified (or deleted) since the last refresh.
+     */
+    private boolean optimizeCacheRefreshes;
+
     public PerObjectType setThreadPool(int threadPool) {
       if (threadPool <= 1) {
         throw new IllegalArgumentException("threadPool must be >= 1");

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
@@ -73,6 +73,7 @@ public class StorageServiceConfigurationProperties {
     private int threadPool;
     private long refreshMs;
     private boolean shouldWarmCache;
+    private long cacheHealthCheckTimeoutSeconds = 90L;
 
     public PerObjectType setThreadPool(int threadPool) {
       if (threadPool <= 1) {

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
@@ -1,44 +1,86 @@
 package com.netflix.spinnaker.front50.config;
 
 import java.util.concurrent.TimeUnit;
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("storage-service")
 @Data
 public class StorageServiceConfigurationProperties {
 
-  private PerObjectType application = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType applicationPermission = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType serviceAccount = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType project = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType notification = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType pipelineStrategy = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType pipeline = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType pipelineTemplate = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType snapshot = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType deliveryConfig = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType pluginInfo = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1));
-  private PerObjectType entityTags = new PerObjectType(2, TimeUnit.MINUTES.toMillis(5), false);
+  private PerObjectType application =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType applicationPermission =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType serviceAccount =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType project =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType notification =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType pipelineStrategy =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType pipeline =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType pipelineTemplate =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType snapshot =
+      new PerObjectType()
+          .setThreadPool(2)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType deliveryConfig =
+      new PerObjectType()
+          .setThreadPool(20)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType pluginInfo =
+      new PerObjectType()
+          .setThreadPool(2)
+          .setRefreshMs(TimeUnit.MINUTES.toMillis(1))
+          .setShouldWarmCache(true);
+  private PerObjectType entityTags =
+      new PerObjectType().setThreadPool(2).setRefreshMs(TimeUnit.MINUTES.toMillis(5));
 
   @Data
-  @AllArgsConstructor
+  @Accessors(chain = true)
   public static class PerObjectType {
     private int threadPool;
     private long refreshMs;
     private boolean shouldWarmCache;
 
-    public PerObjectType(int threadPool, long refreshMs) {
-      this(threadPool, refreshMs, true);
-    }
-
-    public void setThreadPool(int threadPool) {
+    public PerObjectType setThreadPool(int threadPool) {
       if (threadPool <= 1) {
         throw new IllegalArgumentException("threadPool must be >= 1");
       }
 
       this.threadPool = threadPool;
+      return this;
     }
   }
 }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
@@ -75,6 +75,13 @@ public class StorageServiceConfigurationProperties {
     private boolean shouldWarmCache;
     private long cacheHealthCheckTimeoutSeconds = 90L;
 
+    /**
+     * When true, if multiple threads attempt to refresh the cache in StorageServiceSupport
+     * simultaneously, only one actually does the refresh. The others wait until it's complete. This
+     * reduces load on the data store.
+     */
+    private boolean synchronizeCacheRefresh;
+
     public PerObjectType setThreadPool(int threadPool) {
       if (threadPool <= 1) {
         throw new IllegalArgumentException("threadPool must be >= 1");

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java
@@ -1,9 +1,12 @@
 package com.netflix.spinnaker.front50.config;
 
 import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("storage-service")
+@Data
 public class StorageServiceConfigurationProperties {
 
   private PerObjectType application = new PerObjectType(20, TimeUnit.MINUTES.toMillis(1));
@@ -19,104 +22,9 @@ public class StorageServiceConfigurationProperties {
   private PerObjectType pluginInfo = new PerObjectType(2, TimeUnit.MINUTES.toMillis(1));
   private PerObjectType entityTags = new PerObjectType(2, TimeUnit.MINUTES.toMillis(5), false);
 
-  public PerObjectType getApplication() {
-    return application;
-  }
-
-  public void setApplication(PerObjectType application) {
-    this.application = application;
-  }
-
-  public PerObjectType getApplicationPermission() {
-    return applicationPermission;
-  }
-
-  public void setApplicationPermission(PerObjectType applicationPermission) {
-    this.applicationPermission = applicationPermission;
-  }
-
-  public PerObjectType getServiceAccount() {
-    return serviceAccount;
-  }
-
-  public void setServiceAccount(PerObjectType serviceAccount) {
-    this.serviceAccount = serviceAccount;
-  }
-
-  public PerObjectType getProject() {
-    return project;
-  }
-
-  public void setProject(PerObjectType project) {
-    this.project = project;
-  }
-
-  public PerObjectType getNotification() {
-    return notification;
-  }
-
-  public void setNotification(PerObjectType notification) {
-    this.notification = notification;
-  }
-
-  public PerObjectType getPipelineStrategy() {
-    return pipelineStrategy;
-  }
-
-  public void setPipelineStrategy(PerObjectType pipelineStrategy) {
-    this.pipelineStrategy = pipelineStrategy;
-  }
-
-  public PerObjectType getPipeline() {
-    return pipeline;
-  }
-
-  public void setPipeline(PerObjectType pipeline) {
-    this.pipeline = pipeline;
-  }
-
-  public PerObjectType getPipelineTemplate() {
-    return pipelineTemplate;
-  }
-
-  public void setPipelineTemplate(PerObjectType pipelineTemplate) {
-    this.pipelineTemplate = pipelineTemplate;
-  }
-
-  public PerObjectType getSnapshot() {
-    return snapshot;
-  }
-
-  public void setSnapshot(PerObjectType snapshot) {
-    this.snapshot = snapshot;
-  }
-
-  public PerObjectType getDeliveryConfig() {
-    return deliveryConfig;
-  }
-
-  public void setDeliveryConfig(PerObjectType deliveryConfig) {
-    this.deliveryConfig = deliveryConfig;
-  }
-
-  public PerObjectType getPluginInfo() {
-    return pluginInfo;
-  }
-
-  public void setPluginInfo(PerObjectType pluginInfo) {
-    this.pluginInfo = pluginInfo;
-  }
-
-  public PerObjectType getEntityTags() {
-    return entityTags;
-  }
-
-  public void setEntityTags(PerObjectType entityTags) {
-    this.entityTags = entityTags;
-  }
-
+  @Data
+  @AllArgsConstructor
   public static class PerObjectType {
-
     private int threadPool;
     private long refreshMs;
     private boolean shouldWarmCache;
@@ -125,42 +33,12 @@ public class StorageServiceConfigurationProperties {
       this(threadPool, refreshMs, true);
     }
 
-    public PerObjectType(int threadPool, long refreshMs, boolean shouldWarmCache) {
-      setThreadPool(threadPool);
-      setRefreshMs(refreshMs);
-      setShouldWarmCache(shouldWarmCache);
-    }
-
     public void setThreadPool(int threadPool) {
       if (threadPool <= 1) {
         throw new IllegalArgumentException("threadPool must be >= 1");
       }
 
       this.threadPool = threadPool;
-    }
-
-    public int getThreadPool() {
-      return threadPool;
-    }
-
-    public long getRefreshMs() {
-      return refreshMs;
-    }
-
-    public void setRefreshMs(long refreshMs) {
-      this.refreshMs = refreshMs;
-    }
-
-    public boolean isShouldWarmCache() {
-      return shouldWarmCache;
-    }
-
-    public boolean getShouldWarmCache() {
-      return shouldWarmCache;
-    }
-
-    public void setShouldWarmCache(boolean shouldWarmCache) {
-      this.shouldWarmCache = shouldWarmCache;
     }
   }
 }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
@@ -40,6 +40,20 @@ public interface StorageService {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Loads objects which have the last_modified_at time larger than the provided threshold
+   *
+   * @param objectType {@link ObjectType} of the objects to be loaded
+   * @param lastModifiedThreshold threshold to use for filtering based on the last_modified_at time
+   *     in ms
+   * @return {@link Map<String, List<T>>} with two keys, "deleted" and "not_deleted". Each value is
+   *     a list of fetched objects that satisfy the provided last_modified_at threshold.
+   */
+  default <T extends Timestamped> Map<String, List<T>> loadObjectsNewerThan(
+      ObjectType objectType, long lastModifiedThreshold) {
+    throw new UnsupportedOperationException();
+  }
+
   void deleteObject(ObjectType objectType, String objectKey);
 
   default void bulkDeleteObjects(ObjectType objectType, Collection<String> objectKeys) {

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -45,7 +45,6 @@ import rx.Observable;
 import rx.Scheduler;
 
 public abstract class StorageServiceSupport<T extends Timestamped> {
-  private static final long HEALTH_MILLIS = TimeUnit.SECONDS.toMillis(90);
   private final Logger log = LoggerFactory.getLogger(getClass());
   protected final AtomicReference<Set<T>> allItemsCache = new AtomicReference<>();
 
@@ -458,6 +457,6 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
   }
 
   protected long getHealthMillis() {
-    return HEALTH_MILLIS;
+    return TimeUnit.SECONDS.toMillis(configProperties.getCacheHealthCheckTimeoutSeconds());
   }
 }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -80,10 +80,6 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
     this.scheduler = scheduler;
     this.objectKeyLoader = objectKeyLoader;
     this.configProperties = configurationProperties;
-    if (configProperties.getRefreshMs() >= getHealthMillis()) {
-      throw new IllegalArgumentException(
-          "Cache refresh time must be more frequent than cache health timeout");
-    }
     this.registry = registry;
     this.circuitBreakerRegistry = circuitBreakerRegistry;
 
@@ -126,6 +122,11 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
 
   @PostConstruct
   void startRefresh() {
+    if (configProperties.getRefreshMs() >= getHealthMillis()) {
+      throw new IllegalArgumentException(
+          "Cache refresh time must be more frequent than cache health timeout");
+    }
+
     if (configProperties.getRefreshMs() > 0) {
       if (configProperties.isShouldWarmCache()) {
         try {

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.application;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -33,8 +34,7 @@ public class DefaultApplicationDAO extends StorageServiceSupport<Application>
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -42,8 +42,7 @@ public class DefaultApplicationDAO extends StorageServiceSupport<Application>
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/application/DefaultApplicationPermissionDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.application;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -30,8 +31,7 @@ public class DefaultApplicationPermissionDAO extends StorageServiceSupport<Appli
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -39,8 +39,7 @@ public class DefaultApplicationPermissionDAO extends StorageServiceSupport<Appli
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/delivery/DefaultDeliveryRepository.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/delivery/DefaultDeliveryRepository.java
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.front50.model.delivery;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -18,8 +19,7 @@ public class DefaultDeliveryRepository extends StorageServiceSupport<Delivery>
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -27,8 +27,7 @@ public class DefaultDeliveryRepository extends StorageServiceSupport<Delivery>
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/notification/DefaultNotificationDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/notification/DefaultNotificationDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.notification;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -31,8 +32,7 @@ public class DefaultNotificationDAO extends StorageServiceSupport<Notification>
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -40,8 +40,7 @@ public class DefaultNotificationDAO extends StorageServiceSupport<Notification>
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.pipeline;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -35,8 +36,7 @@ public class DefaultPipelineDAO extends StorageServiceSupport<Pipeline> implemen
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -44,8 +44,7 @@ public class DefaultPipelineDAO extends StorageServiceSupport<Pipeline> implemen
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineStrategyDAO.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model.pipeline;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -35,8 +36,7 @@ public class DefaultPipelineStrategyDAO extends StorageServiceSupport<Pipeline>
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -44,8 +44,7 @@ public class DefaultPipelineStrategyDAO extends StorageServiceSupport<Pipeline>
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineTemplateDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineTemplateDAO.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.front50.model.pipeline;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -31,8 +32,7 @@ public class DefaultPipelineTemplateDAO extends StorageServiceSupport<PipelineTe
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -40,8 +40,7 @@ public class DefaultPipelineTemplateDAO extends StorageServiceSupport<PipelineTe
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/DefaultPluginInfoRepository.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/DefaultPluginInfoRepository.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.front50.model.plugins;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -37,8 +38,7 @@ public class DefaultPluginInfoRepository extends StorageServiceSupport<PluginInf
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -46,8 +46,7 @@ public class DefaultPluginInfoRepository extends StorageServiceSupport<PluginInf
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/DefaultPluginVersionPinningRepository.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/plugins/DefaultPluginVersionPinningRepository.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.front50.model.plugins;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -32,8 +33,7 @@ public class DefaultPluginVersionPinningRepository
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -41,8 +41,7 @@ public class DefaultPluginVersionPinningRepository
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/project/DefaultProjectDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.project;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -31,8 +32,7 @@ public class DefaultProjectDAO extends StorageServiceSupport<Project> implements
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -40,8 +40,7 @@ public class DefaultProjectDAO extends StorageServiceSupport<Project> implements
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/serviceaccount/DefaultServiceAccountDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.serviceaccount;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -30,8 +31,7 @@ public class DefaultServiceAccountDAO extends StorageServiceSupport<ServiceAccou
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -39,8 +39,7 @@ public class DefaultServiceAccountDAO extends StorageServiceSupport<ServiceAccou
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/snapshot/DefaultSnapshotDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.snapshot;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -30,8 +31,7 @@ public class DefaultSnapshotDAO extends StorageServiceSupport<Snapshot> implemen
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -39,8 +39,7 @@ public class DefaultSnapshotDAO extends StorageServiceSupport<Snapshot> implemen
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/tag/DefaultEntityTagsDAO.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.model.tag;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.ObjectKeyLoader;
 import com.netflix.spinnaker.front50.model.ObjectType;
 import com.netflix.spinnaker.front50.model.StorageService;
@@ -32,8 +33,7 @@ public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags>
       StorageService service,
       Scheduler scheduler,
       ObjectKeyLoader objectKeyLoader,
-      long refreshIntervalMs,
-      boolean shouldWarmCache,
+      StorageServiceConfigurationProperties.PerObjectType configurationProperties,
       Registry registry,
       CircuitBreakerRegistry circuitBreakerRegistry) {
     super(
@@ -41,8 +41,7 @@ public class DefaultEntityTagsDAO extends StorageServiceSupport<EntityTags>
         service,
         scheduler,
         objectKeyLoader,
-        refreshIntervalMs,
-        shouldWarmCache,
+        configurationProperties,
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -150,8 +150,7 @@ public class GcsConfig {
             Executors.newFixedThreadPool(
                 storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
         keyLoader,
-        storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
-        storageServiceConfigurationProperties.getApplicationPermission().isShouldWarmCache(),
+        storageServiceConfigurationProperties.getApplicationPermission(),
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -151,7 +151,7 @@ public class GcsConfig {
                 storageServiceConfigurationProperties.getApplicationPermission().getThreadPool())),
         keyLoader,
         storageServiceConfigurationProperties.getApplicationPermission().getRefreshMs(),
-        storageServiceConfigurationProperties.getApplicationPermission().getShouldWarmCache(),
+        storageServiceConfigurationProperties.getApplicationPermission().isShouldWarmCache(),
         registry,
         circuitBreakerRegistry);
   }

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -203,7 +203,7 @@ public class PipelineController {
     if (!pipeline.getId().equals(existingPipeline.getId())) {
       throw new InvalidRequestException(
           format(
-              "The provided id %s doesn't match the pipeline id %s",
+              "The provided id %s doesn't match the existing pipeline id %s",
               pipeline.getId(), existingPipeline.getId()));
     }
 

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.front50.controllers
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
 import com.netflix.spinnaker.front50.model.notification.DefaultNotificationDAO
@@ -202,8 +203,7 @@ class SqlNotificationControllerTck extends NotificationControllerTck {
       storageService,
       scheduler,
       new DefaultObjectKeyLoader(storageService),
-      0,
-      false,
+      new StorageServiceConfigurationProperties.PerObjectType(),
       new NoopRegistry(),
       new InMemoryCircuitBreakerRegistry()
     )

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -170,7 +170,7 @@ abstract class PipelineControllerTck extends Specification {
 
     then:
     response.status == BAD_REQUEST
-    response.errorMessage == "The provided id ${pipeline1.id} doesn't match the pipeline id ${pipeline2.id}"
+    response.errorMessage == "The provided id ${pipeline1.id} doesn't match the existing pipeline id ${pipeline2.id}"
   }
 
   @Unroll

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.ServiceAccountsService
 import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
 import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineDAO
@@ -377,8 +378,7 @@ class SqlPipelineControllerTck extends PipelineControllerTck {
       storageService,
       scheduler,
       new DefaultObjectKeyLoader(storageService),
-      0,
-      false,
+      new StorageServiceConfigurationProperties.PerObjectType(),
       new NoopRegistry(),
       new InMemoryCircuitBreakerRegistry()
     )

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
@@ -20,7 +20,8 @@ package com.netflix.spinnaker.front50.controllers
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
-import com.netflix.spinnaker.front50.api.model.pipeline.Trigger;
+import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
 import com.netflix.spinnaker.front50.model.pipeline.DefaultPipelineStrategyDAO
@@ -228,8 +229,7 @@ class SqlStrategyControllerTck extends StrategyControllerTck {
       storageService,
       scheduler,
       new DefaultObjectKeyLoader(storageService),
-      0,
-      false,
+      new StorageServiceConfigurationProperties.PerObjectType(),
       new NoopRegistry(),
       new InMemoryCircuitBreakerRegistry()
     )

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsControllerTck.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.front50.config.FiatConfigurationProperties
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.jackson.Front50ApiModule
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
@@ -415,11 +416,9 @@ class SqlApplicationsControllerTck extends ApplicationsControllerTck {
       storageService,
       scheduler,
       new DefaultObjectKeyLoader(storageService),
-      0,
-      false,
+      new StorageServiceConfigurationProperties.PerObjectType(),
       new NoopRegistry(),
       new InMemoryCircuitBreakerRegistry()
     )
   }
 }
-

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.front50.controllers.v2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
 import com.netflix.spinnaker.front50.model.project.DefaultProjectDAO
@@ -324,8 +325,7 @@ class SqlProjectsControllerTck extends ProjectsControllerTck {
       storageService,
       scheduler,
       new DefaultObjectKeyLoader(storageService),
-      0,
-      false,
+      new StorageServiceConfigurationProperties.PerObjectType(),
       new NoopRegistry(),
       new InMemoryCircuitBreakerRegistry()
     )


### PR DESCRIPTION
This PR adds three new config flags to [each object type under service-storage](https://github.com/spinnaker/front50/blob/f6452ec07f207246b3ee940c49d31a115886d4a3/front50-core/src/main/java/com/netflix/spinnaker/front50/config/StorageServiceConfigurationProperties.java#L9-L20).

One is fairly mechanical:
* cacheHealthCheckTimeoutSeconds: previously hard-coded to 90

The other two are performance improvements.  They default to false.
* synchronizeCacheRefresh: When true, if multiple threads attempt to refresh the cache in StorageServiceSupport simultaneously, only one actually does the refresh.  The others wait until it's complete.  This reduces load on the data store.

* optimizeCacheRefreshes: When true, for objects that support versioning, cache refreshes only query the data store for objects modified (or deleted) since the last refresh.  This is only implemented for sql.

I don't have before/after metrics for this, but we've been running this code with a mysql data store for about 2 years configured as follows:
```
storage-service:
  application:
    optimizeCacheRefreshes: true
    synchronizeCacheRefresh: true
  pipeline:
    optimizeCacheRefreshes: true
    synchronizeCacheRefresh: true
```
and front50 database load hasn't been on the radar as an optimization target.  We've got a whole bunch of pipelines.