### PR TITLE
feat(sql): add configuration property sql.healthIntervalMillis

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/ItemDAO.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/ItemDAO.java
@@ -36,6 +36,10 @@ public interface ItemDAO<T> {
 
   boolean isHealthy();
 
+  /**
+   * How frequently to refresh health information (e.g. to call isHealthy() to provide info to the
+   * health endpoint)
+   */
   default long getHealthIntervalMillis() {
     return Duration.ofSeconds(30).toMillis();
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
@@ -71,6 +71,7 @@ public interface StorageService {
 
   long getLastModified(ObjectType objectType);
 
+  /** How frequently to refresh health information (e.g. for the health endpoint). */
   default long getHealthIntervalMillis() {
     return Duration.ofSeconds(30).toMillis();
   }

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageServiceSupport.java
@@ -219,6 +219,16 @@ public abstract class StorageServiceSupport<T extends Timestamped> {
     return isHealthy;
   }
 
+  /**
+   * How frequently to refresh health information (e.g. to call isHealthy() to provide info to the
+   * health endpoint).
+   *
+   * <p>By itself, this is independent from ItemDAO.getHealthIntervalMillis, but when e.g.
+   * DefaultPipelineDAO both extends this class, and implements ItemDAO (via PipelineDAO), this
+   * method serves as the override to ItemDAO.getHealthIntervalMillis.
+   *
+   * @return the period from the underlying StorageService
+   */
   public long getHealthIntervalMillis() {
     return service.getHealthIntervalMillis();
   }

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/Front50SqlProperties.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/Front50SqlProperties.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * Note that kork's SqlProperties class also uses the "sql" prefix.
+ *
+ * @param healthIntervalMillis The period to refresh health information (e.g. in the health endpoint).
+ */
+@ConfigurationProperties("sql")
+class Front50SqlProperties {
+  /**
+   * How frequently to refresh health information (e.g. for the health endpoint).
+   */
+  var healthIntervalMillis: Long = Duration.ofSeconds(30).toMillis()
+}

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -26,12 +26,14 @@ import org.jooq.DSLContext
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 
 @Configuration
 @ConditionalOnProperty("sql.enabled")
+@EnableConfigurationProperties(Front50SqlProperties::class)
 @Import(DefaultSqlConfiguration::class)
 class SqlConfiguration {
 
@@ -40,7 +42,8 @@ class SqlConfiguration {
     objectMapper: ObjectMapper,
     registry: Registry,
     jooq: DSLContext,
-    sqlProperties: SqlProperties
+    sqlProperties: SqlProperties,
+    front50SqlProperties: Front50SqlProperties
   ): SqlStorageService =
     SqlStorageService(
       objectMapper,
@@ -50,7 +53,8 @@ class SqlConfiguration {
       sqlProperties.retries,
       1000,
       if (sqlProperties.connectionPools.keys.size > 1)
-        sqlProperties.connectionPools.filter { it.value.default }.keys.first() else sqlProperties.connectionPools.keys.first()
+        sqlProperties.connectionPools.filter { it.value.default }.keys.first() else sqlProperties.connectionPools.keys.first(),
+      front50SqlProperties
     )
 
   @Bean
@@ -59,7 +63,8 @@ class SqlConfiguration {
     objectMapper: ObjectMapper,
     registry: Registry,
     @Qualifier("secondaryJooq") jooq: DSLContext,
-    sqlProperties: SqlProperties
+    sqlProperties: SqlProperties,
+    front50SqlProperties: Front50SqlProperties
   ): SqlStorageService =
     SqlStorageService(
       objectMapper,
@@ -68,6 +73,7 @@ class SqlConfiguration {
       Clock.systemDefaultZone(),
       sqlProperties.retries,
       1000,
-      sqlProperties.connectionPools.filter { !it.value.default }.keys.first()
+      sqlProperties.connectionPools.filter { !it.value.default }.keys.first(),
+      front50SqlProperties
     )
 }

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.api.model.Timestamped
 import com.netflix.spinnaker.front50.model.ObjectType.APPLICATION
 import com.netflix.spinnaker.front50.model.ObjectType.APPLICATION_PERMISSION
@@ -63,7 +64,8 @@ class SqlStorageService(
   private val clock: Clock,
   private val sqlRetryProperties: SqlRetryProperties,
   private val chunkSize: Int,
-  private val poolName: String
+  private val poolName: String,
+  private val front50SqlProperties: Front50SqlProperties
 ) : StorageService, BulkStorageService, AdminOperations {
 
   companion object {
@@ -523,5 +525,9 @@ class SqlStorageService(
           .execute()
       }
     }
+  }
+
+  override fun getHealthIntervalMillis(): Long {
+    return front50SqlProperties.healthIntervalMillis
   }
 }

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.front50.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.api.model.Timestamped
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.model.application.Application
@@ -57,7 +58,8 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
       Clock.systemDefaultZone(),
       SqlRetryProperties(),
       1,
-      "default"
+      "default",
+      Front50SqlProperties()
     )
     context("For ${jooqConfig.dialect}") {
       context("Application") {

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/NotificationControllerTck.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.front50.controllers
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
@@ -196,7 +197,8 @@ class SqlNotificationControllerTck extends NotificationControllerTck {
       Clock.systemDefaultZone(),
       new SqlRetryProperties(),
       100,
-      "default"
+      "default",
+      new Front50SqlProperties()
     )
 
     return new DefaultNotificationDAO(

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.front50.controllers
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.ServiceAccountsService
 import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
@@ -755,7 +756,8 @@ class SqlPipelineControllerTck extends PipelineControllerTck {
       Clock.systemDefaultZone(),
       new SqlRetryProperties(),
       100,
-      "default"
+      "default",
+      new Front50SqlProperties()
     )
 
     pipelineDAOConfigProperties.setRefreshMs(0)

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/StrategyControllerTck.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.front50.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties;
@@ -222,7 +223,8 @@ class SqlStrategyControllerTck extends StrategyControllerTck {
       Clock.systemDefaultZone(),
       new SqlRetryProperties(),
       100,
-      "default"
+      "default",
+      new Front50SqlProperties()
     )
 
     return new DefaultPipelineStrategyDAO(

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ApplicationsControllerTck.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.front50.controllers.v2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.front50.config.FiatConfigurationProperties
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
@@ -409,7 +410,8 @@ class SqlApplicationsControllerTck extends ApplicationsControllerTck {
       Clock.systemDefaultZone(),
       new SqlRetryProperties(),
       100,
-      "default"
+      "default",
+      new Front50SqlProperties()
     )
 
     return new DefaultApplicationDAO(

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/v2/ProjectsControllerTck.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.front50.controllers.v2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
@@ -318,7 +319,8 @@ class SqlProjectsControllerTck extends ProjectsControllerTck {
       Clock.systemDefaultZone(),
       new SqlRetryProperties(),
       100,
-      "default"
+      "default",
+      new Front50SqlProperties()
     )
 
     return new DefaultProjectDAO(


### PR DESCRIPTION
that controls how often the health endpoint refreshes information when using sql.  It defaults to 30 seconds to match the behavior before this change.

Information about cache status for each object type (e.g. pipelines, applications, etc.) contributes to the response from front50's /health endpoint.  This change makes it possible to reduce the likelihood that the cache has refreshed, but the response from the /health endpoint doesn't reflect that.
