### PR TITLE
refactor(mysql): update mysql connector coordinate during upgrade to spring boot 2.7.x

### DIFF
--- a/front50-integration/front50-integration.gradle
+++ b/front50-integration/front50-integration.gradle
@@ -7,7 +7,7 @@ dependencies {
   testImplementation "org.testcontainers:junit-jupiter"
   testImplementation "org.testcontainers:mysql"
   testRuntimeOnly "ch.qos.logback:logback-classic"
-  testRuntimeOnly "mysql:mysql-connector-java"
+  testRuntimeOnly "com.mysql:mysql-connector-j"
 }
 
 test.configure {

--- a/front50-sql-mysql/front50-sql-mysql.gradle
+++ b/front50-sql-mysql/front50-sql-mysql.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  runtimeOnly "mysql:mysql-connector-java"
+  runtimeOnly "com.mysql:mysql-connector-j"
 }

--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -21,7 +21,7 @@ dependencies {
   testImplementation "dev.minutest:minutest"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 
-  testImplementation "mysql:mysql-connector-java"
+  testImplementation "com.mysql:mysql-connector-j"
   testImplementation "org.testcontainers:mysql"
 
   testImplementation "org.testcontainers:postgresql"


### PR DESCRIPTION
In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver

So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom
