### PR TITLE
feat(web): add optional query params to the GET /pipelines endpoint

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/DefaultPipelineDAO.java
@@ -81,6 +81,24 @@ public class DefaultPipelineDAO extends StorageServiceSupport<Pipeline> implemen
   }
 
   @Override
+  public Pipeline getPipelineByName(String application, String pipelineName, boolean refresh) {
+    return all(refresh).stream()
+        .filter(
+            pipeline ->
+                pipeline.getApplication() != null
+                    && pipeline.getApplication().equalsIgnoreCase(application)
+                    && pipeline.getName() != null
+                    && pipeline.getName().equalsIgnoreCase(pipelineName))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    String.format(
+                        "No pipeline found in cache with application %s, name %s",
+                        application, pipelineName)));
+  }
+
+  @Override
   public Pipeline create(String id, Pipeline item) {
     if (id == null) {
       id = UUID.randomUUID().toString();

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/PipelineDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/pipeline/PipelineDAO.java
@@ -10,4 +10,6 @@ public interface PipelineDAO extends ItemDAO<Pipeline> {
   Collection<Pipeline> getPipelinesByApplication(String application);
 
   Collection<Pipeline> getPipelinesByApplication(String application, boolean refresh);
+
+  Pipeline getPipelineByName(String application, String pipelineName, boolean refresh);
 }

--- a/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineDAO.groovy
+++ b/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineDAO.groovy
@@ -45,6 +45,18 @@ class RedisPipelineDAO implements PipelineDAO {
   }
 
   @Override
+  public Pipeline getPipelineByName(String application, String pipelineName, boolean refresh) {
+    def retval = all(refresh).find {
+      it.application == application && it.name == pipelineName
+    }
+    if (!retval) {
+      throw new NotFoundException("No pipeline found with application '${application}', name '${pipelineName}'");
+    }
+
+    retval
+  }
+
+  @Override
   Pipeline findById(String id) throws NotFoundException {
     def results = redisTemplate.opsForHash().get(BOOK_KEEPING_KEY, id)
     if (!results) {

--- a/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineDAOSpec.groovy
+++ b/front50-redis/src/test/groovy/com/netflix/spinnaker/front50/redis/RedisPipelineDAOSpec.groovy
@@ -56,6 +56,22 @@ class RedisPipelineDAOSpec extends PipelineDAOSpec<RedisPipelineDAO> {
     foundPipelineId == newPipeline.id
 
     when:
+    def foundPipelineByName = redisPipelineDAO.getPipelineByName("app1", "pipeline1", true)
+
+    then:
+    foundPipelineByName.id == pipeline.id
+    foundPipelineByName.createTs == pipeline.createTs
+    foundPipelineByName.email == pipeline.email
+    foundPipelineByName.lastModified == pipeline.lastModified
+    foundPipelineByName.updateTs == pipeline.updateTs
+
+    when:
+    redisPipelineDAO.getPipelineByName("app1", "does-not-exist", true)
+
+    then:
+    thrown NotFoundException
+
+    when:
     def findPipelines = redisPipelineDAO.all()
 
     then:

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -225,6 +225,16 @@ public class PipelineController {
     return pipelineDAO.findById(id);
   }
 
+  @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
+  @PostAuthorize("hasPermission(returnObject.application, 'APPLICATION', 'READ')")
+  @RequestMapping(value = "{application:.+}/name/{name:.+}", method = RequestMethod.GET)
+  public Pipeline getByApplicationAndName(
+      @PathVariable String application,
+      @PathVariable String name,
+      @RequestParam(required = false, value = "refresh", defaultValue = "true") boolean refresh) {
+    return pipelineDAO.getPipelineByName(application, name, refresh);
+  }
+
   @PreAuthorize(
       "@fiatPermissionEvaluator.storeWholePermission() and hasPermission(#pipeline.application, 'APPLICATION', 'WRITE') and @authorizationSupport.hasRunAsUserPermission(#pipeline)")
   @RequestMapping(value = "", method = RequestMethod.POST)

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.front50.model.pipeline.V2TemplateConfiguration;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -88,8 +89,47 @@ public class PipelineController {
   public Collection<Pipeline> list(
       @RequestParam(required = false, value = "restricted", defaultValue = "true")
           boolean restricted,
-      @RequestParam(required = false, value = "refresh", defaultValue = "true") boolean refresh) {
-    return pipelineDAO.all(refresh);
+      @RequestParam(required = false, value = "refresh", defaultValue = "true") boolean refresh,
+      @RequestParam(required = false, value = "enabledPipelines") Boolean enabledPipelines,
+      @RequestParam(required = false, value = "enabledTriggers") Boolean enabledTriggers,
+      @RequestParam(required = false, value = "triggerTypes") String triggerTypes) {
+    Collection<Pipeline> pipelines = pipelineDAO.all(refresh);
+
+    if ((enabledPipelines == null) && (enabledTriggers == null) && (triggerTypes == null)) {
+      // no filtering, return all pipelines
+      return pipelines;
+    }
+
+    List<String> triggerTypeList =
+        (triggerTypes != null) ? Arrays.asList(triggerTypes.split(",")) : Collections.emptyList();
+
+    Predicate<Trigger> triggerPredicate =
+        trigger -> {
+          // trigger.getEnabled() may be null, so check that before comparing.  If
+          // trigger.getEnabled() is null, the trigger is disabled.
+          boolean triggerEnabled =
+              (trigger.getEnabled() != null) ? trigger.getEnabled().booleanValue() : false;
+          return ((enabledTriggers == null) || (triggerEnabled == enabledTriggers))
+              && ((triggerTypes == null) || triggerTypeList.contains(trigger.getType()));
+        };
+
+    Predicate<Pipeline> pipelinePredicate =
+        pipeline -> {
+          // pipeline.getDisabled may be null, so check that before comparing.  If
+          // pipeline.getDisabled is null, the pipeline is enabled.
+          boolean pipelineEnabled =
+              (pipeline.getDisabled() == null) || (pipeline.getDisabled() == false);
+
+          return ((enabledPipelines == null) || (pipelineEnabled == enabledPipelines))
+              && pipeline.getTriggers().stream().anyMatch(triggerPredicate);
+        };
+
+    List<Pipeline> retval =
+        pipelines.stream().filter(pipelinePredicate).collect(Collectors.toList());
+
+    log.debug("returning {} of {} total pipeline(s)", retval.size(), pipelines.size());
+
+    return retval;
   }
 
   /**

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -254,6 +254,14 @@ class PipelineControllerSpec extends Specification {
     }
 
     @Override
+    Pipeline getPipelineByName(String application, String pipelineName, boolean refresh) {
+      map.values().stream()
+        .filter({ p -> p.getApplication().equalsIgnoreCase(application) })
+        .filter({ p -> p.getName().equalsIgnoreCase(pipelineName) })
+        .collect(Collectors.toList())
+    }
+
+    @Override
     Pipeline findById(String id) throws NotFoundException {
       def get = map.get(id)
       if (get == null) {

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
 import org.hamcrest.Matchers
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.web.util.UriComponentsBuilder
 
 import java.time.Clock
 import java.util.concurrent.Callable
@@ -44,6 +45,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rx.schedulers.Schedulers
 import spock.lang.*
+
+import static org.hamcrest.Matchers.containsInAnyOrder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -569,6 +572,90 @@ abstract class PipelineControllerTck extends Specification {
     status       | expectPipelineInResponse
     "failed"     | false
     "successful" | true
+  }
+
+  @Unroll
+  void "list filters results based on optional query params (enabledPipelines: #enabledPipelines, enabledTriggers: #enabledTriggers, triggerTypes: #triggerTypes)"() {
+    given:
+    pipelineDAO.create(null, new Pipeline([
+      name       : "enabled pipeline with enabled trigger",
+      application: "test",
+      disabled   : false,
+      triggers   : [
+        [enabled: true, type: "foo"]
+      ]
+    ]))
+    pipelineDAO.create(null, new Pipeline([
+      name       : "enabled pipeline with disabled trigger",
+      application: "test",
+      disabled   : false,
+      triggers   : [
+        [enabled: false, type: "foo"]
+      ]
+    ]))
+    pipelineDAO.create(null, new Pipeline([
+      name       : "implicitly enabled pipeline with enabled trigger",
+      application: "test",
+      triggers   : [
+        [enabled: true, type: "foo"]
+      ]
+    ]))
+    pipelineDAO.create(null, new Pipeline([
+      name       : "disabled pipeline with enabled trigger",
+      application: "test",
+      disabled   : true,
+      triggers   : [
+        [enabled: true, type: "foo"]
+      ]
+    ]))
+    pipelineDAO.create(null, new Pipeline([
+      name       : "disabled pipeline with trigger that has no enabled property",
+      application: "test",
+      disabled   : true,
+      triggers   : [
+        [type: "foo"]
+      ]
+    ]))
+    pipelineDAO.create(null, new Pipeline([
+      name       : "pipeline with trigger type bar",
+      application: "test",
+      disabled   : true,
+      triggers   : [
+        [enabled: true, type: "bar"]
+      ]
+    ]))
+
+    when:
+    UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder
+      .fromPath("/pipelines")
+
+    if (enabledPipelines != null) {
+      uriComponentsBuilder.queryParam("enabledPipelines", enabledPipelines)
+    }
+
+    if (enabledTriggers != null) {
+      uriComponentsBuilder.queryParam("enabledTriggers", enabledTriggers)
+    }
+    if (triggerTypes != null) {
+      uriComponentsBuilder.queryParam("triggerTypes", triggerTypes)
+    }
+    def response = mockMvc.perform(get(uriComponentsBuilder.toUriString()))
+
+    then:
+    response.andReturn().response.status == OK
+    response.andExpect(jsonPath('$.[*].name', containsInAnyOrder(expectedPipelineNames.toArray(new String[0]))))
+
+    where:
+    enabledPipelines | enabledTriggers | triggerTypes   | expectedPipelineNames
+    null             | null            | null           | ["disabled pipeline with enabled trigger", "enabled pipeline with enabled trigger", "enabled pipeline with disabled trigger", "disabled pipeline with trigger that has no enabled property", "implicitly enabled pipeline with enabled trigger", "pipeline with trigger type bar"]
+    false            | null            | null           | ["disabled pipeline with enabled trigger", "disabled pipeline with trigger that has no enabled property", "pipeline with trigger type bar"]
+    true             | null            | null           | ["enabled pipeline with enabled trigger", "enabled pipeline with disabled trigger", "implicitly enabled pipeline with enabled trigger"]
+    null             | false           | null           | ["enabled pipeline with disabled trigger", "disabled pipeline with trigger that has no enabled property"]
+    null             | true            | null           | ["enabled pipeline with enabled trigger", "implicitly enabled pipeline with enabled trigger", "disabled pipeline with enabled trigger", "pipeline with trigger type bar"]
+    null             | null            | "not this one" | []
+    null             | null            | "bar"          | ["pipeline with trigger type bar"]
+    true             | true            | "foo"          | ["enabled pipeline with enabled trigger", "implicitly enabled pipeline with enabled trigger"]
+    false            | true            | "foo,bar"      | ["disabled pipeline with enabled trigger", "pipeline with trigger type bar"]
   }
 
   def "should optimally refresh the cache after updates and deletes"() {


### PR DESCRIPTION
so it's possible for consumers of pipelines (e.g. echo) to get only the information they need.

enabledPipelines: boolean -- only return enabled/disabled pipelines
enabledTriggers: boolean -- only return pipelines with at least one enabled trigger
triggerTypes: only return pipelines with a trigger whose type is present in this comma-separated string of trigger types

for example GET /pipelines?enabledPipelines=true&enabledTriggers=true&triggerTypes=foo,bar

which, with correct URL-encoding is:

GET /pipelines?enabledPipelines=true&enabledTriggers=true&triggerTypes=foo%2Cbar

Note that if both enabledTriggers and triggerTypes are specified, that a single trigger must satisfy both conditions for front50 to return its pipeline.

Also add a GET /pipelines/{application}/name/{name} endpoint which queries for a pipeline by application and name. It responds with 404 if no such pipeline is found.

echo uses this endpoint in https://github.com/spinnaker/echo/pull/1292 for manual triggers by application and name, when its cache doesn't contain the triggered pipeline.