### PR TITLE
refactor(gcs/test): replace deprecated test application context initializer class during upgrade to spring boot 2.6.x

### DIFF
--- a/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt
+++ b/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.front50.model.ObjectType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -36,7 +36,7 @@ import strikt.assertions.isEmpty
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(
   classes = [GcsConfig::class, GcsIntegrationTestConfiguration::class],
-  initializers = [ConfigFileApplicationContextInitializer::class]
+  initializers = [ConfigDataApplicationContextInitializer::class]
 )
 @TestPropertySource(properties = ["spring.config.location=classpath:minimal-gcs-account.yml"])
 class GcsIntegrationTest {


### PR DESCRIPTION
While upgrading spring boot 2.6.15, encounter below error in front50-gcs module during test compilation:
```
> Task :front50-gcs:compileTestKotlin FAILED
e: /front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt: (28, 46): Unresolved reference: ConfigFileApplicationContextInitializer
e: /front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt: (39, 18): Only 'const val' can be used in constant expressions
e: /front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt: (39, 19): Unresolved reference: ConfigFileApplicationContextInitializer
e: /front50/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt: (39, 19): An annotation argument must be a compile-time constant
```
The root cause is the removal of `ConfigFileApplicationContextInitializer` class which got deprecated since [spring boot 2.4.x](https://javadoc.io/doc/org.springframework.boot/spring-boot-test/2.4.4/deprecated-list.html) in favour of `ConfigDataApplicationContextInitializer` class from [spring boot 2.6.x](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#deprecations-from-spring-boot-24). To fix this issue replacing the deprecated class with new class.
