### PR TITLE
feat(batchUpdate): enhance batch update functionality

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -25,7 +25,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(of = {"id", "name", "application"})
 public class Pipeline implements Timestamped {
 
   public static final String TYPE_TEMPLATED = "templatedPipeline";

--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -21,9 +21,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+@EqualsAndHashCode
 public class Pipeline implements Timestamped {
 
   public static final String TYPE_TEMPLATED = "templatedPipeline";

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/config/Front50WebConfig.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/config/Front50WebConfig.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.fiat.shared.FiatStatus;
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter;
 import com.netflix.spinnaker.front50.ItemDAOHealthIndicator;
 import com.netflix.spinnaker.front50.api.validator.PipelineValidator;
+import com.netflix.spinnaker.front50.config.controllers.PipelineControllerConfig;
 import com.netflix.spinnaker.front50.model.application.ApplicationDAO;
 import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
 import com.netflix.spinnaker.front50.model.delivery.DeliveryRepository;
@@ -58,7 +59,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @EnableFiatAutoConfig
 @EnableScheduling
 @Import({PluginsAutoConfiguration.class})
-@EnableConfigurationProperties(StorageServiceConfigurationProperties.class)
+@EnableConfigurationProperties({
+  StorageServiceConfigurationProperties.class,
+  PipelineControllerConfig.class
+})
 public class Front50WebConfig extends WebMvcConfigurerAdapter {
 
   @Autowired private Registry registry;

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/config/controllers/PipelineControllerConfig.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/config/controllers/PipelineControllerConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.front50.config.controllers;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "controller.pipeline")
+public class PipelineControllerConfig {
+
+  /** Holds the configurations to be used for save/update controller mappings */
+  private SavePipelineConfiguration save = new SavePipelineConfiguration();
+
+  @Data
+  public static class SavePipelineConfiguration {
+    /** This controls whether cache should be refreshes while checking for duplicate pipelines */
+    boolean refreshCacheOnDuplicatesCheck = true;
+  }
+}

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -498,16 +498,9 @@ public class PipelineController {
     if (Strings.isNullOrEmpty(pipeline.getId())
         || (boolean) pipeline.getAny().getOrDefault("regenerateCronTriggerIds", false)) {
       // ensure that cron triggers are assigned a unique identifier for new pipelines
-      pipeline.setTriggers(
-          pipeline.getTriggers().stream()
-              .map(
-                  it -> {
-                    if ("cron".equalsIgnoreCase(it.getType())) {
-                      it.put("id", UUID.randomUUID().toString());
-                    }
-                    return it;
-                  })
-              .collect(Collectors.toList()));
+      pipeline.getTriggers().stream()
+          .filter(it -> "cron".equals(it.getType()))
+          .forEach(it -> it.put("id", UUID.randomUUID().toString()));
     }
 
     final ValidatorErrors errors = new ValidatorErrors();

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -290,7 +290,7 @@ public class PipelineController {
 
   @PreAuthorize("@fiatPermissionEvaluator.isAdmin()")
   @RequestMapping(value = "batchUpdate", method = RequestMethod.POST)
-  public void batchUpdate(@RequestBody List<Map<String, Object>> pipelinesJson) {
+  public Map<String, Object> batchUpdate(@RequestBody List<Map<String, Object>> pipelinesJson) {
 
     long batchUpdateStartTime = System.currentTimeMillis();
 
@@ -311,6 +311,7 @@ public class PipelineController {
         pipelines.stream().map(Pipeline::getName).collect(Collectors.toList()));
 
     List<Pipeline> pipelinesToSave = new ArrayList<>();
+    Map<String, Object> returnData = new HashMap<>();
 
     // List of pipelines in the provided request body which don't adhere to the schema
     List<Pipeline> invalidPipelines = new ArrayList<>();
@@ -332,6 +333,10 @@ public class PipelineController {
 
     List<String> savedPipelines =
         pipelinesToSave.stream().map(Pipeline::getName).collect(Collectors.toList());
+    returnData.put("successful_pipelines_count", savedPipelines.size());
+    returnData.put("successful_pipelines", savedPipelines);
+    returnData.put("failed_pipelines_count", failedPipelines.size());
+    returnData.put("failed_pipelines", failedPipelines);
 
     if (!failedPipelines.isEmpty()) {
       log.warn(
@@ -343,6 +348,8 @@ public class PipelineController {
         savedPipelines.size(),
         System.currentTimeMillis() - batchUpdateStartTime,
         savedPipelines);
+
+    return returnData;
   }
 
   @PreAuthorize("hasPermission(#application, 'APPLICATION', 'WRITE')")

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -278,7 +278,6 @@ public class PipelineController {
     validatePipeline(pipeline, staleCheck);
     checkForDuplicatePipeline(
         pipeline.getApplication(), pipeline.getName().trim(), pipeline.getId());
-    pipeline.setName(pipeline.getName().trim());
     log.debug(
         "Successfully validated pipeline {} in {}ms",
         pipeline.getName(),

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.front50.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.api.validator.PipelineValidator
 import com.netflix.spinnaker.front50.api.validator.ValidatorErrors
@@ -43,6 +44,9 @@ class PipelineControllerSpec extends Specification {
   @Autowired
   PipelineControllerConfig pipelineControllerConfig
 
+  @Autowired
+  FiatPermissionEvaluator fiatPermissionEvaluator
+
   @Unroll
   def "test cache refresh enabled flag when checking for duplicate pipelines"() {
     given:
@@ -64,7 +68,8 @@ class PipelineControllerSpec extends Specification {
     }
 
     def pipelineController = new PipelineController(
-      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig)
+      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
+      fiatPermissionEvaluator)
 
     when:
     pipelineControllerConfig.getSave().refreshCacheOnDuplicatesCheck = true
@@ -158,7 +163,8 @@ class PipelineControllerSpec extends Specification {
           Optional.empty(),
           [new MockValidator()] as List<PipelineValidator>,
           Optional.empty(),
-          pipelineControllerConfig
+          pipelineControllerConfig,
+          fiatPermissionEvaluator
         )
       )
       .setControllerAdvice(
@@ -200,7 +206,8 @@ class PipelineControllerSpec extends Specification {
     pipelineDAO.history(testPipelineId, 20) >> pipelineList
 
     def mockMvcWithController = MockMvcBuilders.standaloneSetup(new PipelineController(
-      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig
+      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
+      fiatPermissionEvaluator
     )).build()
 
     when:
@@ -238,7 +245,8 @@ class PipelineControllerSpec extends Specification {
       ]))
 
     def mockMvcWithController = MockMvcBuilders.standaloneSetup(new PipelineController(
-      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig
+      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
+      fiatPermissionEvaluator
     )).build()
 
     when:
@@ -258,6 +266,11 @@ class PipelineControllerSpec extends Specification {
     @Bean
     PipelineDAO pipelineDAO() {
       detachedMockFactory.Stub(PipelineDAO)
+    }
+
+    @Bean
+    FiatPermissionEvaluator fiatPermissionEvaluator() {
+      detachedMockFactory.Stub(FiatPermissionEvaluator)
     }
   }
 

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(controllers = [PipelineController])
-@ContextConfiguration(classes = [TestConfiguration, PipelineController, PipelineControllerConfig])
+@ContextConfiguration(classes = [TestConfiguration, AuthorizationSupport, PipelineController, PipelineControllerConfig])
 class PipelineControllerSpec extends Specification {
 
   @Autowired
@@ -46,6 +46,9 @@ class PipelineControllerSpec extends Specification {
 
   @Autowired
   FiatPermissionEvaluator fiatPermissionEvaluator
+
+  @Autowired
+  private AuthorizationSupport authorizationSupport
 
   @Unroll
   def "should fail the pipeline when staleCheck is true and conditions are met"() {
@@ -86,7 +89,7 @@ class PipelineControllerSpec extends Specification {
 
     def pipelineController = new PipelineController(
       pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
-      localFiatPermissionEvaluator)
+      localFiatPermissionEvaluator, authorizationSupport)
 
     when: "staleCheck is true and conditions are met"
     def response = pipelineController.batchUpdate(pipelinesBatch1, staleCheck_true)
@@ -137,7 +140,7 @@ class PipelineControllerSpec extends Specification {
 
     def pipelineController = new PipelineController(
       pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
-      fiatPermissionEvaluator)
+      fiatPermissionEvaluator, authorizationSupport)
 
     when:
     pipelineControllerConfig.getSave().refreshCacheOnDuplicatesCheck = true
@@ -232,7 +235,8 @@ class PipelineControllerSpec extends Specification {
           [new MockValidator()] as List<PipelineValidator>,
           Optional.empty(),
           pipelineControllerConfig,
-          fiatPermissionEvaluator
+          fiatPermissionEvaluator,
+          authorizationSupport
         )
       )
       .setControllerAdvice(
@@ -275,7 +279,7 @@ class PipelineControllerSpec extends Specification {
 
     def mockMvcWithController = MockMvcBuilders.standaloneSetup(new PipelineController(
       pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
-      fiatPermissionEvaluator
+      fiatPermissionEvaluator, authorizationSupport
     )).build()
 
     when:
@@ -314,7 +318,7 @@ class PipelineControllerSpec extends Specification {
 
     def mockMvcWithController = MockMvcBuilders.standaloneSetup(new PipelineController(
       pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
-      fiatPermissionEvaluator
+      fiatPermissionEvaluator, authorizationSupport
     )).build()
 
     when:

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -48,6 +48,74 @@ class PipelineControllerSpec extends Specification {
   FiatPermissionEvaluator fiatPermissionEvaluator
 
   @Unroll
+  def "should fail the pipeline when staleCheck is true and conditions are met"() {
+    given:
+    def staleCheck_true = true
+    def staleCheck_false = false
+    def localFiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+    def pipelinesBatch1 = [
+      [      id          : "1",
+             name        : "test-pipeline",
+             application : "test-application",
+             lastModified: 1662644108666
+      ]
+    ]
+
+    def pipelinesBatch2 = [
+      [      id          : "1",
+             name        : "test-pipeline",
+             application : "test-application",
+      ]
+    ]
+    def pipelineDAO = new InMemoryPipelineDAO(){
+      @Override
+      Pipeline findById(String id) throws NotFoundException {
+        return new Pipeline([
+          id          : "1",
+          name        : "test-pipeline",
+          application : "test-application",
+          lastModified: 1772644108777
+        ])
+      }
+
+      @Override
+      void bulkImport(Collection<Pipeline> items) {}
+    }
+
+    _ * localFiatPermissionEvaluator.hasPermission(_, "test-application", "APPLICATION", "WRITE") >> true
+
+    def pipelineController = new PipelineController(
+      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty(), pipelineControllerConfig,
+      localFiatPermissionEvaluator)
+
+    when: "staleCheck is true and conditions are met"
+    def response = pipelineController.batchUpdate(pipelinesBatch1, staleCheck_true)
+
+    then: "pipeline save should fail"
+    response.failed_pipelines_count == 1
+    response.successful_pipelines_count == 0
+    response.successful_pipelines == []
+    response.failed_pipelines[0].any.errorMsg ==
+      "Encountered the following error when validating pipeline test-pipeline in the application test-application: " +
+      "The submitted pipeline is stale.  submitted updateTs 1662644108666 does not match stored updateTs 1772644108777"
+
+    when: "staleCheck is false"
+    response = pipelineController.batchUpdate(pipelinesBatch1, staleCheck_false)
+
+    then: "pipeline save should be successful"
+    response.failed_pipelines_count == 0
+    response.successful_pipelines_count == 1
+
+    when: "staleCheck is true but submitted pipeline doesn't have lastModified timestamp"
+    response = pipelineController.batchUpdate(pipelinesBatch2, staleCheck_true)
+
+    then: "pipeline save should be successful"
+    response.failed_pipelines_count == 0
+    response.successful_pipelines_count == 1
+
+  }
+
+  @Unroll
   def "test cache refresh enabled flag when checking for duplicate pipelines"() {
     given:
     def existingPipelineIdNotInCache = "123"

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -333,6 +333,7 @@ class PipelineControllerSpec extends Specification {
     @Override
     Pipeline create(String id, Pipeline item) {
       map.put(id, item)
+      item
     }
 
     @Override

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -18,8 +18,9 @@ package com.netflix.spinnaker.front50.controllers
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.Front50SqlProperties
-import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.front50.ServiceAccountsService
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.config.controllers.PipelineControllerConfig
@@ -73,6 +74,8 @@ abstract class PipelineControllerTck extends Specification {
   ServiceAccountsService serviceAccountsService
   StorageServiceConfigurationProperties.PerObjectType pipelineDAOConfigProperties =
     new StorageServiceConfigurationProperties().getPipeline()
+  FiatPermissionEvaluator fiatPermissionEvaluator
+  AuthorizationSupport authorizationSupport
   ObjectMapper objectMapper
   PipelineControllerConfig pipelineControllerConfig
 
@@ -85,6 +88,8 @@ abstract class PipelineControllerTck extends Specification {
     this.pipelineDAO = Spy(createPipelineDAO())
     this.serviceAccountsService = Mock(ServiceAccountsService)
     this.pipelineControllerConfig = new PipelineControllerConfig()
+    this.fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+    this.authorizationSupport = Spy(new AuthorizationSupport(fiatPermissionEvaluator))
 
     MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter = new MappingJackson2HttpMessageConverter();
     mappingJackson2HttpMessageConverter.setObjectMapper(objectMapper)
@@ -97,7 +102,8 @@ abstract class PipelineControllerTck extends Specification {
           Optional.of(serviceAccountsService),
           Collections.emptyList(),
           Optional.empty(),
-          pipelineControllerConfig
+          pipelineControllerConfig,
+          fiatPermissionEvaluator
         )
       )
       .setMessageConverters(mappingJackson2HttpMessageConverter)

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline
 import com.netflix.spinnaker.front50.ServiceAccountsService
 import com.netflix.spinnaker.front50.api.model.pipeline.Trigger
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
+import com.netflix.spinnaker.front50.config.controllers.PipelineControllerConfig
 import com.netflix.spinnaker.front50.jackson.Front50ApiModule
 import com.netflix.spinnaker.front50.model.DefaultObjectKeyLoader
 import com.netflix.spinnaker.front50.model.SqlStorageService
@@ -73,6 +74,7 @@ abstract class PipelineControllerTck extends Specification {
   StorageServiceConfigurationProperties.PerObjectType pipelineDAOConfigProperties =
     new StorageServiceConfigurationProperties().getPipeline()
   ObjectMapper objectMapper
+  PipelineControllerConfig pipelineControllerConfig
 
   void setup() {
     println "--------------- Test " + specificationContext.currentIteration.name
@@ -82,6 +84,7 @@ abstract class PipelineControllerTck extends Specification {
 
     this.pipelineDAO = Spy(createPipelineDAO())
     this.serviceAccountsService = Mock(ServiceAccountsService)
+    this.pipelineControllerConfig = new PipelineControllerConfig()
 
     MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter = new MappingJackson2HttpMessageConverter();
     mappingJackson2HttpMessageConverter.setObjectMapper(objectMapper)
@@ -93,7 +96,8 @@ abstract class PipelineControllerTck extends Specification {
           objectMapper,
           Optional.of(serviceAccountsService),
           Collections.emptyList(),
-          Optional.empty()
+          Optional.empty(),
+          pipelineControllerConfig
         )
       )
       .setMessageConverters(mappingJackson2HttpMessageConverter)

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -103,7 +103,8 @@ abstract class PipelineControllerTck extends Specification {
           Collections.emptyList(),
           Optional.empty(),
           pipelineControllerConfig,
-          fiatPermissionEvaluator
+          fiatPermissionEvaluator,
+          authorizationSupport
         )
       )
       .setMessageConverters(mappingJackson2HttpMessageConverter)


### PR DESCRIPTION
This PR adds the following functionality to pipeline batch update operation :
- refactor bulk storage operation to make it atomic
- add duplicate pipeline check to /pipelines POST handler method (i.e. save individual pipeline) and  /pipelines/{id} PUT handler method (i.e. update individual pipeline)
- update /pipelines/batchUpdate POST handler method to address deserialization issues and add some useful log statements
- adds configurable controls to decide whether cache should be refreshed while checking for duplicate pipelines 
```yaml
controller:
   pipeline:
      save:
         refreshCacheOnDuplicatesCheck: false // default is true 
```
- Add pipeline validations to validate all the deserialized pipelines
-  batchUpdate now responds with a status of succeeded and failed pipelines info. The response will be a map containing information in the following format:
```
[
"successful_pipelines_count"  : <int>,
"successful_pipelines"        : <List<String>>,
"failed_pipelines_count"      : <int>,
"failed_pipelines"            : <List<Map<String, Object>>> 
]
```
- add staleCheck to batchUpdate
- adjust permissions to batchUpdate 
   - before: isAdmin, 
   - now: verifies application write permission