### PR TITLE
fix(web): restore check for regenerateCronTriggerIds in PipelineController.save

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -252,11 +252,9 @@ public class PipelineController {
     if (Strings.isNullOrEmpty(pipeline.getId())
         || (boolean) pipeline.getAny().getOrDefault("regenerateCronTriggerIds", false)) {
       // ensure that cron triggers are assigned a unique identifier for new pipelines
-      List<Trigger> triggers = pipeline.getTriggers();
-      triggers.stream()
+      pipeline.getTriggers().stream()
           .filter(it -> "cron".equals(it.getType()))
           .forEach(it -> it.put("id", UUID.randomUUID().toString()));
-      pipeline.setTriggers(triggers);
     }
 
     return pipelineDAO.create(pipeline.getId(), pipeline);
@@ -418,8 +416,7 @@ public class PipelineController {
 
   private static Pipeline ensureCronTriggersHaveIdentifier(Pipeline pipeline) {
     // ensure that all cron triggers have an assigned identifier
-    List<Trigger> triggers = pipeline.getTriggers();
-    triggers.stream()
+    pipeline.getTriggers().stream()
         .filter(it -> "cron".equalsIgnoreCase(it.getType()))
         .forEach(
             it -> {
@@ -430,7 +427,6 @@ public class PipelineController {
 
               it.put("id", triggerId);
             });
-    pipeline.setTriggers(triggers);
 
     return pipeline;
   }

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -249,7 +249,8 @@ public class PipelineController {
     pipeline.setName(pipeline.getName().trim());
     pipeline = ensureCronTriggersHaveIdentifier(pipeline);
 
-    if (Strings.isNullOrEmpty(pipeline.getId())) {
+    if (Strings.isNullOrEmpty(pipeline.getId())
+        || (boolean) pipeline.getAny().getOrDefault("regenerateCronTriggerIds", false)) {
       // ensure that cron triggers are assigned a unique identifier for new pipelines
       List<Trigger> triggers = pipeline.getTriggers();
       triggers.stream()

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/StrategyController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/StrategyController.java
@@ -19,7 +19,6 @@ import static java.lang.String.format;
 
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
-import com.netflix.spinnaker.front50.api.model.pipeline.Trigger;
 import com.netflix.spinnaker.front50.exceptions.DuplicateEntityException;
 import com.netflix.spinnaker.front50.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineStrategyDAO;
@@ -68,11 +67,9 @@ public class StrategyController {
 
       // ensure that cron triggers are assigned a unique identifier for new strategies
       if (strategy.getTriggers() != null) {
-        List<Trigger> triggers = strategy.getTriggers();
-        triggers.stream()
+        strategy.getTriggers().stream()
             .filter(it -> "cron".equals(it.getType()))
             .forEach(it -> it.put("id", UUID.randomUUID().toString()));
-        strategy.setTriggers(triggers);
       }
     }
 

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -190,15 +190,15 @@ abstract class PipelineControllerTck extends Specification {
   @Unroll
   void 'should only (re)generate cron trigger ids for new pipelines'() {
     given:
-    def pipeline = [
+    def pipeline = new Pipeline([
       name       : "My Pipeline",
       application: "test",
       triggers   : [
         new Trigger([type: "cron", id: "original-id"])
       ]
-    ]
+    ])
     if (lookupPipelineId) {
-      pipelineDAO.create(null, pipeline as Pipeline)
+      pipelineDAO.create(null, pipeline)
       pipeline.id = pipelineDAO.findById(
         pipelineDAO.getPipelineId("test", "My Pipeline")
       ).getId()
@@ -225,7 +225,7 @@ abstract class PipelineControllerTck extends Specification {
 
   void 'should ensure that all cron triggers have an identifier'() {
     given:
-    def pipeline = [
+    def pipeline = new Pipeline([
       name       : "My Pipeline",
       application: "test",
       triggers   : [
@@ -233,9 +233,9 @@ abstract class PipelineControllerTck extends Specification {
         new Trigger([type: "cron", expression: "2"]),
         new Trigger([type: "cron", id: "", expression: "3"])
       ]
-    ]
+    ])
 
-    pipelineDAO.create(null, pipeline as Pipeline)
+    pipelineDAO.create(null, pipeline)
     pipeline.id = pipelineDAO.findById(
       pipelineDAO.getPipelineId("test", "My Pipeline")
     ).getId()


### PR DESCRIPTION
https://github.com/spinnaker/front50/pull/1035/files#diff-9b514be177faf5444c86a88ab6bb9e6a0add032bfa67862bc8e33b17c4bb9cc9L159 removed it, but [orca's SavePipelineTask](https://github.com/spinnaker/orca/blob/2a2110d849bc50b2497e40554fead7a67abcf8ee/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java#L95) still sets it.

with some little refactors along the way.