### PR TITLE
fix(web): Retrieve dependent pipelines correctly

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
@@ -31,7 +31,7 @@ import com.netflix.spinnaker.front50.exceptions.InvalidRequestException;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO;
-import com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration;
+import com.netflix.spinnaker.front50.model.pipeline.V2TemplateConfiguration;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -186,22 +186,23 @@ public class V2PipelineTemplateController {
     List<String> dependentConfigIds = new ArrayList<>();
 
     String prefixedId = SPINNAKER_PREFIX + templateId;
+
     pipelineDAO.all().stream()
         .filter(pipeline -> pipeline.getType() != null && pipeline.getType().equals(TYPE_TEMPLATED))
         .forEach(
             templatedPipeline -> {
               String source;
               try {
-                TemplateConfiguration config =
-                    objectMapper.convertValue(
-                        templatedPipeline.getConfig(), TemplateConfiguration.class);
 
-                source = config.getPipeline().getTemplate().getSource();
+                V2TemplateConfiguration config =
+                    objectMapper.convertValue(templatedPipeline, V2TemplateConfiguration.class);
+                source = config.getTemplate().getReference();
               } catch (Exception e) {
+                e.printStackTrace();
                 return;
               }
 
-              if (source != null && source.equalsIgnoreCase(prefixedId)) {
+              if (source != null && source.startsWith(prefixedId)) {
                 dependentConfigIds.add(templatedPipeline.getId());
               }
             });

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateController.java
@@ -198,7 +198,6 @@ public class V2PipelineTemplateController {
                     objectMapper.convertValue(templatedPipeline, V2TemplateConfiguration.class);
                 source = config.getTemplate().getReference();
               } catch (Exception e) {
-                e.printStackTrace();
                 return;
               }
 

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateControllerSpec.groovy
@@ -17,8 +17,13 @@
 
 package com.netflix.spinnaker.front50.controllers
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.front50.exceptions.InvalidEntityException
+import static com.netflix.spinnaker.front50.api.model.pipeline.Pipeline.TYPE_TEMPLATED;
+import static com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration.TemplateSource.SPINNAKER_PREFIX;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.model.pipeline.V2TemplateConfiguration;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
@@ -34,7 +39,9 @@ class V2PipelineTemplateControllerSpec extends Specification {
   def controller = new V2PipelineTemplateController(
     pipelineDAO: pipelineDAO,
     pipelineTemplateDAO: pipelineTemplateDAO,
-    objectMapper: new ObjectMapper(),
+    // V2TemplateConfiguration doesn't expect `id` attribute as part of pipeline config.
+    // Hence has to ignore unknown properties when converting the value.
+    objectMapper: new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   )
 
   def template1 = [
@@ -156,6 +163,68 @@ class V2PipelineTemplateControllerSpec extends Specification {
     hash1 == hash2
   }
 
+  def "getDependentConfigs returns empty list when there are no templated pipelines"() {
+    given:
+    pipelineDAO.all() >> []
+
+    when:
+    List<String> dependentConfigIds = controller.getDependentConfigs("myPipelineTemplateId")
+
+    then:
+    dependentConfigIds.isEmpty()
+  }
+
+  def "getDependentConfigs returns empty list when templated pipelines have no dependencies"() {
+    given:
+    Pipeline normalPipeline = new Pipeline()
+    Pipeline templatedPipeline = new Pipeline(id: "id-of-my-templated-pipeline", type: TYPE_TEMPLATED)
+    pipelineDAO.all() >> [normalPipeline, templatedPipeline]
+
+    when:
+    List<String> dependentConfigIds = controller.getDependentConfigs("a-different-pipeline-template-id")
+
+    then:
+    dependentConfigIds.isEmpty()
+  }
+
+  def "getDependentConfigs returns list of dependent pipeline IDs"() {
+    given:
+
+    def normalPipeline = new Pipeline(
+      id: "normalPipeline",
+      name: "normalPipeline",
+      application: "application",
+    )
+    def templatedPipeline = new Pipeline(
+      id: "id-of-my-templated-pipeline",
+      name: "name-of-my-templated-pipeline",
+      application: "application",
+      type: TYPE_TEMPLATED,
+      schema: "v2",
+      template: [
+        reference: SPINNAKER_PREFIX + "myPipelineTemplateId"
+      ]
+    )
+    def oneOtherTemplatedPipeline = new Pipeline(
+      id: "id-of-one-other-templated-pipeline",
+      name: "name-of-one-other-templated-pipeline",
+      application: "application",
+      type: TYPE_TEMPLATED,
+      schema: "v2",
+      template: [
+        reference: SPINNAKER_PREFIX + "oneOtherPipelineTemplateId"
+      ]
+    )
+
+    pipelineDAO.all() >> [normalPipeline, templatedPipeline, oneOtherTemplatedPipeline]
+
+    when:
+    List<String> dependentConfigIds = controller.getDependentConfigs("myPipelineTemplateId")
+
+    then:
+    dependentConfigIds == ["id-of-my-templated-pipeline"]
+  }
+
   @Unroll
   def 'should fail with InvalidEntityException if Id(#id) is not provided or empty'() {
     when:
@@ -168,4 +237,3 @@ class V2PipelineTemplateControllerSpec extends Specification {
     id << [null, "", "    "]
   }
 }
-

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/V2PipelineTemplateControllerSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.front50.model.pipeline.V2TemplateConfiguration;
 import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplateDAO
+import com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -161,6 +162,40 @@ class V2PipelineTemplateControllerSpec extends Specification {
 
     then:
     hash1 == hash2
+  }
+
+  def "verify retrieval of templated pipeline config using v1 approach results in null"() {
+    given:
+
+    def templatedPipeline = new Pipeline(
+      id: "id-of-my-templated-pipeline",
+      name: "name-of-my-templated-pipeline",
+      application: "application",
+      type: TYPE_TEMPLATED,
+      schema: "v2",
+      template: [
+        reference: SPINNAKER_PREFIX + "myPipelineTemplateId"
+      ]
+    )
+    def oneOtherTemplatedPipeline = new Pipeline(
+      id: "id-of-one-other-templated-pipeline",
+      name: "name-of-one-other-templated-pipeline",
+      application: "application",
+      type: TYPE_TEMPLATED,
+      schema: "v2",
+      template: [
+        reference: SPINNAKER_PREFIX + "oneOtherPipelineTemplateId"
+      ]
+    )
+
+    pipelineDAO.all() >> [templatedPipeline, oneOtherTemplatedPipeline]
+
+    when:
+    TemplateConfiguration config = controller.objectMapper.convertValue(
+      templatedPipeline.getConfig(), TemplateConfiguration.class);
+
+    then:
+    config == null
   }
 
   def "getDependentConfigs returns empty list when there are no templated pipelines"() {


### PR DESCRIPTION
### Issue Summary
This fixes the bug regarding `/v2/pipelineTemplates/<pipeline-template-id>/dependentPipelines` API.
Original Issue: https://github.com/spinnaker/spinnaker/issues/6472

### Environment
Spinnaker: `1.33.0+`
Front50: `us-docker.pkg.dev/spinnaker-community/docker/front50:2.31.0`

### Description
Given a `templateId`, the `getDependentConfigs` method called by `listDependentPipelines` method, was returning `null` for pipeline configuration, causing the entire API to return `[]` even if a specific pipeline template had dependent pipelines.. This seems to be because of 👇 change.
```java
import com.netflix.spinnaker.front50.model.pipeline.TemplateConfiguration;
TemplateConfiguration v1Config = objectMapper.convertValue(templatedPipeline.getConfig(), TemplateConfiguration.class);

// `templatedPipeline.getConfig()` above was returning `null`
```
This 👆 I believe is meant for `v1` templates. But for `v2` templates I believe it has to be 👇 :
```java
import com.netflix.spinnaker.front50.model.pipeline.V2TemplateConfiguration;

V2TemplateConfiguration config = objectMapper.convertValue(templatedPipeline, V2TemplateConfiguration.class);
```

Here are the swagger-ui screenshots showing before and after the fix 👇 
| Before | After |
|--------|--------|
| <img width="1276" alt="Before" src="https://github.com/spinnaker/front50/assets/157880/5b87b2fd-7826-4f4e-b544-bd6181bf2808"> | <img width="1267" alt="After" src="https://github.com/spinnaker/front50/assets/157880/b3a5f6a6-8842-4b4c-bae9-df0cabe8d84e">|

Here are the cURL responses showing before and after the fix 👇 
#### Before
```sh
curl -X GET "http://localhost:30084/v2/pipelineTemplates/9d92ff72-2bbf-43a3-bd57-23c221387051/dependents" -H "accept: */*"
[]
```

#### After
```sh
curl -X GET "http://localhost:30084/v2/pipelineTemplates/9d92ff72-2bbf-43a3-bd57-23c221387051/dependents" -H "accept: */*"
[{"application":"products","pipelineConfigId":"9aef1986-48cf-44ce-859c-97b3042388db","pipelineName":"[Mother Pipeline] Global Deployment Express"}]
```