### PR TITLE
fix(validator): Fix NPE when traffic management is not defined in a deployment manifest

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/validator/pipeline/KubernetesBlueGreenStrategyValidator.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/validator/pipeline/KubernetesBlueGreenStrategyValidator.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.front50.api.validator.PipelineValidator;
 import com.netflix.spinnaker.front50.api.validator.ValidatorErrors;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -39,6 +40,7 @@ public class KubernetesBlueGreenStrategyValidator implements PipelineValidator {
             .filter(KubernetesBlueGreenStrategyValidator::kubernetesProvider)
             .filter(KubernetesBlueGreenStrategyValidator::deployManifestStage)
             .map(KubernetesBlueGreenStrategyValidator::getTrafficManagement)
+            .filter(Objects::nonNull)
             .filter(KubernetesBlueGreenStrategyValidator::trafficManagementEnabled)
             .map(KubernetesBlueGreenStrategyValidator::getTrafficManagementOptions)
             .anyMatch(KubernetesBlueGreenStrategyValidator::redBlackStrategy);

--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/pipeline/KubernetesBlueGreenStrategyValidatorSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/validator/pipeline/KubernetesBlueGreenStrategyValidatorSpec.groovy
@@ -102,6 +102,22 @@ class KubernetesBlueGreenStrategyValidatorSpec extends Specification {
     !errors.hasErrors()
   }
 
+  def "should not return error when trafficManagement is not defined"() {
+    setup:
+    def pipeline = new Pipeline()
+    Map<String, Object> options = new LinkedHashMap<>()
+    options
+    pipeline.setStages(List.of(Map.of("cloudProvider","kubernetes", "type", "deployManifest",)))
+    def errors = new ValidatorErrors()
+
+    when:
+    PipelineValidator validator = new KubernetesBlueGreenStrategyValidator()
+    validator.validate(pipeline, errors)
+
+    then:
+    !errors.hasErrors()
+  }
+
   def "should not return error when trafficManagement not enabled"() {
     setup:
     def pipeline = new Pipeline()


### PR DESCRIPTION
If no traffic management is defined in a K8S deploy manifest pipeline, the validator throws an NPE when trying to check if trafficManagement is enabled. 