### PR TITLE
fix(migrations): do not migrate redblack pipelines without stages

### DIFF
--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigration.java
@@ -17,10 +17,7 @@ package com.netflix.spinnaker.front50.migrations;
 
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -77,7 +74,7 @@ public class RedBlackToBlueGreenK8sPipelinesMigration implements Migration {
 
   private static Predicate<Pipeline> pipelineWithRedBlackStrategyPredicate() {
     return pipeline ->
-        pipeline.getStages().stream()
+        Optional.ofNullable(pipeline.getStages()).orElseGet(ArrayList::new).stream()
             .filter(RedBlackToBlueGreenK8sPipelinesMigration::kubernetesProvider)
             .filter(RedBlackToBlueGreenK8sPipelinesMigration::deployManifestStage)
             .map(RedBlackToBlueGreenK8sPipelinesMigration::getTrafficManagement)

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigrationSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/RedBlackToBlueGreenK8sPipelinesMigrationSpec.groovy
@@ -78,6 +78,20 @@ class RedBlackToBlueGreenK8sPipelinesMigrationSpec extends Specification {
     0 * _
   }
 
+  def "should not migrate K8s pipeline that has no stages"() {
+    given:
+    def pipelineWithNoStages = "{\"id\":\"pipeline-1\",\"name\":null,\"application\":\"application1\",\"type\":null,\"schema\":\"1\",\"config\":null,\"triggers\":[],\"index\":null,\"updateTs\":null,\"lastModifiedBy\":null,\"lastModified\":null,\"email\":null,\"disabled\":null,\"template\":null,\"roles\":null,\"serviceAccount\":null,\"executionEngine\":null,\"stageCounter\":null,\"constraints\":null,\"payloadConstraints\":null,\"keepWaitingPipelines\":null,\"limitConcurrent\":null,\"maxConcurrentExecutions\":null,\"parameterConfig\":null,\"spelEvaluator\":null,\"any\":{},\"createdAt\":null}"
+    def pipeline = this.objectMapper.readValue(pipelineWithNoStages, Pipeline.class)
+
+    when:
+    migration.run()
+
+    then:
+    1 * pipelineDAO.all() >> { return [pipeline] }
+    0 * pipelineDAO.update("pipeline-1", _)
+    0 * _
+  }
+
   def "should migrate K8s pipeline that is using redblack strategy"() {
     given:
     def pipelineWithRedBlackStrategy = "{\"id\":\"pipeline-2\",\"name\":null,\"application\":\"application2\",\"type\":null,\"schema\":\"1\",\"config\":null,\"triggers\":[],\"index\":null,\"updateTs\":null,\"lastModifiedBy\":null,\"lastModified\":null,\"email\":null,\"disabled\":null,\"template\":null,\"roles\":null,\"serviceAccount\":null,\"executionEngine\":null,\"stageCounter\":null,\"stages\":[{\"cloudProvider\":\"kubernetes\",\"trafficManagement\":{\"options\":{\"strategy\":\"redblack\"},\"enabled\":true},\"type\":\"deployManifest\"}],\"constraints\":null,\"payloadConstraints\":null,\"keepWaitingPipelines\":null,\"limitConcurrent\":null,\"maxConcurrentExecutions\":null,\"parameterConfig\":null,\"spelEvaluator\":null,\"any\":{},\"createdAt\":null}"


### PR DESCRIPTION
Pipelines created outside of the UI Pipeline Builder may not have stages defined in the JSON. When such a pipeline exists and the `RedBlackToBlueGreenK8sPipelinesMigration` is run the result is an NPE.  This fixes that NPE. 