### PR TITLE
refactor(deprecation): remove deprecated gradle constructs/features from front50 in order to upgrade gradle 7

### DIFF
--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -21,16 +21,9 @@ dependencies {
   implementation project(":front50-api")
 
   implementation "com.fasterxml.jackson.core:jackson-databind"
-  implementation ("com.google.apis:google-api-services-storage:v1-rev20200326-1.30.9") {
-       force=true
-  }
-  implementation ("com.google.auth:google-auth-library-oauth2-http:0.20.0") {
-       force=true
-  }
-  // TODO(plumpy): remove version once added to kork
-  implementation ("com.google.cloud:google-cloud-storage:1.108.0") {
-       force=true
-  }
+  implementation "com.google.apis:google-api-services-storage"
+  implementation "com.google.auth:google-auth-library-oauth2-http"
+  implementation "com.google.cloud:google-cloud-storage"
   implementation "com.google.guava:guava"
   implementation "com.netflix.spectator:spectator-api"
   implementation "io.spinnaker.kork:kork-exceptions"
@@ -48,4 +41,11 @@ dependencies {
   testImplementation "io.strikt:strikt-core"
   testImplementation "io.mockk:mockk"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+}
+
+configurations.all {
+   resolutionStrategy.force 'com.google.apis:google-api-services-storage:v1-rev20200326-1.30.9'
+   resolutionStrategy.force 'com.google.auth:google-auth-library-oauth2-http:0.20.0'
+   // TODO(plumpy): remove version once added to kork
+   resolutionStrategy.force 'com.google.cloud:google-cloud-storage:1.108.0'
 }

--- a/front50-oracle/front50-oracle.gradle
+++ b/front50-oracle/front50-oracle.gradle
@@ -4,13 +4,15 @@ dependencies {
 
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "io.spinnaker.kork:kork-core"
-  implementation ('com.oracle.oci.sdk:oci-java-sdk-objectstorage:1.19.1'){
-        force=true
-  }
+  implementation 'com.oracle.oci.sdk:oci-java-sdk-objectstorage'
   implementation "com.sun.jersey:jersey-client:1.19.4"
   implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
 
   testImplementation project(":front50-test")
+}
+
+configurations.all {
+   resolutionStrategy.force 'com.oracle.oci.sdk:oci-java-sdk-objectstorage:1.19.1'
 }


### PR DESCRIPTION
While executing the build script with --warning-mode=fail received below error:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0
```
And the deprecated gradle features are:
```
> Configure project :front50-gcs
Using force on a dependency has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#forced_dependencies
        at front50_gcs_93cicf1icrojzycbnu0sn2y0i$_run_closure1$_closure2.doCall(/front50/front50-gcs/front50-gcs.gradle:25)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
> Configure project :front50-oracle
Using force on a dependency has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). Consult the upgrading guide for further information: https://docs.gradle.org/6.8.1/userguide/upgrading_version_5.html#forced_dependencies
        at front50_oracle_ejtaa9yh72oh2yv6rvypallyx$_run_closure1$_closure2.doCall(/front50/front50-oracle/front50-oracle.gradle:7)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
Tried `(version { strictly ... } })` as suggested by guide, but it didn't work. So refactored it with `resolutionStrategy.force`.
