### PR TITLE
feat(migrations): Support for migrations defined in plugins

### DIFF
--- a/front50-migrations/front50-migrations.gradle
+++ b/front50-migrations/front50-migrations.gradle
@@ -24,4 +24,5 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation project(":front50-test")
+  testImplementation "org.spockframework:spock-spring"
 }

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/MigrationRunner.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/MigrationRunner.java
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.front50.migrations;
 
+import static net.logstash.logback.argument.StructuredArguments.value;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import static net.logstash.logback.argument.StructuredArguments.value;
 
 /**
  * Migration runner runs all the registered migrations as scheduled. By default migration runner

--- a/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/MigrationRunner.java
+++ b/front50-migrations/src/main/java/com/netflix/spinnaker/front50/migrations/MigrationRunner.java
@@ -26,9 +26,12 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Migration runner runs all the registered migrations as scheduled. By default migration runner
- * will <strong>not</strong> run and need to set <strong>`migrations.enabled`</strong> property to
- * enable it.
+ * Migration runner runs all the registered migrations as scheduled. By default, migration runner
+ * will <strong>not</strong> run and need to set <code>migrations.enabled</code> property to enable
+ * it. The interval between migration runs can be set using <code>migrations.intervalMs</code>, and
+ * the initial delay before running the first migration can be set using <code>
+ * migrations.initialDelayMs</code> (can be useful if you initialize migrations in plugins, and they
+ * need some time to start up). Default values are 8 hours and 10 seconds respectively.
  *
  * <p>Note: Ideally migrations should be running only on one instance.
  */
@@ -43,8 +46,10 @@ public class MigrationRunner {
     this.applicationContext = applicationContext;
   }
 
-  /** Run migrations every 8hrs. */
-  @Scheduled(fixedDelay = 28800000, initialDelay = 10000)
+  /** Run migrations every 8hrs (by default). */
+  @Scheduled(
+      fixedDelayString = "${migrations.intervalMs:28800000}",
+      initialDelayString = "${migrations.initialDelayMs:10000}")
   void run() {
     applicationContext.getBeansOfType(Migration.class).values().stream()
         .filter(Migration::isValid)

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/config/MigrationConfigTest.java
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/config/MigrationConfigTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Schibsted ASA. All rights reserved
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+import com.netflix.spinnaker.front50.migrations.MigrationRunner;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class MigrationConfigTest {
+
+  @Bean
+  public MigrationRunner migrationRunner(ApplicationContext applicationContext) {
+    return new MigrationRunner(applicationContext);
+  }
+}

--- a/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/MigrationRunnerSpec.groovy
+++ b/front50-migrations/src/test/groovy/com/netflix/spinnaker/front50/migrations/MigrationRunnerSpec.groovy
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.front50.migrations
+
+import com.netflix.spinnaker.front50.config.MigrationConfigTest
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import spock.lang.Subject
+
+@ContextConfiguration(classes = [MigrationConfigTest, MigrationRunner])
+class MigrationRunnerSpec extends Specification {
+  @SpringBean(name = "myFirstMigration")
+  Migration myFirstMigration = Mock()
+
+  @SpringBean(name = "mySecondMigration")
+  Migration mySecondMigration = Mock()
+
+  @SpringBean(name = "disabledMigration")
+  Migration disabledMigration = Mock()
+
+  @Subject
+  @Autowired
+  MigrationRunner migrationRunner
+
+  def setup() {
+    myFirstMigration.isValid() >> true
+    mySecondMigration.isValid() >> true
+    disabledMigration.isValid() >> false
+  }
+
+  def "should run all enabled migrations"() {
+    when:
+    migrationRunner.run()
+
+    then:
+    1 * myFirstMigration.run()
+    1 * mySecondMigration.run()
+    0 * disabledMigration.run()
+  }
+}


### PR DESCRIPTION
The current implementation of the MigrationRunner is initialized before any migrations in plugins are initialized, and they are therefore not included by the runner. Even if the plugin migrations are defined using `@ExposeToApp`, the beans are never picked up by the MigrationRunner bean. This PR changes the MigrationRunner to look up Migration beans directly from the applicationContext on every run, and will also delay the first run with 10 seconds in order to give some time for plugins to be initialized.