### PR TITLE
fix(web): check trigger.getType() for null before invoking equals method

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -154,7 +154,8 @@ public class PipelineController {
         trigger -> {
           boolean retval =
               trigger.getEnabled()
-                  && (trigger.getType().equals("pipeline"))
+                  && (trigger.getType() != null)
+                  && trigger.getType().equals("pipeline")
                   && id.equals(trigger.getPipeline())
                   && trigger.getStatus().contains(status);
           log.debug(

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -557,6 +557,13 @@ abstract class PipelineControllerTck extends Specification {
         [enabled: null, type: "pipeline", pipeline: "triggering-pipeline", status: [ "successful" ] ]
       ]
     ]))
+    pipelineDAO.create(null, new Pipeline([
+      name       : "enabled trigger with null type",
+      application: "test",
+      triggers   : [
+        [enabled: true, type: null, pipeline: "triggering-pipeline", status: [ "successful" ] ]
+      ]
+    ]))
 
     when:
     def response = mockMvc.perform(get("/pipelines/triggeredBy/triggering-pipeline/${status}/"))


### PR DESCRIPTION
in PipelineController.getTriggeredPipelines to avoid a NullPointerException.
