### PR TITLE
chore(dependency): fix to upgrade groovy 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects { project ->
       testImplementation("org.springframework:spring-test")
       testImplementation("org.hamcrest:hamcrest-core")
       testRuntimeOnly("cglib:cglib-nodep")
-      testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+      testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
       testRuntimeOnly("org.objenesis:objenesis")
     }
     // Keep this constraint till all other components get bumped up to this version and subsequently updated in the kork.

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -46,6 +46,7 @@ dependencies {
   testImplementation project(":front50-sql")
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "io.reactivex:rxjava"
+  testImplementation "org.codehaus.groovy:groovy-json"
 
   // Add each included cloud provider project as a runtime dependency
   gradle.includedProviderProjects.each {


### PR DESCRIPTION
chore(dependency): add testImplementation of groovy-json dependency while upgrading to groovy 3.x

While upgrading groovy from 2.5.15 to 3.0.10, encountered following error during front50-web:test :
```
startup failed:
/front50/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy: 42: unable to resolve class groovy.json.JsonSlurper
 @ line 42, column 1.
   import groovy.json.JsonSlurper
   ^
1 error
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':front50-web:compileTestGroovy'.
```
To resolve this issue added testImplementation of org.codehaus.groovy:groovy-json in front50-web.gradle
***************************************************

refactor(build): cleanup of junit-vintage-engine and introduce junit-jupiter-engine with upgrade of groovy 3.x