### PR TITLE
fix(sql): teach SqlStorageService.loadObjects and loadObjectsNewerThan to skip invalid objects

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
@@ -53,7 +53,8 @@ public interface StorageService {
    * @param lastModifiedThreshold threshold to use for filtering based on the last_modified_at time
    *     in ms
    * @return {@link Map<String, List<T>>} with two keys, "deleted" and "not_deleted". Each value is
-   *     a list of fetched objects that satisfy the provided last_modified_at threshold.
+   *     a list of fetched objects that satisfy the provided last_modified_at threshold. Any objects
+   *     that fail to deserialize are skipped.
    */
   default <T extends Timestamped> Map<String, List<T>> loadObjectsNewerThan(
       ObjectType objectType, long lastModifiedThreshold) {

--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/model/StorageService.java
@@ -35,6 +35,12 @@ public interface StorageService {
   <T extends Timestamped> T loadObject(ObjectType objectType, String objectKey)
       throws NotFoundException;
 
+  /**
+   * Load objects of the given type with the given keys
+   *
+   * @param objectType {@link ObjectType} of the objects to load
+   * @return A list of the loaded objects. Any objects that fail to deserialize are skipped.
+   */
   default <T extends Timestamped> List<T> loadObjects(
       ObjectType objectType, List<String> objectKeys) {
     throw new UnsupportedOperationException();

--- a/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
+++ b/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.front50.model
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.api.model.Timestamped
@@ -91,6 +93,8 @@ class SqlStorageService(
     private val lastModifiedField = field("last_modified_at", Long::class.java)
   }
 
+  private val invalidJsonCounterId: Id = registry.createId("sqlStorageService.invalidJson");
+
   override fun supportsVersioning(): Boolean {
     return true
   }
@@ -145,14 +149,18 @@ class SqlStorageService(
             }
           }
 
-          records.map {
-            objectMapper.readValue(
-              it.getValue(field("body", String::class.java)),
-              objectType.clazz as Class<T>
-            ).apply {
-              this.createdAt = it.getValue(field("created_at", Long::class.java))
-
-              this.lastModified = it.getValue(field("last_modified_at", Long::class.java))
+          records.mapNotNull {
+            val body = it.getValue(field("body", String::class.java))
+            try  {
+              objectMapper.readValue(body, objectType.clazz as Class<T>
+              ).apply {
+                this.createdAt = it.getValue(field("created_at", Long::class.java))
+                this.lastModified = it.getValue(field("last_modified_at", Long::class.java))
+              }
+            } catch (e: JsonProcessingException) {
+              log.error("unable to deserialize {}", objectType.name, e)
+              registry.counter(invalidJsonCounterId.withTag("objectType", objectType.group)).increment();
+              null
             }
           }
         }

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.front50.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.config.Front50SqlProperties
 import com.netflix.spinnaker.front50.api.model.Timestamped
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
@@ -31,9 +31,12 @@ import dev.minutest.rootContext
 import java.time.Clock
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.hasSize
+import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotEqualTo
@@ -51,9 +54,12 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
       jooqConfig.jdbcUrl,
       jooqConfig.dialect
     )
+
+    val registry = DefaultRegistry()
+
     val sqlStorageService = SqlStorageService(
       ObjectMapper(),
-      NoopRegistry(),
+      registry,
       jooq,
       Clock.systemDefaultZone(),
       SqlRetryProperties(),
@@ -137,6 +143,11 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
       }
 
       context("Pipeline") {
+
+        after {
+          registry.reset()
+        }
+
         test("create, update and delete a pipeline") {
           // verify that a pipeline can be created
           sqlStorageService.storeObject(
@@ -185,7 +196,7 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
         }
 
         var lastModifiedMs : Long = 100
-        test("bulk load pipelines") {
+        test("loadObjects basic behavior") {
           val objectKeys = mutableSetOf<String>()
           val lastModifiedList = mutableSetOf<Long>()
           (1..10).forEach {
@@ -218,6 +229,53 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
           expectThat(
             pipelines.map { it.lastModified }.toSet()
           ).isEqualTo(lastModifiedList)
+          expectThat(registry.counter("sqlStorageService.invalidJson", "objectType", "pipelines").count()).isEqualTo(0);
+        }
+
+        test("loadObjects with malformed pipelines") {
+          // populate one record that fails to deserialize
+          val lastModified: Long = Instant.now().toEpochMilli()
+
+          // Can't use storeObject since it serializes a valid object...
+          val invalidObjectKey = "new-id-pipeline001-busted"
+          val bustedPipeline = mapOf("id" to invalidObjectKey,
+                                     "name" to "new-pipeline001-busted",
+                                     "application" to "application001",
+                                     "body" to "not json",
+                                     "created_at" to lastModified,
+                                     "last_modified_at" to lastModified,
+                                     "last_modified_by" to "test-user",
+                                     "is_deleted" to false)
+          jooq.insertInto(table("pipelines"), *bustedPipeline.keys.map { field(it) }.toTypedArray())
+            .values(bustedPipeline.values)
+            .execute()
+
+          val onlyInvalid = sqlStorageService.loadObjects<Pipeline>(
+            ObjectType.PIPELINE,
+            listOf(invalidObjectKey)
+          )
+          expectThat(onlyInvalid).isEmpty()
+          expectThat(registry.counter("sqlStorageService.invalidJson", "objectType", "pipelines").count()).isEqualTo(1);
+
+          // Add a valid pipeline and repeat.  Make sure we get only the valid pipeline.
+          val validObjectKey = "new-id-pipeline002-valid"
+          sqlStorageService.storeObject(
+            ObjectType.PIPELINE,
+            validObjectKey,
+            Pipeline().apply {
+              this.setId(validObjectKey)
+              this.setName("new-pipeline002")
+              this.setLastModified(lastModified)
+              this.setApplication("application001")
+            }
+          )
+
+          val withValidPipeline = sqlStorageService.loadObjects<Pipeline>(
+            ObjectType.PIPELINE,
+            listOf(invalidObjectKey, validObjectKey)
+          )
+          expectThat(withValidPipeline.map { it.id }.toList()).isEqualTo(listOf(validObjectKey))
+          expectThat(registry.counter("sqlStorageService.invalidJson", "objectType", "pipelines").count()).isEqualTo(2);
         }
 
         test("load pipelines newer than") {


### PR DESCRIPTION
and return the valid ones.  This allows the cache to populate and gives the health check a chance to succeed.

No, it's not supposed to be possible for bad pipelines to make it to the database, but...things happen.