### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY front50-web/build/install/front50 /opt/front50
 RUN mkdir -p /opt/front50/plugins && chown -R spinnaker:nogroup /opt/front50/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 101.2 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 101.6 Segmentation fault (core dumped)
#9 101.7 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 102.1 Segmentation fault (core dumped)
#9 102.1 dpkg: error processing package libc-bin (--configure): #9 102.1  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/front50/actions/runs/13294117039/job/37121766728?pr=1528

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834