### PR TITLE
chore(dependency): unpin mysql-connector-java

### DIFF
--- a/front50-sql-mysql/front50-sql-mysql.gradle
+++ b/front50-sql-mysql/front50-sql-mysql.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  runtimeOnly "mysql:mysql-connector-java:8.0.12"
+  runtimeOnly "mysql:mysql-connector-java"
 }


### PR DESCRIPTION
Before:
```
$ ./gradlew front50-sql-mysql:dI --dependency mysql-connector-java --configuration runtimeClasspath

> Task :front50-sql-mysql:dependencyInsight
mysql:mysql-connector-java:8.0.33
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 11           |
   Selection reasons:
      - By constraint
      - Forced

mysql:mysql-connector-java:8.0.33
\--- io.spinnaker.kork:kork-bom:7.227.0
     \--- runtimeClasspath

mysql:mysql-connector-java:8.0.12 -> 8.0.33
\--- runtimeClasspath
```

After:
```
$ ./gradlew front50-sql-mysql:dI --dependency mysql-connector-java --configuration runtimeClasspath

> Task :front50-sql-mysql:dependencyInsight
mysql:mysql-connector-java:8.0.33
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 11           |
   Selection reasons:
      - By constraint
      - Forced

mysql:mysql-connector-java:8.0.33
\--- io.spinnaker.kork:kork-bom:7.227.0
     \--- runtimeClasspath

mysql:mysql-connector-java -> 8.0.33
\--- runtimeClasspath
```