### PR TITLE
refactor(dependency): replace groovy coordinates during upgrade of groovy 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects { project ->
       annotationProcessor("org.projectlombok:lombok")
       testAnnotationProcessor("org.projectlombok:lombok")
 
-      testImplementation("org.codehaus.groovy:groovy")
+      testImplementation("org.apache.groovy:groovy")
       testImplementation("org.spockframework:spock-core")
       testImplementation("org.springframework.boot:spring-boot-starter-test")
       testImplementation("org.spockframework:spock-spring")

--- a/front50-redis/front50-redis.gradle
+++ b/front50-redis/front50-redis.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation project(":front50-api")
   implementation "io.spinnaker.kork:kork-exceptions"
 
-  implementation("org.codehaus.groovy:groovy")
+  implementation("org.apache.groovy:groovy")
 
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/front50-test/front50-test.gradle
+++ b/front50-test/front50-test.gradle
@@ -19,7 +19,7 @@ dependencies {
   implementation project(":front50-core")
   implementation project(":front50-s3")
 
-  implementation "org.codehaus.groovy:groovy"
+  implementation "org.apache.groovy:groovy"
   implementation "org.spockframework:spock-core"
   implementation "com.amazonaws:aws-java-sdk-s3"
 }

--- a/front50-web/front50-web.gradle
+++ b/front50-web/front50-web.gradle
@@ -46,7 +46,7 @@ dependencies {
   testImplementation project(":front50-sql")
   testImplementation "io.spinnaker.kork:kork-sql-test"
   testImplementation "io.reactivex:rxjava"
-  testImplementation "org.codehaus.groovy:groovy-json"
+  testImplementation "org.apache.groovy:groovy-json"
 
   // Add each included cloud provider project as a runtime dependency
   gradle.includedProviderProjects.each {


### PR DESCRIPTION
Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions.
