### PR TITLE
fix(gha): fix branch detection error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # Given a tag, determine what branch we are on, so we can bump dependencies (or not)
       - name: Get Branch
         run: |
-          BRANCHES=$(git branch -r --contains ${{ github.ref }})
+          BRANCHES=$(git branch -r --contains ${{ github.ref }} | grep -v 'HEAD')
           echo "BRANCHES is '${BRANCHES}'"
           # Check for no branches explicitly...Otherwise echo adds a newline so wc thinks there's
           # one branch.  And echo -n makes it appear that there's one less branch than there


### PR DESCRIPTION
from e.g. https://github.com/spinnaker/front50/actions/runs/13421258969/job/37494202537
```
Run BRANCHES=$(git branch -r --contains refs/tags/v2.38.0) BRANCHES is '  origin/HEAD -> origin/master
  origin/master'
NUM_BRANCHES is '2'
exactly one branch required to release front50, but there are 2 (  origin/HEAD -> origin/master
  origin/master)
```
similar to https://github.com/spinnaker/fiat/pull/1205