### PR TITLE
refactor(core/test): refactor NioGroovyMethods.readBytes() to use java.nio.file.Files

### DIFF
--- a/front50-core/src/test/groovy/com/netflix/spinnaker/front50/plugins/CachingPluginBinaryStorageServiceSpec.groovy
+++ b/front50-core/src/test/groovy/com/netflix/spinnaker/front50/plugins/CachingPluginBinaryStorageServiceSpec.groovy
@@ -20,6 +20,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 import java.nio.file.Path
+import java.nio.file.Files
 
 class CachingPluginBinaryStorageServiceSpec extends Specification {
 
@@ -58,6 +59,6 @@ class CachingPluginBinaryStorageServiceSpec extends Specification {
   }
 
   private String getCacheFile(String key) {
-    return new String(getCachePath(key).readBytes())
+    return new String(Files.readAllBytes(getCachePath(key)))
   }
 }


### PR DESCRIPTION
This change would make code less dependent on groovy upgrades. 
Test coverage remain same before and after refactor (Tests executed 305).
