### PR TITLE
chore(dependency): add explicit dependency of groovy-json in front50-web while upgrading groovy 3.x

### DIFF
--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -46,6 +46,7 @@ dependencies {
   testImplementation project(":front50-sql")
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "io.reactivex:rxjava"
+  testImplementation "org.codehaus.groovy:groovy-json"
 
   // Add each included cloud provider project as a runtime dependency
   gradle.includedProviderProjects.each {


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-json is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and encounter below error during test compilation:
```
startup failed:
/front50/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy: 42: unable to resolve class groovy.json.JsonSlurper
 @ line 42, column 1.
   import groovy.json.JsonSlurper
   ^
1 error
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':front50-web:compileTestGroovy'.
```
So, adding explicit dependency of groovy-json in front50-web.gradle.

With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-json appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:

```
$ ./gradlew front50-web:dI --dependency groovy-json --configuration testCompileClasspath
Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details

> Task :front50-web:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)
```